### PR TITLE
mk: assign empty value to OBJCACHE rather than not set

### DIFF
--- a/verilator.mk
+++ b/verilator.mk
@@ -43,6 +43,7 @@ EMU_CXX_EXTRA_FLAGS ?=
 
 EMU_VFILES    = $(SIM_VSRC)
 
+OBJCACHE =
 CCACHE := $(if $(shell which ccache),ccache,)
 ifneq ($(CCACHE),)
 export OBJCACHE = ccache


### PR DESCRIPTION
In some servers, for verilator, if OBJCACHE is not set, ccache will be the default value but ccache is already uninstalled.
So assign empty value to OBJCACHE to aviod ccache.