### PR TITLE
Add preliminary support for batch mode

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -1,0 +1,60 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2023 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.batch
+
+import chisel3._
+import chisel3.util._
+import chisel3.util.experimental.BoringUtils
+import difftest._
+
+import scala.collection.mutable.ListBuffer
+
+object Batch {
+  private val instances = ListBuffer.empty[DifftestBundle]
+
+  def apply[T <: DifftestBundle](gen: T): T = {
+    register(WireInit(0.U.asTypeOf(gen)))
+  }
+
+  def register[T <: DifftestBundle](gen: T): T = {
+    BoringUtils.addSource(gen, s"batch_${instances.length}")
+    instances += gen
+    gen
+  }
+
+  def collect(): BatchEndpoint = {
+    Module(new BatchEndpoint(instances.toSeq))
+  }
+}
+
+class BatchEndpoint(signals: Seq[DifftestBundle]) extends Module {
+  val in = WireInit(0.U.asTypeOf(MixedVec(signals.map(_.cloneType))))
+  for ((data, batch_id) <- in.zipWithIndex) {
+    BoringUtils.addSink(data, s"batch_$batch_id")
+  }
+
+  val batch_size = 32
+  val batch_data = Mem(batch_size, in.cloneType)
+  val batch_ptr = RegInit(0.U(log2Ceil(batch_size).W))
+  batch_ptr := batch_ptr + 1.U
+  batch_data(batch_ptr) := in
+
+  // Sync the data when batch is completed
+  val do_batch_sync = batch_ptr === (batch_size - 1).U
+  // TODO: implement the sync logic for the batch data
+  dontTouch(do_batch_sync)
+  dontTouch(WireInit(batch_data(0)))
+}

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -18,6 +18,7 @@ package difftest
 
 import chisel3._
 import chisel3.util._
+import difftest.batch.Batch
 import difftest.dpic.DPIC
 
 import java.nio.charset.StandardCharsets
@@ -417,6 +418,7 @@ object DifftestModule {
     val id = register(gen, style)
     val difftest: T = Wire(gen)
     val sink = style match {
+      case "batch" => Batch(gen)
       // By default, use the DPI-C style.
       case _ => DPIC(gen)
     }
@@ -436,8 +438,14 @@ object DifftestModule {
   }
 
   def hasDPIC: Boolean = instances.exists(_._2 == "dpic")
+  def hasBatch: Boolean = instances.exists(_._2 == "batch")
   def finish(cpu: String, cppHeader: Option[String] = Some("dpic")): Unit = {
-    DPIC.collect()
+    if (hasDPIC) {
+      DPIC.collect()
+    }
+    if (hasBatch) {
+      Batch.collect()
+    }
     if (cppHeader.isDefined) {
       generateCppHeader(cpu, cppHeader.get)
     }


### PR DESCRIPTION
For now, we only implement a 2D array to store the difftest trace. The sync logic should be further implemented to support the real batch mode.

The sync may reuse other styles such as DPI-C. However, it should be carefully implemented to act like a real batch data transfer. We don't know how it looks like now so we are leaving it empty.

The C++ difftest files also need to support batch mode with an array of DiffTrace as the input. Actually we already have the DiffTrace abstraction, the only thing to do is to avoid calling simulation ticks when dealing with the batch data and resume simulation after it.