### PR TITLE
SimJTAG: use logic for random

### DIFF
--- a/src/test/vsrc/common/SimJTAG.v
+++ b/src/test/vsrc/common/SimJTAG.v
@@ -41,7 +41,7 @@ module SimJTAG #(
 
    bit          r_reset;
 
-   wire [31:0]  random_bits = $random;
+   logic [31:0] random_bits = $random;
 
    wire         #0.1 __jtag_TDO = jtag_TDO_driven ?
                 jtag_TDO_data : random_bits[0];


### PR DESCRIPTION
Palladium doesn't support set $random to wire. Use dummy logic val to set it.