### PR TITLE
Gen C++ and Verilog macros by GatewayConfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ PLUGIN_CSRC_DIR = $(abspath ./src/test/csrc/plugin)
 PLUGIN_INC_DIR  = $(abspath $(PLUGIN_CSRC_DIR)/include)
 SIM_CXXFLAGS   += -I$(PLUGIN_INC_DIR)
 
+GEN_VSRC_DIR = $(BUILD_DIR)/generated-src
 VSRC_DIR   = $(abspath ./src/test/vsrc/common)
 SIM_VSRC = $(shell find $(VSRC_DIR) -name "*.v" -or -name "*.sv")
 

--- a/palladium.mk
+++ b/palladium.mk
@@ -15,7 +15,7 @@ PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_DELAY=0
 ifeq ($(RELEASE_WITH_ASSERT), 1)
 PLDM_MACRO_FLAGS 	+= +define+SYNTHESIS +define+TB_NO_DPIC
 else
-PLDM_MACRO_FLAGS 	+= +define+DIFFTEST +define+TB_DPIC_NONBLOCK
+PLDM_MACRO_FLAGS 	+= +define+DIFFTEST
 endif
 PLDM_MACRO_FLAGS 	+= $(PLDM_EXTRA_MACRO)
 
@@ -30,6 +30,7 @@ endif
 # Compiler Args
 IXCOM_FLAGS 	+= -xecompile compilerOptions=$(PLDM_SCRIPTS_DIR)/compilerOptions.qel
 IXCOM_FLAGS 	+= +tb_import_systf+fwrite +tb_import_systf+fflush
+IXCOM_FLAGS 	+= $(addprefix -incdir , $(PLDM_VSRC_DIR))
 IXCOM_FLAGS 	+= $(PLDM_MACRO_FLAGS)
 IXCOM_FLAGS 	+= +dut+$(PLDM_TB_TOP)
 ifeq ($(RELEASE_WITH_ASSERT), 1)
@@ -48,7 +49,7 @@ endif
 IXCOM_FLAGS 	+= +tfconfig+$(PLDM_SCRIPTS_DIR)/argConfigs.qel
 
 # Verilog Files
-PLDM_VSRC_DIR  	 = $(RTL_DIR)
+PLDM_VSRC_DIR  	 = $(RTL_DIR) $(GEN_VSRC_DIR)
 ifeq ($(RELEASE_WITH_ASSERT), 1)
 PLDM_VSRC_DIR 	+= $(abspath ./src/test/vsrc/vcs) $(abspath ./src/test/vsrc/common/SimJTAG.v)
 else
@@ -73,7 +74,7 @@ DPILIB_EMU    	 = $(PLDM_BUILD_DIR)/libdpi_emu.so
 PLDM_CSRC_DIR 	 = $(abspath ./src/test/csrc/vcs)
 PLDM_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(PLDM_CSRC_DIR) -name "*.cpp")
 PLDM_CXXFLAGS 	 = -m64 -c -fPIC -g -std=c++11 -I$(PLDM_IXCOM) -I$(PLDM_SIMTOOL)
-PLDM_CXXFLAGS 	+= $(SIM_CXXFLAGS) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES) -DTB_DEFERRED_RESULT
+PLDM_CXXFLAGS 	+= $(SIM_CXXFLAGS) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
 
 # XMSIM Flags
 XMSIM_FLAGS 	 = --xmsim -64 +xcprof -profile -PROFTHREAD

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -30,12 +30,6 @@ object Squash {
     val module = Module(new SquashEndpoint(bundles, config))
     module
   }
-
-  def collect(config: GatewayConfig): Seq[String] = {
-    var macros = Seq("CONFIG_DIFFTEST_SQUASH")
-    if (config.squashReplay) macros ++= Seq("CONFIG_DIFFTEST_SQUASH_REPLAY")
-    macros
-  }
 }
 
 class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
