### PR TITLE
emu: fix incorrect waveform in DRAMSim3 cosim

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -251,9 +251,6 @@ inline void Emulator::single_cycle() {
   dramsim3_helper_rising(axi);
 #endif
 
-  dut_ptr->clock = 1;
-  dut_ptr->eval();
-
 #if VM_TRACE == 1
   if (enable_waveform) {
     auto trap = difftest[0]->get_trap_event();
@@ -264,6 +261,9 @@ inline void Emulator::single_cycle() {
     if (in_range) { tfp->dump(cycle); }
   }
 #endif
+
+  dut_ptr->clock = 1;
+  dut_ptr->eval();
 
 #ifdef WITH_DRAMSIM3
   axi_copy_from_dut_ptr(dut_ptr, axi);


### PR DESCRIPTION
This issue was discussed in https://github.com/OpenXiangShan/difftest/issues/17 and partially resolved in https://github.com/OpenXiangShan/difftest/pull/19
However, in the previous PR, both ready signals for DRAMsim3 & in students' core are delayed for one cycle in the waveform. This PR fix this issue (now ready and valid signals can be high in the same clock cycle).