### PR TITLE
Difftest: Add synthesizable implementation for Helpers

### DIFF
--- a/src/main/scala/common/Flash.scala
+++ b/src/main/scala/common/Flash.scala
@@ -50,6 +50,54 @@ class FlashHelper extends ExtModule with HasExtModuleInline {
        |  always @(posedge clock) begin
        |    if (r_en) flash_read(r_addr, r_data);
        |  end
+       |`else
+       |  // 1K entries. 8KB size.
+       |  `define FLASH_SIZE (8 * 1024)
+       |  reg [7:0] flash_mem [0 : `FLASH_SIZE - 1];
+       |
+       |  for (genvar i = 0; i < 8; i++) begin
+       |    always @(posedge clk) begin
+       |      if (ren) r_data[8 * i + 7 : 8 * i] <= flash_mem[r_addr + i];
+       |    end
+       |  end
+       |
+       |`ifdef FLASH_IMAGE
+       |  integer flash_image, n_read;
+       |  // Create string-type FLASH_IMAGE
+       |  `define STRINGIFY(x) `"x`"
+       |  `define FLASH_IMAGE_S `STRINGIFY(`FLASH_IMAGE)
+       |`endif // FLASH_IMAGE
+       |
+       |  initial begin
+       |    for (integer i = 0; i < `FLASH_SIZE; i++) begin
+       |      flash_mem[i] = 8'h0;
+       |    end
+       |`ifdef FLASH_IMAGE
+       |    flash_image = $$fopen(`FLASH_IMAGE_S, "rb");
+       |    n_read = $$fread(flash_mem, flash_image);
+       |    $$fclose(flash_image);
+       |    if (!n_read) begin
+       |      $$fatal(1, "Flash: cannot load image from %s.", `FLASH_IMAGE_S);
+       |    end
+       |    else begin
+       |      $$display("Flash: load %d bytes from %s.", n_read, `FLASH_IMAGE_S);
+       |    end
+       |`else
+       |    `ifdef NANHU
+       |      // Used for pc = 0x8000_0000
+       |      // flash_mem[0] = 64'h01f292930010029b
+       |      // flash_mem[1] = 64'h00028067
+       |      reg [7:0] init_flash [0:11] = '{8'h9b, 8'h02, 8'h10, 8'h00, 8'h93, 8'h92, 8'hf2, 8'h01, 8'h67, 8'h80, 8'h02, 8'h00};
+       |    `else
+       |      // Used for pc = 0x20_0000_0000
+       |      reg [7:0] init_flash [0:11] = '{8'h9b, 8'h02, 8'h10, 8'h00, 8'h93, 8'h92, 8'h52, 8'h02, 8'h67, 8'h80, 8'h02, 8'h00};
+       |    `endif // NANHU
+       |    for (integer i = 0; i < 12; i = i + 1) begin
+       |        flash_mem[i] = init_flash[i];
+       |    end
+       |`endif // FLASH_IMAGE
+       |  end
+       |
        |`endif // SYNTHESIS
        |
        |endmodule

--- a/src/test/vsrc/common/SimJTAG.v
+++ b/src/test/vsrc/common/SimJTAG.v
@@ -1,14 +1,16 @@
 // See LICENSE.SiFive for license details.
 //VCS coverage exclude_file
+`ifndef SYNTHESIS
 import "DPI-C" function int jtag_tick
 (
  output bit jtag_TCK,
  output bit jtag_TMS,
  output bit jtag_TDI,
  output bit jtag_TRSTn,
- 
+
  input bit  jtag_TDO
 );
+`endif // SYNTHESIS
 
 module SimJTAG #(
                  parameter TICK_DELAY = 50
@@ -16,7 +18,7 @@ module SimJTAG #(
 
                    input         clock,
                    input         reset,
-                   
+
                    input         enable,
                    input         init_done,
 
@@ -24,25 +26,26 @@ module SimJTAG #(
                    output        jtag_TMS,
                    output        jtag_TDI,
                    output        jtag_TRSTn,
- 
+
                    input         jtag_TDO_data,
                    input         jtag_TDO_driven,
-                          
+
                    output [31:0] exit
                    );
 
+`ifndef SYNTHESIS
    reg [31:0]                    tickCounterReg;
    wire [31:0]                   tickCounterNxt;
-   
+
    assign tickCounterNxt = (tickCounterReg == 0) ? TICK_DELAY :  (tickCounterReg - 1);
-   
+
    bit          r_reset;
 
    wire [31:0]  random_bits = $random;
-   
-   wire         #0.1 __jtag_TDO = jtag_TDO_driven ? 
+
+   wire         #0.1 __jtag_TDO = jtag_TDO_driven ?
                 jtag_TDO_data : random_bits[0];
-      
+
    bit          __jtag_TCK;
    bit          __jtag_TMS;
    bit          __jtag_TDI;
@@ -50,12 +53,12 @@ module SimJTAG #(
    int          __exit;
 
    reg          init_done_sticky;
-   
+
    assign #0.1 jtag_TCK   = __jtag_TCK;
    assign #0.1 jtag_TMS   = __jtag_TMS;
    assign #0.1 jtag_TDI   = __jtag_TDI;
    assign #0.1 jtag_TRSTn = __jtag_TRSTn;
-   
+
    assign #0.1 exit = __exit;
 
    always @(posedge clock) begin
@@ -80,5 +83,6 @@ module SimJTAG #(
          end // if (enable && init_done_sticky)
       end // else: !if(reset || r_reset)
    end // always @ (posedge clock)
+`endif // SYNTHESIS
 
 endmodule

--- a/src/test/vsrc/common/SimJTAG.v
+++ b/src/test/vsrc/common/SimJTAG.v
@@ -83,6 +83,12 @@ module SimJTAG #(
          end // if (enable && init_done_sticky)
       end // else: !if(reset || r_reset)
    end // always @ (posedge clock)
+`else
+   assign jtag_TCK   = 1'b0;
+   assign jtag_TMS   = 1'b0;
+   assign jtag_TDI   = 1'b0;
+   assign jtag_TRSTn = 1'b1;
+   assign exit       = 32'b0;
 `endif // SYNTHESIS
 
 endmodule


### PR DESCRIPTION
When run without difftest, we will use verilog to replace DPIC. Args passing will be optimized later