### PR TITLE
coverage: fix the regex for module definition

### DIFF
--- a/scripts/coverage/statistics.py
+++ b/scripts/coverage/statistics.py
@@ -148,7 +148,7 @@ def get_coverage_statistics(line_annotations, start, end):
 def get_modules(lines):
     modules = {}
 
-    module_pattern = re.compile("module (\w+)\(")
+    module_pattern = re.compile("module (\w+)\s*\(")
     endmodule_pattern = re.compile("endmodule")
     submodule_pattern = re.compile("(\w+) (\w+) \( // @\[\w+.scala \d+:\d+\]")
 

--- a/src/main/scala/common/LogPerfControl.scala
+++ b/src/main/scala/common/LogPerfControl.scala
@@ -34,18 +34,19 @@ private class LogPerfHelper extends BlackBox with HasBlackBoxInline {
       |`endif
       |
       |/*verilator tracing_off*/
+      |/*verilator coverage_off*/
       |
-      |module LogPerfHelper (
+      |module LogPerfHelper(
       |  output [63:0] timer,
       |  output        logEnable,
       |  output        clean,
       |  output        dump
       |);
       |
-      |assign timer         = `SIM_TOP_MODULE_NAME.difftest_timer;
-      |assign logEnable     = `SIM_TOP_MODULE_NAME.difftest_log_enable;
-      |assign clean         = `SIM_TOP_MODULE_NAME.difftest_perfCtrl_clean;
-      |assign dump          = `SIM_TOP_MODULE_NAME.difftest_perfCtrl_dump;
+      |assign timer     = `SIM_TOP_MODULE_NAME.difftest_timer;
+      |assign logEnable = `SIM_TOP_MODULE_NAME.difftest_log_enable;
+      |assign clean     = `SIM_TOP_MODULE_NAME.difftest_perfCtrl_clean;
+      |assign dump      = `SIM_TOP_MODULE_NAME.difftest_perfCtrl_dump;
       |
       |endmodule
       |


### PR DESCRIPTION
It now allows `module module_name (` as well.

We are not providing general-purpose Verilog parsing scripts. However, we need to at least support Chisel-generated sources using DiffTest. The LogPerfHelp module in DiffTest has a whitespace after module name.