### PR TITLE
Gateway: seperate functional component

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -1,0 +1,62 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.batch
+
+import chisel3._
+import chisel3.util._
+import difftest._
+import difftest.gateway.GatewayConfig
+
+class BatchOutput(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Bundle {
+  val data = Vec(config.batchSize, MixedVec(bundles))
+  val info = Vec(config.batchSize, UInt(log2Ceil(config.batchSize).W))
+  val enable = Bool()
+  val step = UInt(config.stepWidth.W)
+}
+
+object Batch {
+  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): BatchOutput = {
+    val module = Module(new BatchEndpoint(bundles.toSeq.map(_.cloneType), config))
+    module.in := bundles
+    module.out
+  }
+}
+
+class BatchEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+  val buffer = Mem(config.batchSize, in.cloneType)
+  val out = IO(Output(new BatchOutput(bundles, config)))
+
+  val need_store = WireInit(true.B)
+  if (config.hasGlobalEnable) {
+    need_store := VecInit(in.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+  }
+  val ptr = RegInit(0.U(log2Ceil(config.batchSize).W))
+  when(need_store) {
+    ptr := ptr + 1.U
+    when(ptr === (config.batchSize - 1).U) {
+      ptr := 0.U
+    }
+    buffer(ptr) := in
+  }
+  val do_sync = ptr === (config.batchSize - 1).U && need_store
+  for (((data, ifo), idx) <- out.data.zip(out.info).zipWithIndex) {
+    data := buffer(idx)
+    ifo := idx.U
+  }
+  out.enable := RegNext(do_sync)
+  out.step := Mux(out.enable, config.batchSize.U, 0.U)
+}

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -21,7 +21,7 @@ import chisel3.reflect.DataMirror
 import chisel3.util._
 import difftest.DifftestModule.streamToFile
 import difftest._
-import difftest.gateway.{GatewayBundle, GatewayConfig}
+import difftest.gateway.{GatewayBatchBundle, GatewayBundle, GatewayConfig}
 
 import scala.collection.mutable.ListBuffer
 
@@ -32,7 +32,8 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
   val clock = IO(Input(Clock()))
   val enable = IO(Input(Bool()))
   val io = IO(Input(gen))
