### PR TITLE
Update support for verilog design

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ NUM_CORES  ?= 1
 
 # Set USE_DIFFTEST_MAIN to 1 in your design's Makefile to generate Verilog by difftest
 # rather than by design.
-# Set this varieble if your design is written in Verilog.
+# Set this variable if your design is written in Verilog.
 USE_DIFFTEST_MAIN ?= 0
 
 BUILD_DIR  = $(DESIGN_DIR)/build

--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,5 @@ release-lock:
 clean: vcs-clean
 	rm -rf $(BUILD_DIR)
 
-.PHONY: sim-verilog emu difftest_v clean$(REF_SO)
+.PHONY: sim-verilog emu difftest_verilog clean$(REF_SO)
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ SIM_TOP    ?= SimTop
 DESIGN_DIR ?= ..
 NUM_CORES  ?= 1
 
+# Set USE_DIFFTEST_MAIN to 1 in your design's Makefile to generate Verilog by difftest
+# rather than by design.
+# Set this varieble if your design is written in Verilog.
 USE_DIFFTEST_MAIN ?= 0
 
 BUILD_DIR  = $(DESIGN_DIR)/build

--- a/Makefile
+++ b/Makefile
@@ -22,29 +22,6 @@ USE_DIFFTEST_MAIN ?= 0
 
 BUILD_DIR  = $(DESIGN_DIR)/build
 SIM_TOP_V  = $(BUILD_DIR)/$(SIM_TOP).v
-DIFFTEST_V = \
-	$(BUILD_DIR)/DifftestArchEvent.v \
-	$(BUILD_DIR)/DifftestBasicInstrCommit.v \
-	$(BUILD_DIR)/DifftestInstrCommit.v \
-	$(BUILD_DIR)/DifftestBasicTrapEvent.v \
-	$(BUILD_DIR)/DifftestTrapEvent.v \
-	$(BUILD_DIR)/DifftestCSRState.v \
-	$(BUILD_DIR)/DifftestDebugMode.v \
-	$(BUILD_DIR)/DifftestIntWriteback.v \
-	$(BUILD_DIR)/DifftestFpWriteback.v \
-	$(BUILD_DIR)/DifftestArchIntRegState.v \
-	$(BUILD_DIR)/DifftestArchFpRegState.v \
-	$(BUILD_DIR)/DifftestSbufferEvent.v \
-	$(BUILD_DIR)/DifftestStoreEvent.v \
-	$(BUILD_DIR)/DifftestLoadEvent.v \
-	$(BUILD_DIR)/DifftestAtomicEvent.v \
-	$(BUILD_DIR)/DifftestPtwEvent.v \
-	$(BUILD_DIR)/DifftestRefillEvent.v \
-	$(BUILD_DIR)/DifftestLrScEvent.v \
-	$(BUILD_DIR)/DifftestRunaheadEvent.v \
-	$(BUILD_DIR)/DifftestRunaheadCommitEvent.v \
-	$(BUILD_DIR)/DifftestRunaheadRedirectEvent.v \
-	$(BUILD_DIR)/DifftestRunaheadMemdepPred.v
 
 DIFF_SCALA_FILE = $(shell find ./src/main/scala -name '*.scala')
 SCALA_FILE = $(shell find $(DESIGN_DIR)/src/main/scala -name '*.scala' 2>/dev/null)
@@ -54,12 +31,10 @@ $(SIM_TOP_V): $(DIFF_SCALA_FILE) $(SCALA_FILE)
 	$(MAKE) -C $(DESIGN_DIR) sim-verilog
 
 # generate difftest files for non-chisel design.
-$(DIFFTEST_V): $(DIFF_SCALA_FILE)
+difftest_verilog:
 ifeq ($(USE_DIFFTEST_MAIN), 1)
 	mill chiselModule.runMain difftest.DifftestMain -td $(BUILD_DIR)
 endif
-
-difftest_v: $(DIFFTEST_V)
 
 # co-simulation with DRAMsim3
 ifeq ($(WITH_DRAMSIM3),1)

--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,48 @@ SIM_TOP    ?= SimTop
 DESIGN_DIR ?= ..
 NUM_CORES  ?= 1
 
