### PR TITLE
DPIC: reset diffstate_buffer to nullptr after free

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -273,11 +273,13 @@ object DPIC {
          |    diffstate_buffer[i] = new DPICBuffer;
          |  }
          |}
+         |
          |void diffstate_buffer_free() {
          |  for (int i = 0; i < NUM_CORES; i++) {
          |    delete diffstate_buffer[i];
          |  }
          |  delete[] diffstate_buffer;
+         |  diffstate_buffer = nullptr;
          |}
       """.stripMargin
     interfaceCpp += interfaces.map(_._3).mkString("")


### PR DESCRIPTION
DPI-C functions are using the diffstate_buffer to check whether the corresponding data structures have been initialized. However, we are not resetting it to nullptr after free. If the simulation environment is reset manually and restarted, then this pointer will be a dangling pointer and corrupt the next DPI-C calls.