### PR TITLE
lightSSS: stop subprocess when time out

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -79,6 +79,9 @@
 // if error, let simulator print debug info
 #define ENABLE_SIMULATOR_DEBUG_INFO
 
+// how many cycles child processes step forward when reaching error point
+#define STEP_FORWARD_CYCLES 100
+
 // -----------------------------------------------------------------------
 // Memory difftest config
 // -----------------------------------------------------------------------


### PR DESCRIPTION
* in case of the situation that the main process meets bug and stops, but the subprocess continues running with no bug.