### PR TITLE
difftest: add a special field to instr commit

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -51,6 +51,7 @@ class DiffInstrCommitIO extends DifftestBundle with DifftestWithIndex {
   val valid    = Input(Bool())
   val pc       = Input(UInt(64.W))
   val instr    = Input(UInt(32.W))
+  val special  = Input(UInt(8.W))
   val skip     = Input(Bool())
   val isRVC    = Input(Bool())
   val scFailed = Input(Bool())

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -58,6 +58,7 @@ typedef struct {
   uint8_t  skip;
   uint8_t  isRVC;
   uint8_t  scFailed;
+  uint8_t  fused;
   uint8_t  wen;
   uint8_t  wdest;
   uint64_t wdata;

--- a/src/test/csrc/difftest/interface.cpp
+++ b/src/test/csrc/difftest/interface.cpp
@@ -56,6 +56,7 @@ INTERFACE_INSTR_COMMIT {
     packet->skip     = skip;
     packet->isRVC    = isRVC;
     packet->scFailed = scFailed;
+    packet->fused    = special;
     packet->wen      = wen;
     packet->wdest    = wdest;
     packet->wdata    = wdata;

--- a/src/test/csrc/difftest/interface.h
+++ b/src/test/csrc/difftest/interface.h
@@ -71,6 +71,7 @@ extern "C" int v_difftest_step();
     DPIC_ARG_BIT  valid,                 \
     DPIC_ARG_LONG pc,                    \
     DPIC_ARG_INT  instr,                 \
+    DPIC_ARG_BYTE special,               \
     DPIC_ARG_BIT  skip,                  \
     DPIC_ARG_BIT  isRVC,                 \
     DPIC_ARG_BIT  scFailed,              \

--- a/src/test/vsrc/common/difftest.v
+++ b/src/test/vsrc/common/difftest.v
@@ -74,6 +74,7 @@ endmodule
   `DPIC_ARG_BIT  valid,
   `DPIC_ARG_LONG pc,
   `DPIC_ARG_INT  instr,
+  `DPIC_ARG_BYTE special,
   `DPIC_ARG_BIT  skip,
   `DPIC_ARG_BIT  isRVC,
   `DPIC_ARG_BIT  scFailed,
@@ -88,6 +89,7 @@ endmodule
   input        valid,
   input [63:0] pc,
   input [31:0] instr,
+  input [ 7:0] special,
   input        skip,
   input        isRVC,
   input        scFailed,
@@ -97,7 +99,7 @@ endmodule
 );
   `DIFFTEST_MOD_DPIC_CALL_BEGIN_WITH_EN(valid, InstrCommit) (
     coreid, index,
-    valid, pc, instr, skip, isRVC, scFailed, wen, wdest, wdata
+    valid, pc, instr, special, skip, isRVC, scFailed, wen, wdest, wdata
   ) `DIFFTEST_MOD_DPIC_CALL_END_WITH_EN(InstrCommit)
 endmodule
 


### PR DESCRIPTION
This commit adds a special field to instruction commit packet. For now,
it is used to indicate that the instruction is a fused instruction. In
the future, we will move isRVC, scFailed, moveElim, etc into this field.

When the instruction is fused, we need to let REF commit one more
instruction.