### PR TITLE
squash: allow enabling/disabling during simulation

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -21,6 +21,9 @@
 #include "ram.h"
 #include "flash.h"
 #include "spikedasm.h"
+#ifdef CONFIG_DIFFTEST_SQUASH
+#include "svdpi.h"
+#endif // CONFIG_DIFFTEST_SQUASH
 
 Difftest **difftest = NULL;
 
@@ -71,6 +74,19 @@ void difftest_finish() {
   delete[] difftest;
   difftest = NULL;
 }
+
+#ifdef CONFIG_DIFFTEST_SQUASH
+extern "C" void set_squash_enable(int enable);
+void difftest_squash_set(int enable, const char *scope_name = "TOP.SimTop.SquashEndpoint.control") {
+  auto scope = svGetScopeFromName(scope_name);
+  if (scope == NULL) {
+    printf("Error: Could not retrieve scope with name '%s'\n", scope_name);
+    assert(scope);
+  }
+  svSetScope(scope);
+  set_squash_enable(rand());
+}
+#endif // CONFIG_DIFFTEST_SQUASH
 
 Difftest::Difftest(int coreid) : id(coreid) {
   state = new DiffState();

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -355,4 +355,8 @@ void difftest_finish();
 void difftest_trace();
 int init_nemuproxy(size_t);
 
+#ifdef CONFIG_DIFFTEST_SQUASH
+extern "C" void difftest_squash_set(int enable, const char *scope_name);
+#endif // CONFIG_DIFFTEST_SQUASH
+
 #endif


### PR DESCRIPTION
We add a Blackbox with an exported C/C++ task and a Verilog argument parser to control the enable bit for Squash.

For now, the Verilog argument can only specify a cycle counter to disable the Squash after exceeding specific clock cycles.