### PR TITLE
fix: do not do_store_check before FIRST_INST_ADDRESS

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -100,19 +100,21 @@ int Difftest::step() {
   if (check_timeout()) {
     return 1;
   }
-  do_first_instr_commit();
-  if (do_store_check()) {
-    return 1;
-  }
 
+  do_first_instr_commit();
+  
 #ifdef DEBUG_GOLDENMEM
   if (do_golden_memory_update()) {
     return 1;
   }
 #endif
-
+  
   if (!has_commit) {
     return 0;
+  }
+
+  if (do_store_check()) {
+    return 1;
   }
 
 #ifdef DEBUG_REFILL


### PR DESCRIPTION
REF model is not setuped until the 1st inst commit. do_store_check before
that will always fail