### PR TITLE
DPIC: move valid to the wrapper as enable

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -146,12 +146,11 @@ private class DummyDPICWrapper[T <: DifftestBundle](gen: T, hasGlobalEnable: Boo
 
   val dpic = Module(new DPIC(gen))
   dpic.clock := clock
-  val enable = Wire(Bool())
-  enable := io.getValid
+  val enable = WireInit(true.B)
+  dpic.enable := io.getValid && enable
   if (hasGlobalEnable) {
     BoringUtils.addSink(enable, "dpic_global_enable")
   }
-  dpic.enable := enable
   dpic.io := io
 }
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -77,6 +77,8 @@ Difftest::Difftest(int coreid) : id(coreid) {
   dut.trap.cycleCnt = 0;
   dut.trap.instrCnt = 0;
 
+  memset(&dut, 0, sizeof(dut));
+
 #ifdef CONFIG_DIFFTEST_INSTRCOVER
   memset(dut.icover, 0, sizeof(dut.icover));
 #endif // CONFIG_DIFFTEST_INSTRCOVER


### PR DESCRIPTION
Previously we are using the valid bit in the generated C++ function to decide whether to update other fields. However, this brings both performance and functional issues.

When valid is set to false in the hardware, we still need to call the DPI-C function, causing performance overhead. Besides, we still update the valid field in C++. However, the index may be invalid at this time and brings out-of-range memory accesses.

Now we move the valid condition to the enable bit in DPI-C module wrapper. The simulator should avoid calling the DPI-C function when not necessary.