### PR TITLE
vset support

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -67,6 +67,7 @@ class DiffInstrCommitIO extends DiffBasicInstrCommitIO {
   val sqIdx    = Input(UInt(7.W))
   val isLoad   = Input(Bool())
   val isStore  = Input(Bool())
+  val isVsetFirst = Input(Bool())
 }
 
 class DiffBasicTrapEventIO extends DifftestBundle {

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -79,6 +79,7 @@ typedef struct {
   uint16_t robidx;
   uint8_t  isLoad;
   uint8_t  isStore;
+  uint8_t  isVsetFirst;
 } instr_commit_t;
 
 typedef struct {

--- a/src/test/csrc/difftest/interface.cpp
+++ b/src/test/csrc/difftest/interface.cpp
@@ -90,6 +90,7 @@ INTERFACE_INSTR_COMMIT {
     packet->robidx   = robidx;
     packet->isLoad   = isLoad;
     packet->isStore  = isStore;
+    packet->isVsetFirst = isVsetFirst;
   }
 }
 

--- a/src/test/csrc/difftest/interface.h
+++ b/src/test/csrc/difftest/interface.h
@@ -98,7 +98,8 @@ extern "C" int v_difftest_step();
     DPIC_ARG_BYTE lqidx,                 \
     DPIC_ARG_BYTE sqidx,                 \
     DPIC_ARG_BIT  isLoad,                \
-    DPIC_ARG_BIT  isStore                \
+    DPIC_ARG_BIT  isStore,               \
+    DPIC_ARG_BIT  isVsetFirst            \
   )
 
 // v_difftest_BasicTrapEvent


### PR DESCRIPTION
1. Add isVsetFirst in DiffInstrCommitIO
2. Skip regs cmp when an incomplete vset is commit in 1 cycle.