-  val dut_pos = Option.when(config.hasDutPos)(IO(Input(UInt(config.dutPosWidth.W))))
+  val dut_zone = Option.when(config.hasDutZone)(IO(Input(UInt(config.dutZoneWidth.W))))
+  val dut_index = Option.when(config.isBatch)(IO(Input(UInt(log2Ceil(config.batchSize).W))))
 
   def getDirectionString(data: Data): String = {
     if (DataMirror.directionOf(data) == ActualDirection.Input) "input " else "output"
@@ -64,9 +65,8 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
   val dpicFuncName: String = s"v_difftest_${desiredName.replace("Difftest", "")}"
   val modPorts: Seq[Seq[(String, Data)]] = {
     val common = ListBuffer(Seq(("clock", clock)), Seq(("enable", enable)))
-    if (config.hasDutPos) {
-      common += Seq(("dut_pos", dut_pos.get))
-    }
+    if (config.hasDutZone) common += Seq(("dut_zone", dut_zone.get))
+    if (config.isBatch) common += Seq(("dut_index", dut_index.get))
     // ExtModule implicitly adds io_* prefix to the IOs (because the IO val is named as io).
     // This is different from BlackBoxes.
     common.toSeq ++ io.elements.toSeq.reverse.map { case (name, data) =>
@@ -84,7 +84,8 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
   val dpicFuncAssigns: Seq[String] = {
     val filters: Seq[(DifftestBundle => Boolean, Seq[String])] = Seq(
       ((_: DifftestBundle) => true, Seq("io_coreid")),
-      ((_: DifftestBundle) => config.hasDutPos, Seq("dut_pos")),
+      ((_: DifftestBundle) => config.hasDutZone, Seq("dut_zone")),
+      ((_: DifftestBundle) => config.isBatch, Seq("dut_index")),
       ((x: DifftestBundle) => x.isIndexed, Seq("io_index")),
       ((x: DifftestBundle) => x.isFlatten, Seq("io_address"))
     )
@@ -105,8 +106,9 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
        |  ${dpicFuncArgs.flatten.map(arg => getDPICArgString(arg._1, arg._2, true)).mkString(",\n  ")}
        |)""".stripMargin
   val dpicFunc: String = {
-    val dut_pos = if (config.hasDutPos) "dut_pos" else "0"
-    val packet = s"DUT_BUF(io_coreid,$dut_pos)->${gen.desiredCppName}"
+    val dut_zone = if (config.hasDutZone) "dut_zone" else "0"
+    val dut_index = if (config.isBatch) "dut_index" else "0"
+    val packet = s"DUT_BUF(io_coreid, $dut_zone, $dut_index)->${gen.desiredCppName}"
     val index = if (gen.isIndexed) "[io_index]" else if (gen.isFlatten) "[io_address]" else ""
     s"""
        |$dpicFuncProto {
@@ -161,32 +163,50 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
 }
 
 private class DummyDPICWrapper[T <: DifftestBundle](gen: T, config: GatewayConfig) extends Module {
-  val io = IO(Input(UInt(gen.getWidth.W)))
-  val enable = IO(Input(Bool()))
-  val dut_pos = Option.when(config.hasDutPos)(IO(Input(UInt(config.dutPosWidth.W))))
-
-  val unpack = io.asTypeOf(gen)
+  val io = IO(Input(new GatewayBundle(gen, config)))
   val dpic = Module(new DPIC(gen, config))
   dpic.clock := clock
-  dpic.enable := unpack.bits.getValid && enable
-  if (config.hasDutPos) dpic.dut_pos.get := dut_pos.get
-  dpic.io := unpack
+  dpic.enable := io.data.bits.getValid && io.enable
+  dpic.io := io.data
+  if (config.hasDutZone) dpic.dut_zone.get := io.dut_zone.get
+}
+
+private class DummyDPICBatchWrapper[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig) extends Module {
+  val io = IO(Input(new GatewayBatchBundle(bundles, config)))
+  val interfaces = ListBuffer.empty[(String, String, String)]
+  for ((group, ifo) <- io.data.zip(io.info)) {
+    for (gen <- group) {
+      val dpic = Module(new DPIC(gen.cloneType, config))
+      dpic.clock := clock
+      dpic.enable := gen.bits.getValid && io.enable
+      dpic.io := gen
+      if (config.hasDutZone) dpic.dut_zone.get := io.dut_zone.get
+      dpic.dut_index.get := ifo
+      if (!interfaces.map(_._1).contains(dpic.dpicFuncName)) {
+        val interface = (dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc)
+        interfaces += interface
+      }
+    }
+  }
 }
 
 object DPIC {
   val interfaces = ListBuffer.empty[(String, String, String)]
 
-  def apply[T <: DifftestBundle](gen: T, config: GatewayConfig, port: GatewayBundle): UInt = {
-    val module = Module(new DummyDPICWrapper(gen, config))
-    module.enable := port.enable
-    if (config.hasDutPos) module.dut_pos.get := port.dut_pos.get
-
+  def apply(bundle: GatewayBundle, config: GatewayConfig): Unit = {
+    val module = Module(new DummyDPICWrapper(bundle.data.cloneType, config))
+    module.io := bundle
     val dpic = module.dpic
     if (!interfaces.map(_._1).contains(dpic.dpicFuncName)) {
       val interface = (dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc)
       interfaces += interface
     }
-    module.io
+  }
+
+  def batch(template: MixedVec[DifftestBundle], bundle: GatewayBatchBundle, config: GatewayConfig): Unit = {
+    val module = Module(new DummyDPICBatchWrapper(template.toSeq.map(_.cloneType), config))
+    module.io := bundle
+    interfaces ++= module.interfaces.toSeq
   }
 
   def collect(): Unit = {
@@ -205,19 +225,29 @@ object DPIC {
       """
         |class DPICBuffer : public DiffStateBuffer {
         |private:
-        |  DiffTestState buffer[CONFIG_DIFFTEST_BUFLEN];
+        |  DiffTestState buffer[CONFIG_DIFFTEST_ZONESIZE][CONFIG_DIFFTEST_BUFLEN];
         |  int read_ptr = 0;
+        |  int zone_ptr = 0;
+        |  bool init = true;
         |public:
         |  DPICBuffer() {
         |    memset(buffer, 0, sizeof(buffer));
         |  }
-        |  inline DiffTestState* get(int pos) {
-        |    return buffer+pos;
+        |  inline DiffTestState* get(int zone, int index) {
+        |    return buffer[zone] + index;
         |  }
         |  inline DiffTestState* next() {
-        |    DiffTestState* ret = buffer+read_ptr;
-        |    read_ptr = (read_ptr + 1) % CONFIG_DIFFTEST_BUFLEN;
+        |    DiffTestState* ret = buffer[zone_ptr] + read_ptr;
+        |    read_ptr = read_ptr + 1;
         |    return ret;
+        |  }
+        |  inline void switch_zone() {
+        |    if (init) {
+        |      init = false;
+        |      return;
+        |    }
+        |    zone_ptr = (zone_ptr + 1) % CONFIG_DIFFTEST_ZONESIZE;
+        |    read_ptr = 0;
         |  }
         |};
         |""".stripMargin
@@ -236,7 +266,7 @@ object DPIC {
     interfaceCpp +=
       s"""
          |DiffStateBuffer** diffstate_buffer = nullptr;
-         |#define DUT_BUF(core_id,pos) (diffstate_buffer[core_id]->get(pos))
+         |#define DUT_BUF(core_id, zone, index) (diffstate_buffer[core_id]->get(zone, index))
          |
          |void diffstate_buffer_init() {
          |  diffstate_buffer = new DiffStateBuffer*[NUM_CORES];

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -390,8 +390,9 @@ object DifftestModule {
          |class DiffStateBuffer {
          |public:
          |  virtual ~DiffStateBuffer() {}
-         |  virtual DiffTestState* get(int pos) = 0;
+         |  virtual DiffTestState* get(int zone, int index) = 0;
          |  virtual DiffTestState* next() = 0;
+         |  virtual void switch_zone() = 0;
          |};
          |
          |extern DiffStateBuffer** diffstate_buffer;

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -22,16 +22,16 @@ import difftest._
 import difftest.gateway.GatewayConfig
 
 object Squash {
-  def apply[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig): SquashEndpoint = {
-    val module = Module(new SquashEndpoint(bundles, config))
-    module
+  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): MixedVec[DifftestBundle] = {
+    val module = Module(new SquashEndpoint(bundles.toSeq.map(_.cloneType), config))
+    module.in := bundles
+    module.out
   }
 }
 
 class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
   val out = IO(Output(MixedVec(bundles)))
-  val idx = Option.when(config.squashReplay)(IO(Output(UInt(log2Ceil(config.replaySize).W))))
 
   val state = RegInit(0.U.asTypeOf(MixedVec(bundles)))
 
@@ -123,8 +123,9 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
         }
       }
     }
-    idx.get := Mux(in_replay, control.replay_idx.get, squash_idx)
     out := Mux(in_replay, replay_data(replay_ptr), squashed)
+    val info = out.filter(_.desiredCppName == "trace_info").head.asInstanceOf[DiffTraceInfo]
+    info.squash_idx.get := Mux(in_replay, control.replay_idx.get, squash_idx)
   } else {
     out := squashed
   }

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -32,7 +32,7 @@ int difftest_init() {
   difftest = new Difftest*[NUM_CORES];
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i] = new Difftest(i);
-    difftest[i]->dut = diffstate_buffer[i]->get(0);
+    difftest[i]->dut = diffstate_buffer[i]->get(0, 0);
   }
   return 0;
 }
@@ -58,6 +58,7 @@ int difftest_state() {
 
 int difftest_nstep(int step){
   int last_trap_code = STATE_RUNNING;
+  difftest_switch_zone();
   for(int i = 0; i < step; i++){
     if(difftest_step()){
       last_trap_code = STATE_ABORT;
@@ -70,6 +71,11 @@ int difftest_nstep(int step){
   return last_trap_code;
 }
 
+void difftest_switch_zone() {
+  for (int i = 0; i < NUM_CORES; i++) {
+    diffstate_buffer[i]->switch_zone();
+  }
+}
 int difftest_step() {
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i]->dut = diffstate_buffer[i]->next();

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -215,9 +215,11 @@ public:
   }
   void trace_write(int step){
     if (difftrace){
+      int zone = 0;
       for (int i = 0; i < step; i++) {
-        difftrace->append(diffstate_buffer[id]->get(i));
+        difftrace->append(diffstate_buffer[id]->get(zone, i));
       }
+      zone = (zone + 1) % CONFIG_DIFFTEST_ZONESIZE;
     }
   }
 
@@ -375,6 +377,7 @@ extern Difftest **difftest;
 int difftest_init();
 
 int difftest_nstep(int step);
+void difftest_switch_zone();
 int difftest_step();
 int difftest_state();
 void difftest_finish();

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -114,6 +114,7 @@ static int simv_result = 0;
 extern "C" void simv_nstep(uint8_t step) {
   if (simv_result)
     return;
+  difftest_switch_zone();
   for (int i = 0; i < step; i++) {
     int ret = simv_step();
     if (ret) {
@@ -127,6 +128,7 @@ extern "C" void simv_nstep(uint8_t step) {
 }
 #else
 extern "C" int simv_nstep(uint8_t step) {
+  difftest_switch_zone();
   for(int i = 0; i < step; i++) {
     int ret = simv_step();
     if(ret)


### PR DESCRIPTION
* We seperate gateway mixed logic to PreProcess, Squash, Batch, GatewaySink and ZoneControl
* We add zone-related logic. DUT will write to different zones of State_Buffer at different clock. And REF will also read different zone at each nstep. It will help with async Read and Write. Also used when step at next cycle may be lag behind transfer.
* Each zone's len will be batchSize when isBatch, default is 1.
* Transfer Module such as DPIC should declare GatewayBundle for same IO interface. And batch will has specific Interface, declare GatewayBatchBundle.