### PR TITLE
Fix the data type T parameter of WiringControl

### DIFF
--- a/src/main/scala/common/WiringControl.scala
+++ b/src/main/scala/common/WiringControl.scala
@@ -62,13 +62,13 @@ object DifftestWiring {
     })
   }
 
-  def addSource(data: Data, name: String): Data = {
+  def addSource[T <: Data](data: T, name: String): T = {
     getWire(data, name).setSource()
     WiringControl.addSource(data, name)
     data
   }
 
-  def addSink(data: Data, name: String): Data = {
+  def addSink[T <: Data](data: T, name: String): T = {
     getWire(data, name).addSink()
     WiringControl.addSink(data, name)
     data


### PR DESCRIPTION
Should return the same data type as the input using polymorphic methods.