### PR TITLE
TB_ASYNC: Rename GfifoControl to AsyncControl

### DIFF
--- a/src/test/vsrc/vcs/AsyncControl.v
+++ b/src/test/vsrc/vcs/AsyncControl.v
@@ -1,8 +1,8 @@
-`ifdef PALLADIUM
+`ifdef TB_ASYNC
 
 `define STEP_WIDTH 8
 
-module GfifoControl(
+module AsyncControl(
   input clock,
   input reset,
   input [`STEP_WIDTH - 1:0] step,
@@ -12,7 +12,9 @@ module GfifoControl(
 import "DPI-C" function int simv_result_fetch();
 import "DPI-C" function void simv_nstep(int step);
 
+`ifdef PALLADIUM
 initial $ixc_ctrl("gfifo", "simv_nstep");
+`endif // PALLADIUM
 
 reg [63:0] fetch_cycles;
 initial fetch_cycles = 4999;
@@ -41,4 +43,4 @@ always @(posedge clock) begin
 end
 
 endmodule;
-`endif // PALLADIUM
+`endif // TB_ASYNC

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -24,9 +24,9 @@ import "DPI-C" function void set_flash_bin(string bin);
 import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
 import "DPI-C" function void simv_init();
-`ifndef PALLADIUM
+`ifndef TB_ASYNC
 import "DPI-C" function int simv_nstep(int step);
-`endif // PALLADIUM
+`endif // TB_ASYNC
 `endif // TB_NO_DPIC
 
 `ifdef PALLADIUM
@@ -186,15 +186,15 @@ always @(posedge clock) begin
   end
 end
 
-`ifdef PALLADIUM
+`ifdef TB_ASYNC
 wire simv_result;
-GfifoControl gfifo(
+AsyncControl async(
   .clock(clock),
   .reset(reset),
   .step(difftest_step_delay),
   .simv_result(simv_result)
 );
-`endif // PALLADIUM
+`endif // TB_ASYNC
 `endif // TB_NO_DPIC
 
 reg [63:0] n_cycles;
@@ -216,7 +216,7 @@ always @(posedge clock) begin
     if (!n_cycles) begin
       simv_init();
     end
-`ifdef PALLADIUM
+`ifdef TB_ASYNC
     else if (simv_result) begin
       $display("DIFFTEST FAILED at cycle %d", n_cycles);
       $finish();
@@ -229,7 +229,7 @@ always @(posedge clock) begin
         $finish();
       end
     end
-`endif // PALLADIUM
+`endif // TB_ASYNC
 `endif // TB_NO_DPIC
   end
 end


### PR DESCRIPTION
Use AsyncControl to support async compare.
Wrap it by TB_ASYNC instead of PALLADIUM, so we can test in other platform.