### PR TITLE
Fix palladium.mk

### DIFF
--- a/palladium.mk
+++ b/palladium.mk
@@ -7,8 +7,6 @@ PLDM_CC_OBJ_DIR	 	 = $(abspath $(PLDM_BUILD_DIR)/cc_obj)
 # Macro Flags
 PLDM_MACRO_FLAGS  	 = +define+TOP_MODULE=$(PLDM_TOP_MODULE)
 PLDM_MACRO_FLAGS 	+= +define+PALLADIUM
-PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_GARBAGE_ASSIGN
-PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_INVALID_ASSIGN
 PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_MEM_INIT
 PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_REG_INIT
 PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_DELAY=0
@@ -24,7 +22,7 @@ IXCOM_FLAGS  	 = -clean -64 -ua +sv +ignoreSimVerCheck +xe_alt_xlm
 ifeq ($(RELEASE_WITH_ASSERT), 1)
 IXCOM_FLAGS 	+= +1xua
 else
-IXCOM_FLAGS 	+= +iscDelay+tb_top +iscDelay+SimJTAG -enableLargeSizeMem
+IXCOM_FLAGS 	+= +iscDelay+tb_top -enableLargeSizeMem
 endif
 
 # Compiler Args
@@ -41,7 +39,7 @@ endif
 
 # Other Args
 IXCOM_FLAGS 	+= -v $(PLDM_IXCOM)/IXCclkgen.sv
-IXCOM_FLAGS 	+= +iscdisp+Rob +iscdisp+tb_top +iscdisp+MemRWHelper
+IXCOM_FLAGS 	+= +iscdisp+tb_top
 ifneq ($(RELEASE_WITH_ASSERT), 1)
 IXCOM_FLAGS 	+= +rtlCommentPragma +tran_relax -relativeIXCDIR -rtlNameForGenerate
 endif

--- a/src/main/scala/common/Flash.scala
+++ b/src/main/scala/common/Flash.scala
@@ -51,6 +51,9 @@ class FlashHelper extends ExtModule with HasExtModuleInline {
        |    if (r_en) flash_read(r_addr, r_data);
        |  end
        |`else
+       |`ifdef PALLADIUM
+       |  initial $ixc_ctrl("tb_import", "display");
+       |`endif // PALLADIUM
        |  // 1K entries. 8KB size.
        |  `define FLASH_SIZE (8 * 1024)
        |  reg [7:0] flash_mem [0 : `FLASH_SIZE - 1];

--- a/src/main/scala/common/Mem.scala
+++ b/src/main/scala/common/Mem.scala
@@ -23,6 +23,9 @@ trait HasMemInit { this: ExtModule =>
   val mem_init =
     """
       |`ifdef SYNTHESIS
+      |`ifdef PALLADIUM
+      |  initial $ixc_ctrl("tb_import", "display");
+      |`endif // PALLADIUM
       |  // 1536MB memory
       |  `define RAM_SIZE (1536 * 1024 * 1024)
       |

--- a/src/test/vsrc/common/SimJTAG.v
+++ b/src/test/vsrc/common/SimJTAG.v
@@ -34,6 +34,9 @@ module SimJTAG #(
                    );
 
 `ifndef SYNTHESIS
+   `ifdef PALLADIUM
+   initial $ixc_ctrl("map_delays");
+   `endif
    reg [31:0]                    tickCounterReg;
    wire [31:0]                   tickCounterNxt;
 


### PR DESCRIPTION
We remove RANDOMIZE_GARBAGE_ASSIGN and RANDOMIZE_INVALID_ASSIGN because it will cause many DPIC function to get $random, which slow the simulation speed.

Move some display and delay declaration inside module, because some module may sometimes not be used by DUT, declaration in command-line will cause conflict.