### PR TITLE
Difftest: enable squash replay

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -221,4 +221,5 @@ class RunaheadRedirectEvent extends DifftestBaseBundle with HasValid {
 }
 
 class TraceInfo(val config: GatewayConfig) extends DifftestBaseBundle {
+  val squash_idx = Option.when(config.squashReplay)(UInt(log2Ceil(config.replaySize).W))
 }

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -20,25 +20,29 @@ import chisel3.experimental.ExtModule
 import chisel3.util._
 import chisel3.util.experimental.BoringUtils
 import difftest._
+import difftest.gateway.GatewayConfig
 
 import scala.collection.mutable.ListBuffer
 
 object Squash {
   private val instances = ListBuffer.empty[DifftestBundle]
 
-  def apply[T <: Seq[DifftestBundle]](bundles: T): SquashEndpoint = {
-    val module = Module(new SquashEndpoint(bundles))
+  def apply[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig): SquashEndpoint = {
+    val module = Module(new SquashEndpoint(bundles, config))
     module
   }
 
-  def collect(): Seq[String] = {
-    Seq("CONFIG_DIFFTEST_SQUASH")
+  def collect(config: GatewayConfig): Seq[String] = {
+    var macros = Seq("CONFIG_DIFFTEST_SQUASH")
+    if (config.squashReplay) macros ++= Seq("CONFIG_DIFFTEST_SQUASH_REPLAY")
+    macros
   }
 }
 
-class SquashEndpoint(bundles: Seq[DifftestBundle]) extends Module {
+class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
   val out = IO(Output(MixedVec(bundles)))
+  val idx = Option.when(config.squashReplay)(IO(Output(UInt(log2Ceil(config.replaySize).W))))
 
   val state = RegInit(0.U.asTypeOf(MixedVec(bundles)))
 
@@ -58,13 +62,13 @@ class SquashEndpoint(bundles: Seq[DifftestBundle]) extends Module {
   val supportsSquashBaseVec = VecInit(state.map(_.supportsSquashBase).toSeq)
   val supportsSquashBase = supportsSquashBaseVec.asUInt.andR
 
-  val control = Module(new SquashControl)
+  val control = Module(new SquashControl(config))
   control.clock := clock
   control.reset := reset
 
   // Submit the pending non-squashable events immediately.
   val should_tick = !control.enable || !supportsSquash || !supportsSquashBase || tick_first_commit
-  out := Mux(should_tick, state, 0.U.asTypeOf(MixedVec(bundles)))
+  val squashed = Mux(should_tick, state, 0.U.asTypeOf(MixedVec(bundles)))
 
   // Sometimes, the bundle may have squash dependencies.
   val do_squash = WireInit(VecInit.fill(in.length)(true.B))
@@ -84,18 +88,91 @@ class SquashEndpoint(bundles: Seq[DifftestBundle]) extends Module {
         s := i.squash(s)
       }
   }
+
+  if (config.squashReplay) {
+    val replay_data = Mem(config.replaySize, in.cloneType)
+    val replay_ptr = RegInit(0.U(log2Ceil(config.replaySize).W))
+    val replay_table = Mem(config.replaySize, replay_ptr.cloneType)
+
+    // Maybe every state is non-squashable, preventing two replayable squashed data have the same idx
+    val squash_idx = RegInit(0.U(log2Ceil(config.replaySize).W))
+
+    // write
+    when (should_tick & !control.replay.get) {
+      // record position of first unsquashed data
+      val next_squash_idx = Mux(squash_idx === (config.replaySize - 1).U, 0.U, squash_idx + 1.U)
+      replay_table(next_squash_idx) := replay_ptr
+      squash_idx := next_squash_idx
+    }
+    // ignore useless unsquashed data when hasGlobalEnable
+    val needStore = WireInit(true.B)
+    if (config.hasGlobalEnable) {
+      needStore := VecInit(in.filter(_.needUpdate.isDefined).map(_.needUpdate.get).toSeq).asUInt.orR
+    }
+    when ((should_tick || do_squash.asUInt.orR) && needStore && !control.replay.get) {
+      replay_data(replay_ptr) := in
+      replay_ptr := replay_ptr + 1.U
+      when (replay_ptr === (config.replaySize - 1).U) {
+        replay_ptr := 0.U
+      }
+    }
+
+    // read
+    val in_replay = RegInit(false.B) // indicates ptr in correct replay pos
+    when (control.replay.get) {
+      when (!in_replay) {
+        in_replay := true.B
+        replay_ptr := replay_table(control.replay_idx.get) // position of first corresponding unsquashed data
+      }.otherwise {
+        replay_ptr := replay_ptr + 1.U
+        when (replay_ptr === (config.replaySize - 1).U) {
+          replay_ptr := 0.U
+        }
+      }
+    }
+    idx.get := Mux(in_replay, control.replay_idx.get, squash_idx)
+    out := Mux(in_replay, replay_data(replay_ptr), squashed)
+  }
+  else {
+    out := squashed
+  }
 }
 
-class SquashControl extends ExtModule with HasExtModuleInline {
+class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleInline {
   val clock = IO(Input(Clock()))
   val reset = IO(Input(Reset()))
   val enable = IO(Output(Bool()))
+  val replay = Option.when(config.squashReplay)(IO(Output(Bool())))
+  val replay_idx = Option.when(config.squashReplay)(IO(Output(UInt(log2Ceil(config.replaySize).W))))
+
+  val replay_port = if (config.squashReplay)
+    s"""
+       |  output reg replay,
+       |  output reg [${log2Ceil(config.replaySize) - 1}:0] replay_idx,
+       |""".stripMargin
+    else ""
+  val replay_init = if (config.squashReplay)
+    s"""
+       |  replay = 1'b0;
+       |  replay_idx = ${log2Ceil(config.replaySize)}'b0;
+       |""".stripMargin
+    else ""
+  val replay_task = if (config.squashReplay)
+    """
+      |export "DPI-C" task set_squash_replay;
+      |task set_squash_replay(int idx);
+      |  replay = 1'b1;
+      |  replay_idx = idx;
+      |endtask
+      |""".stripMargin
+    else ""
 
   setInline("SquashControl.v",
-    """
+    s"""
       |module SquashControl(
       |  input clock,
       |  input reset,
+      |$replay_port
       |  output reg enable
       |);
       |
@@ -104,6 +181,7 @@ class SquashControl extends ExtModule with HasExtModuleInline {
       |initial begin
       |  set_squash_scope();
       |  enable = 1'b1;
+      |$replay_init
       |end
       |
       |// For the C/C++ interface
@@ -111,14 +189,14 @@ class SquashControl extends ExtModule with HasExtModuleInline {
       |task set_squash_enable(int en);
       |  enable = en;
       |endtask
+      |$replay_task
       |
       |// For the simulation argument +squash_cycles=N
       |reg [63:0] squash_cycles;
       |initial begin
-      |  squash_cycles = 0;
-      |  if ($test$plusargs("squash-cycles")) begin
-      |    $value$plusargs("squash-cycles=%d", squash_cycles);
-      |    $display("set squash cycles: %d", squash_cycles);
+      |  if ($$test$$plusargs("squash-cycles")) begin
+      |    $$value$$plusargs("squash-cycles=%d", squash_cycles);
+      |    $$display("set squash cycles: %d", squash_cycles);
       |  end
       |end
       |

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -353,6 +353,22 @@ protected:
   int apply_delayed_writeback();
 
   void raise_trap(int trapCode);
+
+#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
+  bool isSquash;
+  int squash_idx;
+  bool inReplay = false;
+  int replay_idx;
+
+  DiffState *state_ss = NULL;
+  REF_PROXY *proxy_ss = NULL;
+  uint64_t squash_csr_buf[4096];
+  long squash_memsize;
+  char *squash_membuf;
+  bool squash_check();
+  void squash_snapshot();
+  void squash_replay();
+#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
 };
 
 extern Difftest **difftest;
@@ -371,6 +387,9 @@ int init_nemuproxy(size_t);
 #ifdef CONFIG_DIFFTEST_SQUASH
 extern "C" void set_squash_scope();
 extern "C" void difftest_squash_enable(int enable);
+#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
+extern "C" void difftest_squash_replay(int idx);
+#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
 #endif // CONFIG_DIFFTEST_SQUASH
 
 #endif


### PR DESCRIPTION
* Before squashed dut_state changes REF, we will first snapshot and record its idx. Temporarily we use naive memcpy for implementation.
* After squashed dut_state trigger error, we will record its idx as replay_idx, then recover REF to state before it works.
* Replay_idx will be passed to HW by DPIC task, then corresponding unsquashed dut_state will be submitted again with same replay_idx.
* We will filter dut_state with different idx, so only first error state will be check again as a series of unsquashed state.