### PR TITLE
Gateway,top: remove batch Buffer and select, modify step logic.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,25 +246,26 @@ jobs:
             rm -r difftest
             cp -r $GITHUB_WORKSPACE .
 
-      - name: Verilator Build with VCS Top (with Select)
+      - name: Verilator Build with VCS Top (with delayedStep)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            sed -i 's/diffstateSelect: Boolean = false/diffstateSelect: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/delayedStep    : Boolean = false/delayedStep    : Boolean = true/' difftest/src/main/scala/Gateway.scala
             make simv VCS=verilator
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
-      - name: Verilator Build with VCS Top (with Squash Batch and Global Enable)
+      - name: Verilator Build with VCS Top (with delayedStep Squash Batch and Global Enable)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
+            sed -i 's/delayedStep    : Boolean = false/delayedStep    : Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/isSquash       : Boolean = false/isSquash       : Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/isBatch        : Boolean = false/isBatch        : Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/hasGlobalEnable: Boolean = false/hasGlobalEnable: Boolean = true/' difftest/src/main/scala/Gateway.scala

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -176,22 +176,12 @@ always @(posedge clock) begin
 end
 
 `ifndef TB_NO_DPIC
-reg [`STEP_WIDTH - 1:0] difftest_step_delay;
-always @(posedge clock) begin
-  if (reset) begin
-    difftest_step_delay <= 0;
-  end
-  else begin
-    difftest_step_delay <= difftest_step;
-  end
-end
-
 `ifdef TB_ASYNC
 wire simv_result;
 AsyncControl async(
   .clock(clock),
   .reset(reset),
-  .step(difftest_step_delay),
+  .step(difftest_step),
   .simv_result(simv_result)
 );
 `endif // TB_ASYNC
@@ -222,9 +212,9 @@ always @(posedge clock) begin
       $finish();
     end
 `else
-    else if (|difftest_step_delay) begin
+    else if (|difftest_step) begin
       // check errors
-      if (simv_nstep(difftest_step_delay)) begin
+      if (simv_nstep(difftest_step)) begin
         $display("DIFFTEST FAILED at cycle %d", n_cycles);
         $finish();
       end


### PR DESCRIPTION
Blocking time of Palladium Hardware depends on number of DPICs. There is no need to store DPICs and pass them at the same time because it will not changes its number. Instead, it will consumes far more gates.

In simulation platform such as VCS and Palladium, the order of DPICs at same cycle is not fixed, so we delay step by one clock to ensure transmission is done. However, it means buffer read (when step) may be conflicted with write at same pos. So we add an extra pos to buffer, so next pos will not be read and write at the same time.