### PR TITLE
difftest: Add PTW refill check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test-difftest:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -170,7 +170,7 @@ class DiffRefillEventIO extends DifftestBundle {
   val valid = Input(Bool())
   val addr  = Input(UInt(64.W))
   val data  = Input(Vec(8, UInt(64.W)))
-  val cacheid = Input(Bool())
+  val cacheid = Input(UInt(8.W))
 }
 
 class DiffLrScEventIO extends DifftestBundle {

--- a/src/main/scala/DifftestMain.scala
+++ b/src/main/scala/DifftestMain.scala
@@ -40,6 +40,7 @@ class DifftestTop extends Module {
     var difftest_ptw_event = Module(new DifftestPtwEvent);
     var difftest_irefill_event = Module(new DifftestRefillEvent);
     var difftest_drefill_event = Module(new DifftestRefillEvent);
+    var difftest_ptwrefill_event = Module(new DifftestRefillEvent);
     var difftest_lr_sc_event = Module(new DifftestLrScEvent);
     var difftest_runahead_event = Module(new DifftestRunaheadEvent);
     var difftest_runahead_commit_event = Module(new DifftestRunaheadCommitEvent);

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -116,7 +116,7 @@ int Difftest::step() {
   }
 
 #ifdef DEBUG_REFILL
-  if (do_irefill_check() || do_drefill_check() ) {
+  if (do_irefill_check() || do_drefill_check() || do_ptwrefill_check() ) {
     return 1;
   }
 #endif
@@ -398,8 +398,8 @@ int Difftest::do_store_check() {
 int Difftest::do_refill_check(int cacheid) {
   static uint64_t last_valid_addr = 0;
   char buf[512];
-  refill_event_t dut_refill = cacheid == DCACHEID ? dut.d_refill : dut.i_refill ;    
-  const char* name = cacheid == DCACHEID ? "DCache" : "ICache";
+  refill_event_t dut_refill = cacheid == PAGECACHEID ? dut.ptw_refill : cacheid == DCACHEID ? dut.d_refill : dut.i_refill ;
+  const char* name = cacheid == PAGECACHEID ? "PageCache" : cacheid == DCACHEID ? "DCache" : "ICache";
   dut_refill.addr = dut_refill.addr - dut_refill.addr % 64;
   if (dut_refill.valid == 1 && dut_refill.addr != last_valid_addr) {
     last_valid_addr = dut_refill.addr;
@@ -429,15 +429,16 @@ int Difftest::do_refill_check(int cacheid) {
 }
 
 int Difftest::do_irefill_check() {
-    return do_refill_check(ICACHEID);   
+    return do_refill_check(ICACHEID);
 }
-
 
 int Difftest::do_drefill_check() {
-    return do_refill_check(DCACHEID);   
+    return do_refill_check(DCACHEID);
 }
 
-
+int Difftest::do_ptwrefill_check() {
+    return do_refill_check(PAGECACHEID);
+}
 
 inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData, uint64_t atomicMask, uint8_t atomicFuop, uint64_t atomicOut) {
   // We need to do atmoic operations here so as to update goldenMem

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -25,7 +25,7 @@
 enum { DIFFTEST_TO_DUT, DIFFTEST_TO_REF };
 enum { REF_TO_DUT, DUT_TO_REF };
 enum { REF_TO_DIFFTEST, DUT_TO_DIFFTEST };
-enum { ICACHEID, DCACHEID };
+enum { ICACHEID, DCACHEID, PAGECACHEID };
 // DIFFTEST_TO_DUT ~ REF_TO_DUT ~ REF_TO_DIFFTEST
 // DIFFTEST_TO_REF ~ DUT_TO_REF ~ DUT_TO_DIFFTEST
 #define CP printf("%s: %d\n", __FILE__, __LINE__);fflush( stdout );
@@ -217,6 +217,7 @@ typedef struct {
   ptw_event_t       ptw;
   refill_event_t    d_refill;
   refill_event_t    i_refill;
+  refill_event_t    ptw_refill;
   lr_sc_evevnt_t    lrsc;
   run_ahead_event_t runahead[DIFFTEST_RUNAHEAD_WIDTH];
   run_ahead_commit_event_t runahead_commit[DIFFTEST_RUNAHEAD_WIDTH];
@@ -339,8 +340,9 @@ public:
   inline ptw_event_t *get_ptw_event() {
     return &(dut.ptw);
   }
-  inline refill_event_t *get_refill_event(bool dcache) {
-    if(dcache) return &(dut.d_refill);
+  inline refill_event_t *get_refill_event(uint8_t cacheid) {
+    if (cacheid == PAGECACHEID) return &(dut.ptw_refill);
+    else if(cacheid == DCACHEID) return &(dut.d_refill);
     return &(dut.i_refill);
   }
   inline lr_sc_evevnt_t *get_lr_sc_event() {
@@ -413,6 +415,7 @@ protected:
   int do_refill_check(int cacheid);
   int do_irefill_check();
   int do_drefill_check();
+  int do_ptwrefill_check();
   int do_golden_memory_update();
   // inline uint64_t *ref_regs_ptr() { return (uint64_t*)&ref.regs; }
   // inline uint64_t *dut_regs_ptr() { return (uint64_t*)&dut.regs; }

--- a/src/test/csrc/difftest/interface.cpp
+++ b/src/test/csrc/difftest/interface.cpp
@@ -340,7 +340,7 @@ INTERFACE_PTW_EVENT {
 
 INTERFACE_REFILL_EVENT {
   RETURN_NO_NULL
-  // 0 for icache and 1 for dcache
+  // 0 for icache, 1 for dcache and 2 for page cache
   auto packet = difftest[coreid]->get_refill_event(cacheid);
   packet->valid = valid;
   if (packet->valid) {

--- a/src/test/csrc/difftest/interface.h
+++ b/src/test/csrc/difftest/interface.h
@@ -386,7 +386,7 @@ extern "C" int v_difftest_step();
     DPIC_ARG_LONG data_5,                \
     DPIC_ARG_LONG data_6,                \
     DPIC_ARG_LONG data_7,                \
-    DPIC_ARG_BIT  cacheid                \
+    DPIC_ARG_BYTE cacheid                \
   )
 
 // v_difftest_RefillEvent


### PR DESCRIPTION
Add PageCache_refill_check which is similar to icache_refill_check and dcache_refill_check. I have checked that both icache_refill_check and dcache_refill_check can still work after this commit.