### PR TITLE
Fix: replace pointer to instance array with pointer array

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -384,7 +384,7 @@ object DifftestModule {
          |  virtual DiffTestState* next() = 0;
          |};
          |
-         |extern DiffStateBuffer* diffstate_buffer;
+         |extern DiffStateBuffer* diffstate_buffer[];
          |
          |extern void diffstate_buffer_init();
          |extern void diffstate_buffer_free();

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -32,7 +32,7 @@ int difftest_init() {
   difftest = new Difftest*[NUM_CORES];
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i] = new Difftest(i);
-    difftest[i]->dut = diffstate_buffer[i].get(0);
+    difftest[i]->dut = diffstate_buffer[i]->get(0);
   }
   return 0;
 }
@@ -72,7 +72,7 @@ int difftest_nstep(int step){
 
 int difftest_step() {
   for (int i = 0; i < NUM_CORES; i++) {
-    difftest[i]->dut = diffstate_buffer[i].next();
+    difftest[i]->dut = diffstate_buffer[i]->next();
     int ret = difftest[i]->step();
     if (ret) {
       return ret;

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -216,7 +216,7 @@ public:
   void trace_write(int step){
     if (difftrace){
       for (int i = 0; i < step; i++) {
-        difftrace->append(diffstate_buffer[id].get(i));
+        difftrace->append(diffstate_buffer[id]->get(i));
       }
     }
   }


### PR DESCRIPTION
Parent class pointer increment will still use parent class size when pointing to derived class instance