### PR TITLE
Add FST Waveform support

### DIFF
--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -22,7 +22,11 @@
 #include "lightsss.h"
 #include "VSimTop.h"
 #include "VSimTop__Syms.h"
+#ifdef ENABLE_FST
+#include <verilated_fst_c.h>
+#else
 #include <verilated_vcd_c.h>	// Trace file format header
+#endif
 #include <sys/types.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -84,7 +88,11 @@ struct EmuArgs {
 class Emulator {
 private:
   VSimTop *dut_ptr;
+#ifdef ENABLE_FST
+  VerilatedFstC* tfp;
+#else
   VerilatedVcdC* tfp;
+#endif
   bool enable_waveform;
   bool force_dump_wave = false;
 #ifdef VM_SAVABLE

--- a/verilator.mk
+++ b/verilator.mk
@@ -57,8 +57,12 @@ endif
 
 # Verilator trace support
 EMU_TRACE ?=
-ifeq ($(EMU_TRACE),1)
+ifneq (,$(filter $(EMU_TRACE),1 vcd VCD))
 VEXTRA_FLAGS += --trace
+endif
+ifneq (,$(filter $(EMU_TRACE),fst FST))
+VEXTRA_FLAGS += --trace-fst
+EMU_CXXFLAGS += -DENABLE_FST
 endif
 
 # Verilator multi-thread support


### PR DESCRIPTION
Please use EMU_TRACE=1, EMU_TRACE=vcd or EMU_TRACE=VCD to dump waveform of vcd format, and use EMU_TRACE=fst or EMU_TRACE=FST to dump waveform of fst format.