### PR TITLE
emu: delete lightsss to avoid resource leaks

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -484,6 +484,7 @@ Emulator::~Emulator() {
     else {
       lightsss->do_clear();
     }
+    delete lightsss;
   }
 
   display_trapinfo();


### PR DESCRIPTION
Shared memory resources should be released manually. Otherwise the system would be out of shared memory resources.