@@ -168,6 +162,7 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
 
   setInline("SquashControl.v",
     s"""
+      |`include "DifftestMacros.v"
       |module SquashControl(
       |  input clock,
       |  input reset,

--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -1,25 +1,20 @@
-`ifdef TB_DPIC_NONBLOCK
-  `define TB_DEFERRED_RESULT
-`endif
-
-`define STEP_WIDTH 8
-
-`ifdef TB_DEFERRED_RESULT
+`include "DifftestMacros.v"
+`ifdef CONFIG_DIFFTEST_DEFERRED_RESULT
 module DeferredControl(
   input clock,
   input reset,
-  input [`STEP_WIDTH - 1:0] step,
+  input [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] step,
   output reg simv_result
 );
 
 import "DPI-C" function int simv_result_fetch();
 import "DPI-C" function void simv_nstep(int step);
 
-`ifdef TB_DPIC_NONBLOCK
+`ifdef CONFIG_DIFFTEST_NONBLOCK
 `ifdef PALLADIUM
 initial $ixc_ctrl("gfifo", "simv_nstep");
 `endif // PALLADIUM
-`endif TB_DPIC_NONBLOCK
+`endif // CONFIG_DIFFTEST_NONBLOCK
 
 reg [63:0] fetch_cycles;
 initial fetch_cycles = 4999;
@@ -48,4 +43,4 @@ always @(posedge clock) begin
 end
 
 endmodule;
-`endif // TB_DEFERRED_RESULT
+`endif // CONFIG_DIFFTEST_DEFERRED_RESULT

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -13,11 +13,8 @@
 *
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
-`ifdef TB_DPIC_NONBLOCK
-  `define TB_DEFERRED_RESULT
-`endif
-`define STEP_WIDTH 8
 
+`include "DifftestMacros.v"
 module tb_top();
 
 `ifndef TB_NO_DPIC
@@ -26,9 +23,9 @@ import "DPI-C" function void set_flash_bin(string bin);
 import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
 import "DPI-C" function void simv_init();
-`ifndef TB_DEFERRED_RESULT
+`ifndef CONFIG_DIFFTEST_DEFERRED_RESULT
 import "DPI-C" function int simv_nstep(int step);
-`endif // TB_DEFERRED_RESULT
+`endif // CONFIG_DIFFTEST_DEFERRED_RESULT
 `endif // TB_NO_DPIC
 
 `ifdef PALLADIUM
@@ -52,7 +49,7 @@ wire        difftest_uart_out_valid;
 wire [ 7:0] difftest_uart_out_ch;
 wire        difftest_uart_in_valid;
 wire [ 7:0] difftest_uart_in_ch;
-wire [`STEP_WIDTH - 1:0] difftest_step;
+wire [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] difftest_step;
 
 string bin_file;
 string flash_bin_file;
@@ -178,7 +175,7 @@ always @(posedge clock) begin
 end
 
 `ifndef TB_NO_DPIC
-reg [`STEP_WIDTH - 1:0] difftest_step_delay;
+reg [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] difftest_step_delay;
 always @(posedge clock) begin
   if (reset) begin
     difftest_step_delay <= 0;
@@ -188,7 +185,7 @@ always @(posedge clock) begin
   end
 end
 
-`ifdef TB_DEFERRED_RESULT
+`ifdef CONFIG_DIFFTEST_DEFERRED_RESULT
 wire simv_result;
 DeferredControl deferred(
   .clock(clock),
@@ -196,7 +193,7 @@ DeferredControl deferred(
   .step(difftest_step_delay),
   .simv_result(simv_result)
 );
-`endif // TB_DEFERRED_RESULT
+`endif // CONFIG_DIFFTEST_DEFERRED_RESULT
 `endif // TB_NO_DPIC
 
 reg [63:0] n_cycles;
@@ -218,7 +215,7 @@ always @(posedge clock) begin
     if (!n_cycles) begin
       simv_init();
     end
-`ifdef TB_DEFERRED_RESULT
+`ifdef CONFIG_DIFFTEST_DEFERRED_RESULT
     else if (simv_result) begin
       $display("DIFFTEST FAILED at cycle %d", n_cycles);
       $finish();
@@ -231,7 +228,7 @@ always @(posedge clock) begin
         $finish();
       end
     end
-`endif // TB_DEFERRED_RESULT
+`endif // CONFIG_DIFFTEST_DEFERRED_RESULT
 `endif // TB_NO_DPIC
   end
 end

--- a/vcs.mk
+++ b/vcs.mk
@@ -75,7 +75,7 @@ VCS_FLAGS += +define+UNIT_DELAY +define+no_warning
 # C++ flags
 VCS_FLAGS += -CFLAGS "$(VCS_CXXFLAGS)" -LDFLAGS "$(VCS_LDFLAGS)"
 # search build for other missing verilog files
-VCS_FLAGS += -y $(RTL_DIR) +libext+.v
+VCS_FLAGS += -y $(RTL_DIR) -y $(GEN_VSRC_DIR) +libext+.v
 # enable fsdb dump
 VCS_FLAGS += $(EXTRA)
 

--- a/verilator.mk
+++ b/verilator.mk
@@ -104,6 +104,7 @@ VERILATOR_FLAGS =                   \
   --output-split 30000              \
   --output-split-cfuncs 30000       \
   -I$(RTL_DIR)                      \
+  -I$(GEN_VSRC_DIR)		    \
   -CFLAGS "$(EMU_CXXFLAGS)"         \
   -LDFLAGS "$(EMU_LDFLAGS)"         \
   -o $(abspath $(EMU))              \


### PR DESCRIPTION
Currently all macros in Gateway can be decided by GatewayConfig, we move macros inside Config for better comprehension.

Difftest-related macros in Verilog can be configured in generated DifftestMacros.v, which should be included by all files use those macros.

Some redundant passing of config and return val of collect is removed. Some macros are renamed for similar format.