### PR TITLE
Update refproxy to dlopen single riscv64-spike-so file even for multicore.

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -45,7 +45,11 @@
 #if defined(CPU_NUTSHELL)
 #define FIRST_INST_ADDRESS 0x80000000UL
 #elif defined(CPU_XIANGSHAN) || defined(CPU_ROCKET_CHIP)
+#if defined(SELECTEDSpike)
+#define FIRST_INST_ADDRESS 0x80000000UL
+#else
 #define FIRST_INST_ADDRESS 0x10000000UL
+#endif
 #endif
 
 // sdcard image to be used in simulation

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -20,6 +20,7 @@
 #include "ram.h"
 #include "flash.h"
 #include "spikedasm.h"
+#include "refproxy.h"
 
 Difftest **difftest = NULL;
 
@@ -32,6 +33,10 @@ int difftest_init() {
 }
 
 int init_nemuproxy(size_t ramsize = 0) {
+#if defined(SELECTEDSpike)
+  // For Spike, only create one .so lib even for multicore
+  SpikeProxy::ref_init();
+#endif
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i]->update_nemuproxy(i, ramsize);
   }

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -21,6 +21,35 @@
 uint8_t* ref_golden_mem = NULL;
 const char *difftest_ref_so = NULL;
 
+void* SpikeProxy::handle = nullptr;
+void (*SpikeProxy::sim_init)() = nullptr;
+void (*SpikeProxy::sim_regcpy)(size_t coreid, void *dut, bool direction, bool on_demand) = nullptr;
+void (*SpikeProxy::sim_csrcpy)(size_t coreid, void *dut, bool direction) = nullptr;
+void (*SpikeProxy::sim_memcpy)(size_t coreid, uint64_t nemu_addr, void *dut_buf, size_t n, bool direction) = nullptr;
+void (*SpikeProxy::sim_exec)(size_t coreid, uint64_t n) = nullptr;
+void (*SpikeProxy::sim_reg_display)(size_t coreid) = nullptr;
+void (*SpikeProxy::sim_update_config)(size_t coreid, void *config) = nullptr;
+void (*SpikeProxy::sim_uarchstatus_cpy)(size_t coreid, void *dut, bool direction) = nullptr;
+int (*SpikeProxy::sim_store_commit)(size_t coreid, uint64_t *saddr, uint64_t *sdata, uint8_t *smask) = nullptr;
+void (*SpikeProxy::sim_raise_intr)(size_t coreid, uint64_t no) = nullptr;
+void (*SpikeProxy::sim_load_flash_bin)(void *flash_bin, size_t size) = nullptr;
+#ifdef ENABLE_RUNHEAD
+  void (*SpikeProxy::sim_query)(size_t core_id, void *result_buffer, uint64_t type) = nullptr;
+#endif
+#ifdef DEBUG_MODE_DIFF
+  void (*SpikeProxy::sim_debug_mem_sync)(paddr_t addr, void *bytes, size_t size) = nullptr;
+#endif
+
+// REF_OPTIONAL
+void (*SpikeProxy::sim_close)(size_t) = nullptr; // w/ coreid
+void (*SpikeProxy::sim_set_ramsize)(size_t) = nullptr; // w/o coreid
+void (*SpikeProxy::sim_set_mhartid)(size_t, int) = nullptr; // w/ coreid
+void (*SpikeProxy::sim_put_gmaddr)(void *) = nullptr; // w/o coreid
+void (*SpikeProxy::sim_skip_one)(size_t, bool, bool, uint32_t, uint64_t) = nullptr; // w/ coreid
+void (*SpikeProxy::sim_guided_exec)(size_t, void *) = nullptr; // w/ coreid
+int (*SpikeProxy::sim_disambiguation_state)(size_t) = nullptr; // w/ coreid
+
+
 #define check_and_assert(func)                                \
   do {                                                        \
     if (!func) {                                              \
@@ -43,7 +72,7 @@ REF_ALL(DeclExtRefFunc)
 REF_OPTIONAL(DeclWeakExtRefFunc)
 #endif
 
-AbstractRefProxy::AbstractRefProxy(int coreid, size_t ram_size, const char *env, const char *file_path) :
+Type1Proxy::Type1Proxy(int coreid, size_t ram_size, const char *env, const char *file_path) :
   handler(load_handler(env, file_path)) {
 #ifdef LINKED_REFPROXY_LIB
 #define GetRefFunc(dummy, ref_func, ret, ...) ref_func
@@ -75,13 +104,13 @@ AbstractRefProxy::AbstractRefProxy(int coreid, size_t ram_size, const char *env,
   ref_init();
 }
 
-AbstractRefProxy::~AbstractRefProxy() {
+Type1Proxy::~Type1Proxy() {
   if (handler) {
     dlclose(handler);
   }
 };
 
-void *AbstractRefProxy::load_handler(const char *env, const char *file_path) {
+void *Type1Proxy::load_handler(const char *env, const char *file_path) {
 #ifdef LINKED_REFPROXY_LIB
   Info("The reference model (dynamically or statically linked at compile-time) is %s\n", LINKED_REFPROXY_LIB);
   return nullptr;
@@ -120,98 +149,10 @@ void *AbstractRefProxy::load_handler(const char *env, const char *file_path) {
 }
 
 template <typename T>
-T AbstractRefProxy::load_function(const char *func_name) {
+T Type1Proxy::load_function(const char *func_name) {
   check_and_assert(handler);
   return reinterpret_cast<T>(dlsym(handler, func_name));
 }
-
-RefProxy::~RefProxy() {
-  if (ref_close) {
-    ref_close();
-  }
-}
-
-
-void RefProxy::regcpy(DiffTestState *dut) {
-  memcpy(&regs_int, dut->regs_int.value, 32 * sizeof(uint64_t));
-#ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-  memcpy(&regs_fp, dut->regs_fp.value, 32 * sizeof(uint64_t));
-#endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
-  memcpy(&csr, &dut->csr, sizeof(csr));
-  pc = dut->commit[0].pc;
-#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-  memcpy(&regs_vec, &dut->regs_vec.value, sizeof(regs_vec));
-#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
-#ifdef CONFIG_DIFFTEST_VECCSRSTATE
-  memcpy(&vcsr, &dut->vcsr, sizeof(vcsr));
-#endif // CONFIG_DIFFTEST_VECCSRSTATE
-  ref_regcpy(&regs_int, DUT_TO_REF, false);
-};
-
-int RefProxy::compare(DiffTestState *dut) {
-#define PROXY_COMPARE(field) memcmp(&(dut->field), &(field), sizeof(field))
-
-  const int results[] = {
-    PROXY_COMPARE(regs_int),
-#ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-    PROXY_COMPARE(regs_fp),
-#endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
-#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-    PROXY_COMPARE(regs_vec),
-#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
-#ifdef CONFIG_DIFFTEST_VECCSRSTATE
-    PROXY_COMPARE(vcsr),
-#endif // CONFIG_DIFFTEST_VECCSRSTATE
-    PROXY_COMPARE(csr)
-
-  };
-  for (int i = 0; i < sizeof(results) / sizeof(int); i++) {
-    if (results[i]) {
-      // There may be some waive rules for CSRs
-      if (i == sizeof(results) / sizeof(int) - 1) {
-        // If mismatches are cleared, we sync the states back to REF.
-        if (do_csr_waive(dut) && !PROXY_COMPARE(csr)) {
-          sync(true);
-          return 0;
-        }
-      }
-      return 1;
-    }
-  }
-  return 0;
-};
-
-void RefProxy::display(DiffTestState *dut) {
-  if (dut) {
-#define PROXY_COMPARE_AND_DISPLAY(field, field_names)                   \
-do {                                                                  \
-  uint64_t *_ptr_dut = (uint64_t *)(&((dut)->field));                 \
-  uint64_t *_ptr_ref = (uint64_t *)(&(field));                    \
-  for (int i = 0; i < sizeof(field) / sizeof(uint64_t); i ++) {   \
-    if (_ptr_dut[i] != _ptr_ref[i]) {                                 \
-      printf("%7s different at pc = 0x%010lx, right= 0x%016lx, "      \
-              "wrong = 0x%016lx\n", field_names[i], dut->commit[0].pc, \
-              _ptr_ref[i], _ptr_dut[i]);                               \
-    }                                                                 \
-  }                                                                   \
-} while(0);
-
-    PROXY_COMPARE_AND_DISPLAY(regs_int, regs_name_int)
-#ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-    PROXY_COMPARE_AND_DISPLAY(regs_fp, regs_name_fp)
-#endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
-    PROXY_COMPARE_AND_DISPLAY(csr, regs_name_csr)
-#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-    PROXY_COMPARE_AND_DISPLAY(regs_vec, regs_name_vec)
-#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
-#ifdef CONFIG_DIFFTEST_VECCSRSTATE
-    PROXY_COMPARE_AND_DISPLAY(vcsr, regs_name_vec_csr)
-#endif // CONFIG_DIFFTEST_VECCSRSTATE
-  }
-  else {
-    ref_reg_display();
-  }
-};
 
 #ifdef CPU_ROCKET_CHIP
 // similar function as encodeVirtualAddress@RocketCore.scala: 1151
@@ -243,44 +184,185 @@ static uint64_t read_mtvec(uint64_t paddr) {
 }
 #endif // CPU_ROCKET_CHIP
 
-bool RefProxy::do_csr_waive(DiffTestState *dut) {
-#define CSR_WAIVE(field, mapping)                             \
-  do {                                                        \
-    uint64_t v = mapping(csr.field);                          \
-    if (csr.field != dut->csr.field && dut->csr.field == v) { \
-      csr.field = v;                                          \
-      has_waive = true;                                       \
-    }                                                         \
-  } while (0);
-
-  bool has_waive = false;
-#ifdef CPU_ROCKET_CHIP
-  CSR_WAIVE(mtval, encode_vaddr);
-  CSR_WAIVE(mtval, sext_vaddr_40bit);
-  CSR_WAIVE(stval, encode_vaddr);
-  CSR_WAIVE(stval, sext_vaddr_40bit);
-  CSR_WAIVE(mtvec, read_mtvec);
-  CSR_WAIVE(stvec, read_stvec);
-#endif // CPU_ROCKET_CHIP
-  return has_waive;
-}
-
 #define NEMU_ENV_VARIABLE "NEMU_HOME"
 #define NEMU_SO_FILENAME  "build/riscv64-nemu-interpreter-so"
 NemuProxy::NemuProxy(int coreid, size_t ram_size) :
-  RefProxy(coreid, ram_size, NEMU_ENV_VARIABLE, NEMU_SO_FILENAME) {
+  Type1Proxy(coreid, ram_size, NEMU_ENV_VARIABLE, NEMU_SO_FILENAME) {
 }
 
-#define SPIKE_ENV_VARIABLE "SPIKE_HOME"
-#define SPIKE_SO_FILENAME  "difftest/build/riscv64-spike-so"
-SpikeProxy::SpikeProxy(int coreid, size_t ram_size) :
-  RefProxy(coreid, ram_size, SPIKE_ENV_VARIABLE, SPIKE_SO_FILENAME) {
-}
 
-LinkedProxy::LinkedProxy(int coreid, size_t ram_size) : RefProxy(coreid, ram_size) {
+LinkedProxy::LinkedProxy(int coreid, size_t ram_size) : Type1Proxy(coreid, ram_size) {
   if (NUM_CORES > 1) {
     printf("LinkedProxy does not support NUM_CORES(%d) > 1. Please use other REFs.\n", NUM_CORES);
     fflush(stdout);
     assert(0);
   }
 }
+
+#define SPIKE_ENV_VARIABLE "SPIKE_HOME"
+#define SPIKE_SO_FILENAME  "difftest/build/riscv64-spike-so"
+
+void SpikeProxy::ref_init() 
+{
+  if (difftest_ref_so == NULL) {
+    printf("--diff is not given, "
+           "try to use $(" SPIKE_ENV_VARIABLE ")/" SPIKE_SO_FILENAME
+           " by default\n");
+    const char *spike_home = getenv(SPIKE_ENV_VARIABLE);
+    if (spike_home == NULL) {
+      printf("FATAL: $(" SPIKE_ENV_VARIABLE ") is not defined!\n");
+      exit(1);
+    }
+    const char *so = "/" SPIKE_SO_FILENAME;
+    char *buf = (char *)malloc(strlen(spike_home) + strlen(so) + 1);
+    strcpy(buf, spike_home);
+    strcat(buf, so);
+    difftest_ref_so = buf;
+  }
+
+  printf("SpikeProxy using %s\n", difftest_ref_so);
+
+  handle = dlmopen(LM_ID_NEWLM, difftest_ref_so, RTLD_LAZY | RTLD_DEEPBIND);
+  if (!handle) {
+    printf("%s\n", dlerror());
+    assert(0);
+  }
+
+  sim_init = (void (*)())dlsym(handle, "difftest_init");
+  check_and_assert(sim_init);
+
+  sim_regcpy = (void (*)(size_t, void *, bool, bool))dlsym(handle, "difftest_regcpy");
+  check_and_assert(sim_regcpy);
+
+  sim_csrcpy = (void (*)(size_t, void *, bool))dlsym(handle, "difftest_csrcpy");
+  check_and_assert(sim_csrcpy);
+
+  sim_memcpy = (void (*)(size_t, uint64_t, void *, size_t, bool))dlsym(handle, "difftest_memcpy");
+  check_and_assert(sim_memcpy);
+
+  sim_exec = (void (*)(size_t, uint64_t))dlsym(handle, "difftest_exec");
+  check_and_assert(sim_exec);
+
+  sim_reg_display = (void (*)(size_t))dlsym(handle, "difftest_display");
+  check_and_assert(sim_reg_display);
+
+  sim_update_config = (void (*)(size_t, void *))dlsym(handle, "update_dynamic_config");
+  check_and_assert(sim_update_config);
+
+  sim_uarchstatus_cpy = (void (*)(size_t, void *, bool))dlsym(handle, "difftest_uarchstatus_cpy");
+  check_and_assert(sim_uarchstatus_cpy);
+
+  sim_store_commit = (int (*)(size_t, uint64_t*, uint64_t*, uint8_t*))dlsym(handle, "difftest_store_commit");
+  check_and_assert(sim_store_commit);
+
+  sim_raise_intr = (void (*)(size_t, uint64_t))dlsym(handle, "difftest_raise_intr");
+  check_and_assert(sim_raise_intr);
+
+  // core independent
+  sim_load_flash_bin = (void (*)(void*, size_t))dlsym(handle, "difftest_load_flash");;
+  check_and_assert(sim_load_flash_bin);
+
+#ifdef ENABLE_RUNHEAD
+  sim_query = (void (*)(size_t, void*, uint64_t))dlsym(handle, "difftest_query_ref");
+  check_and_assert(sim_query);
+#endif
+#ifdef DEBUG_MODE_DIFF
+  // core independent
+  sim_debug_mem_sync = (void (*)(uint64_t, void *, size_t))dlsym(handle, "debug_mem_sync");
+  check_and_assert(sim_debug_mem_sync);
+#endif
+
+  // REF_OPTIONAL
+  sim_put_gmaddr = (void (*)(void*))dlsym(handle, "difftest_put_gmaddr");
+  if (NUM_CORES > 1) {
+    check_and_assert(sim_put_gmaddr);
+    assert(ref_golden_mem);
+    sim_put_gmaddr(ref_golden_mem);
+  }
+
+  sim_guided_exec = (void (*)(size_t, void *))dlsym(handle, "difftest_guided_exec");
+  check_and_assert(sim_guided_exec);
+  
+  sim_init();
+}
+
+void SpikeProxy::ref_regcpy(void *dut, bool direction, bool on_demand)
+{
+  sim_regcpy(coreid, dut, direction, on_demand);
+}
+
+void SpikeProxy::ref_csrcpy(void *dut, bool direction)
+{
+  sim_csrcpy(coreid, dut, direction);
+}
+
+void SpikeProxy::ref_memcpy(uint64_t nemu_addr, void *dut_buf, size_t n, bool direction)
+{
+  sim_memcpy(coreid, nemu_addr, dut_buf, n, direction);
+}
+
+void SpikeProxy::ref_exec(uint64_t n)
+{
+  sim_exec(coreid, n);
+}
+
+void SpikeProxy::ref_reg_display()
+{
+  sim_reg_display(coreid);
+}
+
+void SpikeProxy::update_config(void *config)
+{
+  sim_update_config(coreid, config);
+}
+
+void SpikeProxy::uarchstatus_sync(void *dut)
+{
+  sim_uarchstatus_cpy(coreid, dut, DIFFTEST_TO_REF);
+}
+
+int SpikeProxy::store_commit(uint64_t *saddr, uint64_t *sdata, uint8_t *smask)
+{
+  return sim_store_commit(coreid, saddr, sdata, smask);
+}
+
+void SpikeProxy::raise_intr(uint64_t no)
+{
+  sim_raise_intr(coreid, no);
+}
+
+void SpikeProxy::load_flash_bin(void *flash_bin, size_t size)
+{
+  sim_load_flash_bin(flash_bin, size);
+}
+
+#ifdef ENABLE_RUNHEAD
+void SpikeProxy::query(void *result_buffer, uint64_t type)
+{
+  sim_query(coreid, result_buffer, type);
+}
+#endif
+
+#ifdef DEBUG_MODE_DIFF
+void SpikeProxy::debug_mem_sync(uint64_t *addr, void *bytes, size_t size)
+{
+  sim_debug_mem_sync(addr, bytes, size);
+}
+#endif
+
+// REF_OPTIONAL
+void SpikeProxy::ref_put_gmaddr(void *addr)
+{
+  sim_put_gmaddr(addr);
+}
+void SpikeProxy::ref_guided_exec(void *disambiguate_para)
+{
+  sim_guided_exec(coreid, disambiguate_para);
+}
+
+
+
+
+
+
+

--- a/verilator.mk
+++ b/verilator.mk
@@ -97,7 +97,7 @@ ifneq ($(wildcard $(REF)),)
 EMU_CXXFLAGS += -DREF_PROXY=LinkedProxy -DLINKED_REFPROXY_LIB=\\\"$(REF)\\\"
 EMU_LDFLAGS  += $(REF)
 else
-EMU_CXXFLAGS += -DREF_PROXY=$(REF)Proxy
+EMU_CXXFLAGS += -DREF_PROXY=$(REF)Proxy -DSELECTED$(REF)
 REF_HOME_VAR = $(shell echo $(REF)_HOME | tr a-z A-Z)
 ifneq ($(origin $(REF_HOME_VAR)), undefined)
 EMU_CXXFLAGS += -DREF_HOME=\\\"$(shell echo $$$(REF_HOME_VAR))\\\"


### PR DESCRIPTION
This change does not impact using Difftest with NEMU.