### PR TITLE
DPIC: remove include DifftestMacros.v from generated RTL

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -131,16 +131,15 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
     val modPortsString = modPorts.flatten.map(i => getModArgString(i._1, i._2)).mkString(",\n  ")
     // Initial for Palladium GFIFO
     val gfifoInitial =
-      s"""
-         |`ifdef CONFIG_DIFFTEST_NONBLOCK
-         |`ifdef PALLADIUM
-         |initial $$ixc_ctrl("gfifo", "$dpicFuncName");
-         |`endif
-         |`endif // CONFIG_DIFFTEST_NONBLOCK
-         |""".stripMargin
+      if (config.isNonBlock)
+        s"""
+           |`ifdef PALLADIUM
+           |initial $$ixc_ctrl("gfifo", "$dpicFuncName");
+           |`endif
+           |""".stripMargin
+      else ""
     val modDef =
       s"""
-         |`include "DifftestMacros.v"
          |module $desiredName(
          |  $modPortsString
          |);


### PR DESCRIPTION
For Param configuration in fixed code such as vcs/top.v, we include DifftestMacros.v to contain macros corresponding to Param. However, in generated RTL, we can add Macro directly in code generation. And when pure verilog is generated, DifftestMacros may not be created, which cuase syntax error.