### PR TITLE
verilator: add instr-count-dpi for newer versions

### DIFF
--- a/verilator.mk
+++ b/verilator.mk
@@ -44,6 +44,7 @@ endif
 VERILATOR_4_210 := $(shell expr `verilator --version | cut -f3 -d.` \>= 210)
 ifeq ($(VERILATOR_4_210),1)
 EMU_CXXFLAGS += -DVERILATOR_4_210
+VEXTRA_FLAGS += --instr-count-dpi 1
 endif
 
 # Verilator trace support


### PR DESCRIPTION
v4.204: 880 seconds
v4.218: 1017 seconds
v4.218 with instr-count-dpi: 804 seconds

More info at https://github.com/verilator/verilator/issues/3068.