### PR TITLE
Add macros to disable Mem and SimJTAG DPI-C functions

### DIFF
--- a/palladium.mk
+++ b/palladium.mk
@@ -13,7 +13,7 @@ PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_DELAY=0
 ifeq ($(RELEASE_WITH_ASSERT), 1)
 PLDM_MACRO_FLAGS 	+= +define+SYNTHESIS +define+TB_NO_DPIC
 else
-PLDM_MACRO_FLAGS 	+= +define+DIFFTEST
+PLDM_MACRO_FLAGS 	+= +define+DIFFTEST +define+DISABLE_DIFFTEST_RAM_DPIC +define+DISABLE_SIMJTAG_DPIC
 endif
 PLDM_MACRO_FLAGS 	+= $(PLDM_EXTRA_MACRO)
 
@@ -27,7 +27,7 @@ endif
 
 # Compiler Args
 IXCOM_FLAGS 	+= -xecompile compilerOptions=$(PLDM_SCRIPTS_DIR)/compilerOptions.qel
-IXCOM_FLAGS 	+= +tb_import_systf+fwrite +tb_import_systf+fflush
+IXCOM_FLAGS 	+= +gfifoDisp+tb_top
 IXCOM_FLAGS 	+= $(addprefix -incdir , $(PLDM_VSRC_DIR))
 IXCOM_FLAGS 	+= $(PLDM_MACRO_FLAGS)
 IXCOM_FLAGS 	+= +dut+$(PLDM_TB_TOP)
@@ -40,7 +40,6 @@ endif
 
 # Other Args
 IXCOM_FLAGS 	+= -v $(PLDM_IXCOM)/IXCclkgen.sv
-IXCOM_FLAGS 	+= +iscdisp+tb_top
 ifneq ($(RELEASE_WITH_ASSERT), 1)
 IXCOM_FLAGS 	+= +rtlCommentPragma +tran_relax -relativeIXCDIR -rtlNameForGenerate
 endif

