### PR TITLE
vcs: fix incorrect random initialization (X)

### DIFF
--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -105,6 +105,7 @@ initial begin
     max_cycles = 0;
   end
 
+  // Note: reset delay #100 should be larger than RANDOMIZE_DELAY
   #100 reset = 0;
 end
 always #1 clock <= ~clock;

--- a/vcs.mk
+++ b/vcs.mk
@@ -52,8 +52,13 @@ VCS_FLAGS += -full64 +v2k -timescale=1ns/1ns -sverilog -debug_access+all +lint=T
 VCS_FLAGS += +define+DIFFTEST
 # randomize all undefined signals (instead of using X)
 VCS_FLAGS += +vcs+initreg+random
-VCS_FLAGS += +define+RANDOMIZE_GARBAGE_ASSIGN +define+RANDOMIZE_INVALID_ASSIGN
-VCS_FLAGS += +define+RANDOMIZE_MEM_INIT +define+RANDOMIZE_DELAY=0 +define+RANDOMIZE_REG_INIT
+VCS_FLAGS += +define+RANDOMIZE_GARBAGE_ASSIGN
+VCS_FLAGS += +define+RANDOMIZE_INVALID_ASSIGN
+VCS_FLAGS += +define+RANDOMIZE_MEM_INIT
+VCS_FLAGS += +define+RANDOMIZE_REG_INIT
+# manually set RANDOMIZE_DELAY to avoid VCS from incorrect random initialize
+# NOTE: RANDOMIZE_DELAY must NOT be rounded to 0
+VCS_FLAGS += +define+RANDOMIZE_DELAY=1
 # SRAM lib defines
 VCS_FLAGS += +define+UNIT_DELAY +define+no_warning
 # C++ flags


### PR DESCRIPTION
Set RANDOMIZE_DELAY to 0 will cause some random initialized reg be
initialized to X. RANDOMIZE_DELAY should satisfy:

* round(RANDOMIZE_DELAY) > 0
* RANDOMIZE_DELAY < reset delay

See https://github.com/chipsalliance/firrtl/pull/835