-BUILD_DIR = $(DESIGN_DIR)/build
-SIM_TOP_V = $(BUILD_DIR)/$(SIM_TOP).v
+USE_DIFFTEST_MAIN ?= 0
+
+BUILD_DIR  = $(DESIGN_DIR)/build
+SIM_TOP_V  = $(BUILD_DIR)/$(SIM_TOP).v
+DIFFTEST_V = \
+	$(BUILD_DIR)/DifftestArchEvent.v \
+	$(BUILD_DIR)/DifftestBasicInstrCommit.v \
+	$(BUILD_DIR)/DifftestInstrCommit.v \
+	$(BUILD_DIR)/DifftestBasicTrapEvent.v \
+	$(BUILD_DIR)/DifftestTrapEvent.v \
+	$(BUILD_DIR)/DifftestCSRState.v \
+	$(BUILD_DIR)/DifftestDebugMode.v \
+	$(BUILD_DIR)/DifftestIntWriteback.v \
+	$(BUILD_DIR)/DifftestFpWriteback.v \
+	$(BUILD_DIR)/DifftestArchIntRegState.v \
+	$(BUILD_DIR)/DifftestArchFpRegState.v \
+	$(BUILD_DIR)/DifftestSbufferEvent.v \
+	$(BUILD_DIR)/DifftestStoreEvent.v \
+	$(BUILD_DIR)/DifftestLoadEvent.v \
+	$(BUILD_DIR)/DifftestAtomicEvent.v \
+	$(BUILD_DIR)/DifftestPtwEvent.v \
+	$(BUILD_DIR)/DifftestRefillEvent.v \
+	$(BUILD_DIR)/DifftestLrScEvent.v \
+	$(BUILD_DIR)/DifftestRunaheadEvent.v \
+	$(BUILD_DIR)/DifftestRunaheadCommitEvent.v \
+	$(BUILD_DIR)/DifftestRunaheadRedirectEvent.v \
+	$(BUILD_DIR)/DifftestRunaheadMemdepPred.v
 
 DIFF_SCALA_FILE = $(shell find ./src/main/scala -name '*.scala')
-SCALA_FILE = $(shell find $(DESIGN_DIR)/src/main/scala -name '*.scala')
+SCALA_FILE = $(shell find $(DESIGN_DIR)/src/main/scala -name '*.scala' 2>/dev/null)
 
 # generate SimTop.v
 $(SIM_TOP_V): $(DIFF_SCALA_FILE) $(SCALA_FILE)
 	$(MAKE) -C $(DESIGN_DIR) sim-verilog
+
+# generate difftest files for non-chisel design.
+$(DIFFTEST_V): $(DIFF_SCALA_FILE)
+ifeq ($(USE_DIFFTEST_MAIN), 1)
+	mill chiselModule.runMain difftest.DifftestMain -td $(BUILD_DIR)
+endif
+
+difftest_v: $(DIFFTEST_V)
 
 # co-simulation with DRAMsim3
 ifeq ($(WITH_DRAMSIM3),1)
@@ -74,5 +107,5 @@ release-lock:
 clean: vcs-clean
 	rm -rf $(BUILD_DIR)
 
-.PHONY: sim-verilog emu clean$(REF_SO)
+.PHONY: sim-verilog emu difftest_v clean$(REF_SO)
 

--- a/build.sc
+++ b/build.sc
@@ -1,0 +1,42 @@
+import mill._, scalalib._
+import coursier.maven.MavenRepository
+
+trait CommonModule extends ScalaModule {
+  override def scalaVersion = "2.12.13"
+
+  override def scalacOptions = Seq("-Xsource:2.11")
+}
+
+trait HasXsource211 extends ScalaModule {
+  override def scalacOptions = T {
+    super.scalacOptions() ++ Seq(
+      "-deprecation",
+      "-unchecked",
+      "-Xsource:2.11"
+    )
+  }
+}
+
+trait HasChisel3 extends ScalaModule {
+   override def ivyDeps = Agg(
+    ivy"edu.berkeley.cs::chisel3:3.5.0-RC1"
+ )
+}
+
+trait HasChiselTests extends CrossSbtModule  {
+  object test extends Tests {
+    override def ivyDeps = Agg(ivy"org.scalatest::scalatest:3.0.4", ivy"edu.berkeley.cs::chisel-iotesters:1.2+")
+    def testFrameworks = Seq("org.scalatest.tools.Framework")
+  }
+}
+
+object difftest extends SbtModule with CommonModule with HasChisel3 {
+  override def millSourcePath = os.pwd / "difftest"
+}
+
+object chiselModule extends CrossSbtModule with HasChisel3 with HasChiselTests with HasXsource211 {
+  def crossScalaVersion = "2.12.13"
+  override def moduleDeps = super.moduleDeps ++ Seq(
+    difftest
+  )
+}