--- a/src/main/scala/common/Flash.scala
+++ b/src/main/scala/common/Flash.scala
@@ -52,7 +52,7 @@ class FlashHelper extends ExtModule with HasExtModuleInline {
        |  end
        |`else
        |`ifdef PALLADIUM
-       |  initial $ixc_ctrl("tb_import", "display");
+       |  initial $ixc_ctrl("tb_import", "$display");
        |`endif // PALLADIUM
        |  // 1K entries. 8KB size.
        |  `define FLASH_SIZE (8 * 1024)

--- a/src/main/scala/common/Mem.scala
+++ b/src/main/scala/common/Mem.scala
@@ -22,9 +22,9 @@ import chisel3.util._
 trait HasMemInit { this: ExtModule =>
   val mem_init =
     """
-      |`ifdef SYNTHESIS
+      |`ifdef DISABLE_DIFFTEST_RAM_DPIC
       |`ifdef PALLADIUM
-      |  initial $ixc_ctrl("tb_import", "display");
+      |  initial $ixc_ctrl("tb_import", "$display");
       |`endif // PALLADIUM
       |  // 1536MB memory
       |  `define RAM_SIZE (1536 * 1024 * 1024)
@@ -56,7 +56,7 @@ trait HasMemInit { this: ExtModule =>
       |    $display("%m: load %d bytes from %s.", n_read, bin_file);
       |  end
       |end
-      |`endif // SYNTHESIS
+      |`endif // DISABLE_DIFFTEST_RAM_DPIC
       |""".stripMargin
 }
 
@@ -69,9 +69,9 @@ trait HasReadPort { this: ExtModule =>
 
   val r_dpic =
     """
-      |`ifndef SYNTHESIS
+      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
       |import "DPI-C" function longint difftest_ram_read(input longint rIdx);
-      |`endif // SYNTHESIS
+      |`endif // DISABLE_DIFFTEST_RAM_DPIC
       |""".stripMargin
 
   val r_if =
@@ -83,7 +83,7 @@ trait HasReadPort { this: ExtModule =>
 
   val r_func =
     """
-      |`ifndef SYNTHESIS
+      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
       |if (r_enable) begin
       |  r_data <= difftest_ram_read(r_index);
       |end
@@ -91,7 +91,7 @@ trait HasReadPort { this: ExtModule =>
       |if (r_enable) begin
       |  r_data <= memory[r_index];
       |end
-      |`endif // SYNTHESIS
+      |`endif // DISABLE_DIFFTEST_RAM_DPIC
       |""".stripMargin
 
   def read(enable: Bool, index: UInt): UInt = {
@@ -112,14 +112,14 @@ trait HasWritePort { this: ExtModule =>
 
   val w_dpic =
     """
-      |`ifndef SYNTHESIS
+      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
       |import "DPI-C" function void difftest_ram_write
       |(
       |  input  longint index,
       |  input  longint data,
       |  input  longint mask
       |);
-      |`endif // SYNTHESIS
+      |`endif // DISABLE_DIFFTEST_RAM_DPIC
       |""".stripMargin
 
   val w_if =
@@ -132,7 +132,7 @@ trait HasWritePort { this: ExtModule =>
 
   val w_func =
     """
-      |`ifndef SYNTHESIS
+      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
       |if (w_enable) begin
       |  difftest_ram_write(w_index, w_data, w_mask);
       |end
@@ -140,7 +140,7 @@ trait HasWritePort { this: ExtModule =>
       |if (w_enable) begin
       |  memory[w_index] <= (w_data & w_mask) | (memory[w_index] & ~w_mask);
       |end
-      |`endif // SYNTHESIS
+      |`endif // DISABLE_DIFFTEST_RAM_DPIC
       |""".stripMargin
 
   def write(enable: Bool, index: UInt, data: UInt, mask: UInt): HasWritePort = {
@@ -157,6 +157,9 @@ class MemRHelper extends ExtModule with HasExtModuleInline with HasReadPort with
 
   setInline("MemRHelper.v",
     s"""
+       |`ifdef SYNTHESIS
+       |  `define DISABLE_DIFFTEST_RAM_DPIC
+       |`endif
        |$r_dpic
        |module MemRHelper(
        |  $r_if
@@ -175,6 +178,9 @@ class MemWHelper extends ExtModule with HasExtModuleInline with HasWritePort wit
 
   setInline("MemWHelper.v",
     s"""
+       |`ifdef SYNTHESIS
+       |  `define DISABLE_DIFFTEST_RAM_DPIC
+       |`endif
        |$w_dpic
        |module MemWHelper(
        |  $w_if
@@ -194,6 +200,9 @@ class MemRWHelper extends ExtModule with HasExtModuleInline with HasReadPort wit
 
   setInline("MemRWHelper.v",
     s"""
+       |`ifdef SYNTHESIS
+       |  `define DISABLE_DIFFTEST_RAM_DPIC
+       |`endif
        |$r_dpic
        |$w_dpic
        |module MemRWHelper(

--- a/src/test/vsrc/common/SimJTAG.v
+++ b/src/test/vsrc/common/SimJTAG.v
@@ -1,6 +1,9 @@
 // See LICENSE.SiFive for license details.
 //VCS coverage exclude_file
-`ifndef SYNTHESIS
+`ifdef SYNTHESIS
+    `define DISABLE_SIMJTAG_DPIC
+`endif // SYNTHESIS
+`ifndef DISABLE_SIMJTAG_DPIC
 import "DPI-C" function int jtag_tick
 (
  output bit jtag_TCK,
@@ -10,7 +13,7 @@ import "DPI-C" function int jtag_tick
 
  input bit  jtag_TDO
 );
-`endif // SYNTHESIS
+`endif // DISABLE_SIMJTAG_DPIC
 
 module SimJTAG #(
                  parameter TICK_DELAY = 50
@@ -33,7 +36,7 @@ module SimJTAG #(
                    output [31:0] exit
                    );
 
-`ifndef SYNTHESIS
+`ifndef DISABLE_SIMJTAG_DPIC
    `ifdef PALLADIUM
    initial $ixc_ctrl("map_delays");
    `endif
@@ -92,6 +95,6 @@ module SimJTAG #(
    assign jtag_TDI   = 1'b0;
    assign jtag_TRSTn = 1'b1;
    assign exit       = 32'b0;
-`endif // SYNTHESIS
+`endif // DISABLE_SIMJTAG_DPIC
 
 endmodule


### PR DESCRIPTION
We add macros to turn off DPIC on MemRWHelper and SimJTAG without SYNTHESIS. That means we can reduce number of synchronizations if needed. The new macros is defined in palladium.mk by default.

To add build-in decleration of system task for Palladium, we need to add $.

We declare fwrite in tb_top as Gfifo to reduce synchronizations and speed up simulation.