### PR TITLE
Add preliminary support for merging difftrace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,19 @@ jobs:
             ./build/emu -b 0 -e 0 -i ./ready-to-run/microbench.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
             cd difftest && git restore src
 
+      - name: Difftest with Merge and Global DPI-C Enable
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            sed -i 's/hasGlobalEnable: Boolean = false/hasGlobalEnable: Boolean = true/' difftest/src/main/scala/DPIC.scala
+            sed -i 's/isEffective: Boolean = false/isEffective: Boolean = true/' difftest/src/main/scala/Merge.scala
+            make emu
+            ./build/emu -b 0 -e 0 -i ./ready-to-run/microbench.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
+            cd difftest && git restore src
+
       - name: Difftest with Coverage-Guided Fuzzer
         run: |
             git clone https://github.com/OpenXiangShan/riscv-isa-sim.git

--- a/src/main/scala/Merge.scala
+++ b/src/main/scala/Merge.scala
@@ -1,0 +1,113 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2023 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.merge
+
+import chisel3._
+import chisel3.util._
+import chisel3.util.experimental.BoringUtils
+import difftest._
+
+import scala.collection.mutable.ListBuffer
+
+object Merge {
+  private val isEffective: Boolean = false
+  private val instances = ListBuffer.empty[DifftestBundle]
+
+  def apply[T <: DifftestBundle](gen: T): T = {
+    if (isEffective) register(gen, WireInit(0.U.asTypeOf(gen))) else gen
+  }
+
+  def register[T <: DifftestBundle](original: T, merged: T): T = {
+    // There seems to be a bug in WiringUtils when original is some IO of Module.
+    // We manually add a Wire for the source to avoid the WiringException.
+    BoringUtils.addSource(WireInit(original), s"merge_in_${instances.length}")
+    BoringUtils.addSink(merged, s"merge_out_${instances.length}")
+    instances += original.cloneType
+    merged
+  }
+
+  def collect(): Seq[String] = {
+    if (isEffective) {
+      Module(new MergeEndpoint(instances.toSeq))
+      Seq("CONFIG_DIFFTEST_MERGE")
+    }
+    else {
+      Seq()
+    }
+  }
+}
+
+class MergeEndpoint(bundles: Seq[DifftestBundle]) extends Module {
+  val in = WireInit(0.U.asTypeOf(MixedVec(bundles)))
+  for ((data, i) <- in.zipWithIndex) {
+    BoringUtils.addSink(data, s"merge_in_$i")
+  }
+
+  val out = Wire(MixedVec(bundles))
+  for ((data, i) <- out.zipWithIndex) {
+    BoringUtils.addSource(data, s"merge_out_$i")
+  }
+
+  val state = RegInit(0.U.asTypeOf(MixedVec(bundles)))
+
+  // Mark the initial commit events as non-mergeable for initial state synchronization.
+  val hasValidCommitEvent = VecInit(state.filter(_.desiredCppName == "commit").map(_.getValid).toSeq).asUInt.orR
+  val isInitialEvent = RegInit(true.B)
+  when (isInitialEvent && hasValidCommitEvent) {
+    isInitialEvent := false.B
+  }
+  val tick_first_commit = isInitialEvent && hasValidCommitEvent
+
+  // If one of the bundles cannot be merged, the others are not merged as well.
+  val supportsMergeVec = VecInit(in.zip(state).map{ case (i, s) => i.supportsMerge(s) }.toSeq)
+  val supportsMerge = supportsMergeVec.asUInt.andR
+
+  // If one of the bundles cannot be the new base, the others are not as well.
+  val supportsBaseVec = VecInit(state.map(_.supportsBase).toSeq)
+  val supportsBase = supportsBaseVec.asUInt.andR
+
+  // Submit the pending non-mergeable events immediately.
+  val should_tick = !supportsMerge || !supportsBase || tick_first_commit
+  out := Mux(should_tick, state, 0.U.asTypeOf(MixedVec(bundles)))
+
+  for ((i, s) <- in.zip(state)) {
+    s := Mux(should_tick, i, i.mergeWith(s))
+  }
+
+  // Special fix for int writeback. Work for single-core only.
+  if (bundles.exists(_.desiredCppName == "wb_int")) {
+    require(bundles.count(_.isUniqueIdentifier) == 1, "only single-core is supported yet")
+    val writebacks = in.filter(_.desiredCppName == "wb_int").map(_.asInstanceOf[DiffIntWriteback])
+    val numPhyRegs = writebacks.head.numElements
+    val wb_int = Reg(Vec(numPhyRegs, UInt(64.W)))
+    for (wb <- writebacks) {
+      when (wb.valid) {
+        wb_int(wb.address) := wb.data
+      }
+    }
+    val commits = out.filter(_.desiredCppName == "commit").map(_.asInstanceOf[DiffInstrCommit])
+    val num_skip = PopCount(commits.map(c => c.valid && c.skip))
+    assert(num_skip <= 1.U, p"num_skip $num_skip is larger than one. Merge not supported yet")
+    val wb_for_skip = out.filter(_.desiredCppName == "wb_int").head.asInstanceOf[DiffIntWriteback]
+    for (c <- commits) {
+      when (c.valid && c.skip) {
+        wb_for_skip.valid := true.B
+        wb_for_skip.address := c.wpdest
+        wb_for_skip.data := wb_int(c.wpdest)
+      }
+    }
+  }
+}

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -252,12 +252,17 @@ public:
 protected:
   DiffTrace *difftrace = nullptr;
 
