### PR TITLE
Use DPIC-function to return deferred result

### DIFF
--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -7,8 +7,18 @@ module DeferredControl(
   output reg simv_result
 );
 
-import "DPI-C" function int simv_result_fetch();
 import "DPI-C" function void simv_nstep(int step);
+import "DPI-C" context function void set_deferred_result_scope();
+
+initial begin
+  set_deferred_result_scope();
+  simv_result = 1'b0;
+end
+
+export "DPI-C" function set_deferred_result;
+function void set_deferred_result();
+  simv_result = 1'b1;
+endfunction
 
 `ifdef CONFIG_DIFFTEST_NONBLOCK
 `ifdef PALLADIUM
@@ -16,29 +26,13 @@ initial $ixc_ctrl("gfifo", "simv_nstep");
 `endif // PALLADIUM
 `endif // CONFIG_DIFFTEST_NONBLOCK
 
-reg [63:0] fetch_cycles;
-initial fetch_cycles = 4999;
+`ifdef PALLADIUM
+initial $ixc_ctrl("sfifo", "set_deferred_result");
+`endif // PALLADIUM
 
-reg [63:0] fetch_timer;
 always @(posedge clock) begin
-  if (reset) begin
-    simv_result <= 1'b0;
-    fetch_timer <= 64'b0;
-  end
-  else begin
-    if (fetch_timer == fetch_cycles) begin
-      fetch_timer <= 1'b0;
-      if (simv_result_fetch()) begin
-        simv_result <= 1'b1;
-      end
-    end
-    else begin
-      fetch_timer <= fetch_timer + 64'b1;
-    end
-
-    if ((~simv_result) && (|step)) begin
-      simv_nstep(step);
-    end
+  if (!reset && !simv_result && step != 0) begin
+    simv_nstep(step);
   end
 end
 


### PR DESCRIPTION
Before this commit, we fetch simv_result at 5000 cycles. Only when the result is not zero, it works and stop simulation.

Now we use DPIC task to implement the return of simv_result when not zero, so only one DPIC task will be used to stop simulation. That will reduce the cost of fetch and get result return faster.