### PR TITLE
Gateway: seperate functional component

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -1,0 +1,57 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.batch
+
+import chisel3._
+import chisel3.util._
+import difftest._
+import difftest.gateway.GatewayConfig
+
+object Batch {
+  def apply[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig): BatchEndpoint = {
+    val module = Module(new BatchEndpoint(bundles, config))
+    module
+  }
+}
+
+class BatchEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+  val buffer = Mem(config.batchSize, in.cloneType)
+  val out = IO(Output(Vec(config.batchSize, in.cloneType)))
+  val info = IO(Output(Vec(config.batchSize, UInt())))
+  val enable = IO(Output(Bool()))
+  val step = IO(Output(UInt(config.stepWidth.W)))
+
+  val need_store = WireInit(true.B)
+  if (config.hasGlobalEnable) {
+    need_store := VecInit(in.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+  }
+  val ptr = RegInit(0.U(log2Ceil(config.batchSize).W))
+  when(need_store) {
+    ptr := ptr + 1.U
+    when(ptr === (config.batchSize - 1).U) {
+      ptr := 0.U
+    }
+    buffer(ptr) := in
+  }
+  val do_sync = ptr === (config.batchSize - 1).U && need_store
+  for (((data, ifo), idx) <- out.zip(info).zipWithIndex) {
+    data := buffer(idx)
+    ifo := idx.U
+  }
+  enable := RegNext(do_sync)
+  step := Mux(enable, config.batchSize.U, 0.U)
+}

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -390,8 +390,9 @@ object DifftestModule {
          |class DiffStateBuffer {
          |public:
          |  virtual ~DiffStateBuffer() {}
-         |  virtual DiffTestState* get(int pos) = 0;
+         |  virtual DiffTestState* get(int zone, int pos) = 0;
          |  virtual DiffTestState* next() = 0;
+         |  virtual void switch_zone() = 0;
          |};
          |
          |extern DiffStateBuffer** diffstate_buffer;

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -21,6 +21,7 @@ import difftest._
 import difftest.common.DifftestWiring
 import difftest.dpic.DPIC
 import difftest.squash.Squash
+import difftest.batch.Batch
 
 import scala.collection.mutable.ListBuffer
 
@@ -35,21 +36,23 @@ case class GatewayConfig(
   batchSize: Int = 32,
   isNonBlock: Boolean = false
 ) {
-  require(!(diffStateSelect && isBatch))
   if (squashReplay) require(isSquash)
-  def hasDutPos: Boolean = diffStateSelect || isBatch
-  def dutBufLen: Int = if (isBatch) batchSize else if (diffStateSelect) 2 else 1
-  def dutPosWidth: Int = log2Ceil(dutBufLen)
+  def hasDutZone: Boolean = diffStateSelect
+  def dutZoneSize: Int = if (hasDutZone) 2 else 1
+  def dutZoneWidth: Int = log2Ceil(dutZoneSize)
+  def dutBufLen: Int = if (isBatch) batchSize else 1
   def maxStep: Int = if (isBatch) batchSize else 1
   def stepWidth: Int = log2Ceil(maxStep + 1)
   def hasDeferredResult: Boolean = isNonBlock
   def needTraceInfo: Boolean = squashReplay
   def needEndpoint: Boolean = hasGlobalEnable || diffStateSelect || isBatch || isSquash
+  def needPreprocess: Boolean = hasDutZone || isBatch || isSquash || needTraceInfo
   // Macros Generation for Cpp and Verilog
   def cppMacros: Seq[String] = {
     val macros = ListBuffer.empty[String]
     macros += s"CONFIG_DIFFTEST_${style.toUpperCase}"
-    macros += s"CONFIG_DIFFTEST_BUFLEN ${dutBufLen}"
+    macros += s"CONFIG_DIFFTEST_ZONESIZE $dutZoneSize"
+    macros += s"CONFIG_DIFFTEST_BUFLEN $dutBufLen"
     if (isBatch) macros ++= Seq("CONFIG_DIFFTEST_BATCH", s"DIFFTEST_BATCH_SIZE ${batchSize}")
     if (isSquash) macros += "CONFIG_DIFFTEST_SQUASH"
     if (squashReplay) macros += "CONFIG_DIFFTEST_SQUASH_REPLAY"
@@ -78,13 +81,13 @@ object Gateway {
 
   def apply[T <: DifftestBundle](gen: T, style: String): T = {
     config = GatewayConfig(style = style)
-    if (config.needEndpoint)
+    if (config.needEndpoint) {
       register(WireInit(0.U.asTypeOf(gen)))
-    else {
-      val port = Wire(new GatewayBundle(config))
-      port.enable := true.B
-      val bundle = WireInit(0.U.asTypeOf(gen))
-      GatewaySink(gen, config, port) := bundle.asUInt
+    } else {
+      val bundle = WireInit(gen)
+      val sink = GatewaySink(gen, config)
+      sink.io := bundle
+      sink.enable := true.B
       bundle
     }
   }
@@ -117,6 +120,7 @@ object Gateway {
 }
 
 class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val extraInstances = ListBuffer.empty[(DifftestBundle, String)]
   val in = WireInit(0.U.asTypeOf(MixedVec(signals.map(_.cloneType))))
   val in_pack = WireInit(0.U.asTypeOf(MixedVec(signals.map(gen => UInt(gen.getWidth.W)))))
   for ((data, id) <- in_pack.zipWithIndex) {
@@ -124,8 +128,126 @@ class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) exten
     in(id) := data.asTypeOf(in(id).cloneType)
   }
 
-  val share_wbint = WireInit(in)
-  if (config.hasDutPos || config.isSquash) {
+  val preprocessed = if (config.needPreprocess) {
+    val preprocess = Module(new Preprocess(in.toSeq.map(_.cloneType), config))
+    extraInstances ++= preprocess.extraInstances
+    preprocess.in := in
+    WireInit(preprocess.out)
+  } else {
+    WireInit(in)
+  }
+
+  val squashed = if (config.isSquash) {
+    val squash = Squash(preprocessed.toSeq.map(_.cloneType), config)
+    squash.in := preprocessed
+    WireInit(squash.out)
+  } else {
+    WireInit(preprocessed)
+  }
+
+  val zoneControl = Option.when(config.hasDutZone)(Module(new ZoneControl(config)))
+  val step = IO(Output(UInt(config.stepWidth.W)))
+  if (config.isBatch) {
+    val batch = Batch(squashed.toSeq.map(_.cloneType), config)
+    batch.in := squashed
+    step := batch.step
+    if (config.hasDutZone) {
+      zoneControl.get.enable := batch.enable
+    }
+
+    val sink = GatewaySink.batch(squashed.toSeq.map(_.cloneType), config)
+    sink.io := batch.out
+    sink.info := batch.info
+    sink.enable := batch.enable
+    if (config.hasDutZone) {
+      sink.dut_zone.get := zoneControl.get.dut_zone.get
+    }
+  } else {
+    val squashed_enable = WireInit(true.B)
+    if (config.hasGlobalEnable) {
+      squashed_enable := VecInit(squashed.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+    }
+    step := Mux(squashed_enable, 1.U, 0.U)
+    if (config.hasDutZone) {
+      zoneControl.get.enable := squashed_enable
+    }
+
+    for(id <- 0 until squashed.length){
+      val sink = GatewaySink(squashed(id).cloneType, config)
+      sink.io := squashed(id)
+      sink.enable := squashed_enable
+      if (config.hasDutZone) {
+        sink.dut_zone.get := zoneControl.get.dut_zone.get
+      }
+    }
+  }
+
+  GatewaySink.collect(config)
+
+}
+
+
+object GatewaySink{
+  def apply[T <: DifftestBundle](gen: T, config: GatewayConfig): GatewaySink[T] = {
+    config.style match {
+      case "dpic" => DPIC(gen, config)
+      case _ => DPIC(gen, config) // Default: DPI-C
+    }
+  }
+
+  def batch[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig): GatewayBatchSink[T] = {
+    config.style match {
+      case "dpic" => DPIC.batch(bundles, config)
+      case _ => DPIC.batch(bundles, config) // Default: DPI-C
+    }
+  }
+
+  def collect(config: GatewayConfig): Unit = {
+    config.style match {
+      case "dpic" => DPIC.collect()
+      case _ => DPIC.collect() // Default: DPI-C
+    }
+  }
+}
+
+class GatewayBaseSink(config: GatewayConfig) extends Module {
+  val enable = IO(Input(Bool()))
+  val dut_zone = Option.when(config.hasDutZone)(IO(Input(UInt(config.dutZoneWidth.W))))
+}
+
+class GatewaySink[T <: DifftestBundle](gen: T, config: GatewayConfig) extends GatewayBaseSink(config) {
+  val io = IO(Input(gen))
+}
+
+class GatewayBatchSink[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig) extends GatewayBaseSink(config) {
+  val io = IO(Input(Vec(config.batchSize, MixedVec(bundles))))
+  val info = IO(Input(Vec(config.batchSize, UInt())))
+}
+
+class Preprocess(signals: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val extraInstances = ListBuffer.empty[(DifftestBundle, String)]
+  val in = IO(Input(MixedVec(signals)))
+  val out = if (config.needTraceInfo) {
+    val traceInfo = new DiffTraceInfo(config)
+    val signalsWithInfo = signals ++ Seq(traceInfo)
+    extraInstances += ((traceInfo, config.style))
+    IO(Output(MixedVec(signalsWithInfo)))
+  } else {
+    IO(Output(MixedVec(signals)))
+  }
+
+  if (config.needTraceInfo) {
+    for ((data, id) <- in.zipWithIndex) {
+      out(id) := data
+    }
+    val traceinfo = out.filter(_.desiredCppName == "trace_info").head.asInstanceOf[DiffTraceInfo]
+    traceinfo.coreid := out.filter(_.isUniqueIdentifier).head.coreid
+    traceinfo.squash_idx.get := 0.U //default value, set in Squash
+  } else {
+    out := in
+  }
+
+  if (config.hasDutZone || config.isSquash || config.isBatch) {
     // Special fix for int writeback. Work for single-core only
     if (in.exists(_.desiredCppName == "wb_int")) {
       require(in.count(_.isUniqueIdentifier) == 1, "only single-core is supported yet")
@@ -141,7 +263,7 @@ class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) exten
       val commits = in.filter(_.desiredCppName == "commit").map(_.asInstanceOf[DiffInstrCommit])
       val num_skip = PopCount(commits.map(c => c.valid && c.skip))
       assert(num_skip <= 1.U, p"num_skip $num_skip is larger than one. Squash not supported yet")
-      val wb_for_skip = share_wbint.filter(_.desiredCppName == "wb_int").head.asInstanceOf[DiffIntWriteback]
+      val wb_for_skip = out.filter(_.desiredCppName == "wb_int").head.asInstanceOf[DiffIntWriteback]
       for (c <- commits) {
         when(c.valid && c.skip) {
           wb_for_skip.valid := true.B
@@ -156,113 +278,20 @@ class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) exten
       }
     }
   }
-
-  val squashed = WireInit(share_wbint)
-  val squash_idx = Option.when(config.squashReplay)(WireInit(0.U(log2Ceil(config.replaySize).W)))
-  if (config.isSquash) {
-    val squash = Squash(share_wbint.toSeq.map(_.cloneType), config)
-    squash.in := share_wbint
-    squashed := squash.out
-    if (config.squashReplay) {
-      squash_idx.get := squash.idx.get
-    }
-  }
-
-  val signalsWithInfo = ListBuffer.empty[DifftestBundle]
-  signalsWithInfo ++= signals
-  if (config.needTraceInfo) signalsWithInfo += new DiffTraceInfo(config)
-  val out = WireInit(0.U.asTypeOf(MixedVec(signalsWithInfo.toSeq.map(_.cloneType))))
-  if (config.needTraceInfo) {
-    for ((data, id) <- squashed.zipWithIndex) {
-      out(id) := data
-    }
-    val traceinfo = out.filter(_.desiredCppName == "trace_info").head.asInstanceOf[DiffTraceInfo]
-    traceinfo.coreid := out.filter(_.isUniqueIdentifier).head.coreid
-    traceinfo.squash_idx.get := squash_idx.get
-  } else {
-    out := squashed
-  }
-
-  val out_pack = WireInit(0.U.asTypeOf(MixedVec(signalsWithInfo.toSeq.map(gen => UInt(gen.getWidth.W)))))
-  for ((data, id) <- out_pack.zipWithIndex) {
-    data := out(id).asUInt
-  }
-
-  val port_num = if (config.isBatch) config.batchSize else 1
-  val ports = Seq.fill(port_num)(Wire(new GatewayBundle(config)))
-
-  val global_enable = WireInit(true.B)
-  if (config.hasGlobalEnable) {
-    global_enable := VecInit(out.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
-  }
-
-  val batch_data = Option.when(config.isBatch)(Mem(config.batchSize, out_pack.cloneType))
-  val enable = WireInit(false.B)
-  if (config.isBatch) {
-    val batch_ptr = RegInit(0.U(log2Ceil(config.batchSize).W))
-    when(global_enable) {
-      batch_ptr := batch_ptr + 1.U
-      when(batch_ptr === (config.batchSize - 1).U) {
-        batch_ptr := 0.U
-      }
-      batch_data.get(batch_ptr) := out_pack
-    }
-    val do_batch_sync = batch_ptr === (config.batchSize - 1).U && global_enable
-    enable := RegNext(do_batch_sync)
-  } else {
-    enable := global_enable
-  }
-  ports.foreach(port => port.enable := enable)
-
-  if (config.diffStateSelect) {
-    val select = RegInit(false.B)
-    when(global_enable) {
-      select := !select
-    }
-    ports.foreach(port => port.dut_pos.get := select.asUInt)
-  }
-
-  val step = IO(Output(UInt(config.stepWidth.W)))
-  step := Mux(enable, config.maxStep.U, 0.U)
-
-  if (config.isBatch) {
-    for (ptr <- 0 until config.batchSize) {
-      ports(ptr).dut_pos.get := ptr.asUInt
-      for (id <- 0 until out.length) {
-        GatewaySink(out(id).cloneType, config, ports(ptr)) := batch_data.get(ptr)(id)
-      }
-    }
-  } else {
-    for (id <- 0 until out.length) {
-      GatewaySink(out(id).cloneType, config, ports.head) := out_pack(id)
-    }
-  }
-
-  GatewaySink.collect(config)
-
-  val extraInstances = ListBuffer.empty[(DifftestBundle, String)]
-  if (config.needTraceInfo) {
-    extraInstances += ((signalsWithInfo.filter(_.desiredCppName == "trace_info").head, config.style))
-  }
 }
 
-object GatewaySink {
-  def apply[T <: DifftestBundle](gen: T, config: GatewayConfig, port: GatewayBundle): UInt = {
-    config.style match {
-      case "dpic" => DPIC(gen, config, port)
-      case _      => DPIC(gen, config, port) // Default: DPI-C
-    }
-  }
+class ZoneControl(config: GatewayConfig) extends Module {
+  val enable = IO(Input(Bool()))
+  val dut_zone = Option.when(config.hasDutZone)(IO(Output(UInt(config.dutZoneWidth.W))))
 
-  def collect(config: GatewayConfig): Unit = {
-    config.style match {
-      case "dpic" => DPIC.collect()
-      case _      => DPIC.collect() // Default: DPI-C
+  if (config.hasDutZone) {
+    val zone = RegInit(0.U(config.dutZoneWidth.W))
+    when(enable) {
+      zone := zone + 1.U
+      when(zone === (config.dutZoneSize - 1).U) {
+        zone := 0.U
+      }
     }
+    dut_zone.get := zone
   }
-}
-
-class GatewayBundle(config: GatewayConfig) extends Bundle {
-  val enable = Bool()
-  val dut_pos = Option.when(config.hasDutPos)(UInt(config.dutPosWidth.W))
 }

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -32,7 +32,7 @@ int difftest_init() {
   difftest = new Difftest*[NUM_CORES];
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i] = new Difftest(i);
-    difftest[i]->dut = diffstate_buffer[i]->get(0);
+    difftest[i]->dut = diffstate_buffer[i]->get(0, 0);
   }
   return 0;
 }
@@ -58,6 +58,7 @@ int difftest_state() {
 
 int difftest_nstep(int step){
   int last_trap_code = STATE_RUNNING;
+  difftest_switch_zone();
   for(int i = 0; i < step; i++){
     if(difftest_step()){
       last_trap_code = STATE_ABORT;
@@ -70,6 +71,11 @@ int difftest_nstep(int step){
   return last_trap_code;
 }
 
+void difftest_switch_zone() {
+  for (int i = 0; i < NUM_CORES; i++) {
+    diffstate_buffer[i]->switch_zone();
+  }
+}
 int difftest_step() {
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i]->dut = diffstate_buffer[i]->next();

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -215,9 +215,11 @@ public:
   }
   void trace_write(int step){
     if (difftrace){
+      int zone = 0;
       for (int i = 0; i < step; i++) {
-        difftrace->append(diffstate_buffer[id]->get(i));
+        difftrace->append(diffstate_buffer[id]->get(zone, i));
       }
+      zone = (zone + 1) % CONFIG_DIFFTEST_ZONESIZE;
     }
   }
 
@@ -375,6 +377,7 @@ extern Difftest **difftest;
 int difftest_init();
 
 int difftest_nstep(int step);
+void difftest_switch_zone();
 int difftest_step();
 int difftest_state();
 void difftest_finish();

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -114,6 +114,7 @@ static int simv_result = 0;
 extern "C" void simv_nstep(uint8_t step) {
   if (simv_result)
     return;
+  difftest_switch_zone();
   for (int i = 0; i < step; i++) {
     int ret = simv_step();
     if (ret) {
@@ -127,6 +128,7 @@ extern "C" void simv_nstep(uint8_t step) {
 }
 #else
 extern "C" int simv_nstep(uint8_t step) {
+  difftest_switch_zone();
   for(int i = 0; i < step; i++) {
     int ret = simv_step();
     if(ret)


### PR DESCRIPTION
* We seperate gateway mixed logic to PreProcess, Squash, Batch, GatewaySink and ZoneControl
* We add zone-related logic. DUT will write to different zones of State_Buffer at different clock. And REF will also read different zone at each nstep. It will help with async Read and Write. Also used when step at next cycle may be lag behind transfer.
* Each zone's len will be batchSize when isBatch, default is 1.
* Transfer Module such as DPIC should extends GatewaySink for same IO interface. And batch will has specific Interface, extends GatewayBatchSink.