+#ifdef CONFIG_DIFFTEST_MERGE
+  const uint64_t timeout_scale = 256;
+#else
+  const uint64_t timeout_scale = 1;
+#endif // CONFIG_DIFFTEST_MERGE
 #if defined(CPU_NUTSHELL) || defined(CPU_ROCKET_CHIP)
   const uint64_t firstCommit_limit = 1000;
-  const uint64_t stuck_limit = 500;
+  const uint64_t stuck_limit = 500 * timeout_scale;
 #elif defined(CPU_XIANGSHAN)
   const uint64_t firstCommit_limit = 15000;
-  const uint64_t stuck_limit = 15000;
+  const uint64_t stuck_limit = 15000 * timeout_scale;
 #endif
   const uint64_t delay_wb_limit = 80;
 

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -587,7 +587,7 @@ inline void Emulator::single_cycle() {
 
 #if VM_TRACE == 1
   if (args.enable_waveform) {
-#ifndef CONFIG_NO_DIFFTEST
+#if !defined(CONFIG_NO_DIFFTEST) && !defined(CONFIG_DIFFTEST_MERGE)
     uint64_t cycle = difftest[0]->get_trap_event()->cycleCnt;
 #else
     static uint64_t cycle = -1UL;
@@ -626,7 +626,7 @@ inline void Emulator::single_cycle() {
 
 #if VM_TRACE == 1
   if (args.enable_waveform && args.enable_waveform_full) {
-#ifndef CONFIG_NO_DIFFTEST
+#if !defined(CONFIG_NO_DIFFTEST) && !defined(CONFIG_DIFFTEST_MERGE)
     uint64_t cycle = difftest[0]->get_trap_event()->cycleCnt;
 #else
     static uint64_t cycle = -1UL;


### PR DESCRIPTION
This commit adds preliminary support for merging difftest bundles across various cycles to reduce the memory traffic.

Some cases do not support merging yet and should be identified in the bundle definitions via `supportsMerge` and `supportsBase`. Examples include skipped instructions and store events (to maintain the golden memory).

Currently XiangShan requires ~20K merged difftrace during 100K cycles of simulation with the microbench workload (~100K instructions). NutShell requires ~612 merged difftrace during the 100K cycles of simulation with the microbench workload (~50K instructions). XiangShan requires more merged difftrace because of the existence of StoreEvent to maintain the global golden memory.