--- a/src/main/scala/DifftestMain.scala
+++ b/src/main/scala/DifftestMain.scala
@@ -1,0 +1,53 @@
+/***************************************************************************************
+* Copyright (c) 2020-2021 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2021 Peng Cheng Laboratory
+*
+* XiangShan is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+package difftest
+
+import chisel3._
+import chisel3.util._
+import chisel3.stage._
+
+// Main class to generat difftest modules when design is not written in chisel.
+class DifftestTop extends Module {
+    var difftest_arch_event = Module(new DifftestArchEvent);
+    var difftest_basic_instr_commit = Module(new DifftestBasicInstrCommit);
+    var difftest_instr_commit = Module(new DifftestInstrCommit);
+    var difftest_basic_trap_event = Module(new DifftestBasicTrapEvent);
+    var difftest_trap_event = Module(new DifftestTrapEvent);
+    var difftest_csr_state = Module(new DifftestCSRState);
+    var difftest_debug_mode = Module(new DifftestDebugMode);
+    var difftest_int_writeback = Module(new DifftestIntWriteback);
+    var difftest_fp_writeback = Module(new DifftestFpWriteback);
+    var difftest_arch_int_reg_state = Module(new DifftestArchIntRegState);
+    var difftest_arch_fp_reg_state = Module(new DifftestArchFpRegState);
+    var difftest_sbuffer_event = Module(new DifftestSbufferEvent);
+    var difftest_store_event = Module(new DifftestStoreEvent);
+    var difftest_load_event = Module(new DifftestLoadEvent);
+    var difftest_atomic_event = Module(new DifftestAtomicEvent);
+    var difftest_ptw_event = Module(new DifftestPtwEvent);
+    var difftest_refill_event = Module(new DifftestRefillEvent);
+    var difftest_lr_sc_event = Module(new DifftestLrScEvent);
+    var difftest_runahead_event = Module(new DifftestRunaheadEvent);
+    var difftest_runahead_commit_event = Module(new DifftestRunaheadCommitEvent);
+    var difftest_runahead_redirect_event = Module(new DifftestRunaheadRedirectEvent);
+    var difftest_runahead_memdep_pred = Module(new DifftestRunaheadMemdepPred);
+}
+
+object DifftestMain extends App {
+  (new ChiselStage).execute(args, Seq(
+      ChiselGeneratorAnnotation(() => new DifftestTop))
+  )
+}

--- a/verilator.mk
+++ b/verilator.mk
@@ -33,7 +33,7 @@ ifneq ($(CCACHE),)
 export OBJCACHE = ccache
 endif
 
-VEXTRA_FLAGS  = -I$(abspath $(BUILD_DIR)) --x-assign unique -O3 -CFLAGS "$(EMU_CXXFLAGS) $(EMU_CXX_EXTRA_FLAGS)" -LDFLAGS "$(EMU_LDFLAGS)"
+VEXTRA_FLAGS += -I$(abspath $(BUILD_DIR)) --x-assign unique -O3 -CFLAGS "$(EMU_CXXFLAGS) $(EMU_CXX_EXTRA_FLAGS)" -LDFLAGS "$(EMU_LDFLAGS)"
 
 # REF SELECTION
 ifeq ($(REF),spike)


### PR DESCRIPTION
1. Make VEXTRA_FLAGS could accept external flags so that developers could give verilator some extra flags such as include directory et al.
2. Add a new target difftest_verilog to generate difftest modules for Verilog design.