### PR TITLE
difftest: fix the init status of diffstate_buffer

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -394,7 +394,7 @@ object DifftestModule {
          |  virtual DiffTestState* next() = 0;
          |};
          |
-         |extern DiffStateBuffer* diffstate_buffer[];
+         |extern DiffStateBuffer** diffstate_buffer;
          |
          |extern void diffstate_buffer_init();
          |extern void diffstate_buffer_free();


### PR DESCRIPTION
Before difftest is initialized, io_coreid may be out-of-range. Thus, we have to check whether diffstate_buffer is initialized instead of checking the corresponding pointers are initialized with io_coreid.

This problem causes the failure of previous CIs.