### PR TITLE
vcs: fix the max-cycles argument in top

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -27,7 +27,6 @@ static bool has_reset = false;
 static char bin_file[256] = "ram.bin";
 static char *flash_bin_file = NULL;
 static bool enable_difftest = true;
-static int max_cycles = 0;
 
 extern "C" void set_bin_file(char *s) {
   printf("ram image:%s\n",s);
@@ -53,11 +52,6 @@ extern "C" void set_no_diff() {
   enable_difftest = false;
 }
 
-extern "C" void set_max_cycles(long mc) {
-  printf("max cycles:%d\n", mc);
-  max_cycles = mc;
-}
-
 extern "C" void simv_init() {
   common_init("simv");
 
@@ -75,15 +69,6 @@ extern "C" void simv_init() {
 extern "C" int simv_step() {
   if (assert_count > 0) {
     return 1;
-  }
-
-  static int cycles = 0;
-  if (max_cycles != 0) { // 0 for no limit
-    if (cycles >= max_cycles) {
-      eprintf(ANSI_COLOR_YELLOW "EXCEEDED MAX CYCLE:%d\n" ANSI_COLOR_RESET, max_cycles);
-      return 1;
-    }
-    cycles ++;
   }
 
   if (difftest_state() != -1) {

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -18,7 +18,6 @@ import "DPI-C" function void set_bin_file(string bin);
 import "DPI-C" function void set_flash_bin(string bin);
 import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
-import "DPI-C" function void set_max_cycles(int mc);
 import "DPI-C" function void simv_init();
 import "DPI-C" function int simv_step();
 
@@ -41,7 +40,7 @@ string bin_file;
 string flash_bin_file;
 string wave_type;
 string diff_ref_so;
-reg [31:0] max_cycles;
+reg [63:0] max_cycles;
 
 initial begin
   clock = 0;
@@ -102,12 +101,10 @@ initial begin
     set_no_diff();
   end
   // max cycles to execute, no limit for default
+  max_cycles = 0;
   if ($test$plusargs("max-cycles")) begin
     $value$plusargs("max-cycles=%d", max_cycles);
-    set_max_cycles(max_cycles);
-  end
-  else begin
-    max_cycles = 0;
+    $display("set max cycles: %d", max_cycles);
   end
 
   // Note: reset delay #100 should be larger than RANDOMIZE_DELAY
@@ -142,23 +139,32 @@ always @(posedge clock) begin
   end
 end
 
-reg has_init;
+reg [63:0] n_cycles;
 always @(posedge clock) begin
   if (reset) begin
-    has_init <= 1'b0;
+    n_cycles <= 64'h0;
   end
-  else if (!has_init) begin
-    simv_init();
-    has_init <= 1'b1;
-  end
+  else begin
+    n_cycles <= n_cycles + 64'h1;
 
-  // check errors
-  if (!reset && has_init && difftest_step) begin
-    if (simv_step()) begin
+    // max cycles
+    if (max_cycles > 0 && n_cycles >= max_cycles) begin
+      $display("EXCEEDED MAX CYCLE: %d", max_cycles);
       $finish();
     end
-  end
 
+    // difftest
+    if (!n_cycles) begin
+      simv_init();
+    end
+    else if (difftest_step) begin
+      // check errors
+      if (simv_step()) begin
+        $display("DIFFTEST FAILED at cycle %d", n_cycles);
+        $finish();
+      end
+    end
+  end
 end
 
 endmodule


### PR DESCRIPTION
When difftest is not ticked for every clock cycle, the cycles variable may be updated incorrectly. We move the implementation to Verilog to fix it.