### PR TITLE
Bump Chisel 6.0.0-RC2 with stricter Scala linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,13 @@ jobs:
           sudo curl -L https://github.com/com-lihaoyi/mill/releases/download/0.11.1/0.11.1 > /usr/local/bin/mill
           chmod +x /usr/local/bin/mill
 
+      - name: Compile
+        run: |
+          mill -i design[3.6.0].compile
+          mill -i design[6.0.0-M3].compile
+          mill -i design[6.0.0-RC1].compile
+          mill -i design[6.0.0-RC2].compile
+
       - name: Generate Verilog
         run: |
           make difftest_verilog NOOP_HOME=$GITHUB_WORKSPACE

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SIM_TOP_V = $(RTL_DIR)/$(SIM_TOP).$(RTL_SUFFIX)
 
 # generate difftest files for non-chisel design.
 difftest_verilog:
-	mill difftest.test.runMain difftest.DifftestMain -td $(RTL_DIR)
+	mill -i difftest.test.runMain difftest.DifftestMain -td $(RTL_DIR)
 
 # co-simulation with DRAMsim3
 ifeq ($(WITH_DRAMSIM3),1)

--- a/build.sc
+++ b/build.sc
@@ -21,9 +21,10 @@ import publish._
 object ivys {
   val scala = "2.13.10"
   val chiselCrossVersions = Map(
-    "3.5.6" -> (ivy"edu.berkeley.cs::chisel3:3.5.6", ivy"edu.berkeley.cs:::chisel3-plugin:3.5.6"),
     "3.6.0" -> (ivy"edu.berkeley.cs::chisel3:3.6.0", ivy"edu.berkeley.cs:::chisel3-plugin:3.6.0"),
     "6.0.0-M3" -> (ivy"org.chipsalliance::chisel:6.0.0-M3", ivy"org.chipsalliance:::chisel-plugin:6.0.0-M3"),
+    "6.0.0-RC1" -> (ivy"org.chipsalliance::chisel:6.0.0-RC1", ivy"org.chipsalliance:::chisel-plugin:6.0.0-RC1"),
+    "6.0.0-RC2" -> (ivy"org.chipsalliance::chisel:6.0.0-RC2", ivy"org.chipsalliance:::chisel-plugin:6.0.0-RC2"),
   )
 }
 
@@ -39,10 +40,23 @@ trait CommonDiffTest extends ScalaModule with SbtModule with Cross.Module[String
   override def ivyDeps = Agg(ivys.chiselCrossVersions(crossValue)._1)
 }
 
+object design extends Cross[DiffTestModule](ivys.chiselCrossVersions.keys.toSeq)
+
+trait DiffTestModule extends CommonDiffTest {
+
+  override def millSourcePath = os.pwd
+
+  override def scalacOptions = super.scalacOptions() ++
+    Seq("-Xfatal-warnings", "-deprecation:false", "-unchecked", "-Xlint")
+
+}
+
 object difftest extends CommonDiffTest {
-  def crossValue: String = "3.5.6"
+
+  def crossValue: String = "3.6.0"
 
   override def millSourcePath = os.pwd
 
   object test extends SbtModuleTests with TestModule.ScalaTest
+
 }

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -16,14 +16,13 @@
 package difftest.dpic
 
 import chisel3._
-import chisel3.experimental.{DataMirror, ExtModule}
+import chisel3.experimental.ExtModule
+import chisel3.reflect.DataMirror
 import chisel3.util._
-import difftest._
-import difftest.gateway.{GatewayConfig, GatewayBundle}
 import difftest.DifftestModule.streamToFile
+import difftest._
+import difftest.gateway.{GatewayBundle, GatewayConfig}
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths}
 import scala.collection.mutable.ListBuffer
 
 class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig) extends ExtModule

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -290,7 +290,7 @@ object DifftestModule {
   ): T = {
     val difftest: T = Wire(gen)
     if (enabled) {
-      val id = register(gen, style)
+      register(gen, style)
       val sink = Gateway(gen, style)
       sink := Delayer(difftest, delay)
       sink.coreid := difftest.coreid

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -243,12 +243,14 @@ object GatewaySink{
   def apply[T <: DifftestBundle](gen: T, config: GatewayConfig, port: GatewayBundle): UInt = {
     config.style match {
       case "dpic" => DPIC(gen, config, port)
+      case _ => DPIC(gen, config, port) // Default: DPI-C
     }
   }
 
   def collect(config: GatewayConfig): Unit = {
     config.style match {
       case "dpic" => DPIC.collect()
+      case _ => DPIC.collect() // Default: DPI-C
     }
   }
 }

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -21,11 +21,7 @@ import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
 
-import scala.collection.mutable.ListBuffer
-
 object Squash {
-  private val instances = ListBuffer.empty[DifftestBundle]
-
   def apply[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig): SquashEndpoint = {
     val module = Module(new SquashEndpoint(bundles, config))
     module


### PR DESCRIPTION
Deprecations are not checked because we need to maintain the compatibility with several popular Chisel versions.