### PR TITLE
Allow LogPerfControl to be reused if necessary

### DIFF
--- a/src/main/scala/common/LogPerfControl.scala
+++ b/src/main/scala/common/LogPerfControl.scala
@@ -25,7 +25,7 @@ class LogPerfControl extends Bundle {
   val dump = Bool()
 }
 
-class LogPerfHelper extends BlackBox with HasBlackBoxInline {
+private class LogPerfHelper extends BlackBox with HasBlackBoxInline {
   val io = IO(Output(new LogPerfControl))
 
   val verilog =
@@ -56,5 +56,10 @@ class LogPerfHelper extends BlackBox with HasBlackBoxInline {
 object LogPerfControl {
   def apply(): LogPerfControl = {
     Module(new LogPerfHelper).io
+  }
+
+  private val instances = scala.collection.mutable.ListBuffer.empty[LogPerfControl]
+  def reuse(checker: LogPerfControl => Boolean): LogPerfControl = {
+    instances.find(checker).getOrElse(instances.addOne(apply()).last)
   }
 }


### PR DESCRIPTION
Since https://github.com/chipsalliance/chisel/pull/3753, the users are able to check whether a Data is visible in the current context. To avoid a large number of duplicated LogPerfControl modules, we allow it to be reused when some previous instance is still visible to the current context.

Call `LogPerfControl.reuse(DataMirror.isVisible)` instead of pure `apply()` to allow the reuse.

However, this is still a temporary workaround. In the future, we need some clean methods to extract the simulation environment and access these signals during simulation, possibly via XMR.