### PR TITLE
emu: explicitly pass seed to verilator with Verilated::randSeed

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -246,6 +246,7 @@ Emulator::Emulator(int argc, const char *argv[]):
   // srand
   srand(args.seed);
   srand48(args.seed);
+  Verilated::randSeed(args.seed);
   Verilated::randReset(2);
   assert_init();
 

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -56,6 +56,7 @@ struct EmuArgs {
   const char *wave_path;
   const char *ram_size;
   const char *flash_bin;
+  const char *select_db;
   bool enable_waveform;
   bool enable_snapshot;
   bool force_dump_result;
@@ -89,6 +90,7 @@ struct EmuArgs {
     ram_size = NULL;
     image = NULL;
     flash_bin = NULL;
+    select_db = NULL;
     enable_waveform = false;
     enable_snapshot = true;
     force_dump_result = false;


### PR DESCRIPTION
With Verilated::randSeed, we can truly pass seed to Verilator. Otherwise, seeds specified using srand48 will be overwritten by verilator's built-in srand48. 
See more details in Verilator-doc "+verilator+rand+seed" and [https://github.com/verilator/verilator/blob/master/include/verilated.cpp](url)