### PR TITLE
Batch: pack DPIC to reduce sync times

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -320,7 +320,7 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
-      - name: Verilator Build with VCS Top (with Squash Batch and Global Enable)
+      - name: Verilator Build with VCS Top (with Squash Select Batch and Global Enable)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
@@ -328,6 +328,7 @@ jobs:
             source ./env.sh
             make clean
             sed -i 's/isSquash: Boolean = false/isSquash: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/diffstateSelect: Boolean = false/diffstateSelect: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/isBatch: Boolean = false/isBatch: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/hasGlobalEnable: Boolean = false/hasGlobalEnable: Boolean = true/' difftest/src/main/scala/Gateway.scala
             make simv VCS=verilator -j2

--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -19,44 +19,148 @@ import chisel3._
 import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
+import difftest.Delayer
 
-class BatchOutput(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Bundle {
-  val data = Vec(config.batchSize, MixedVec(bundles))
-  val info = Vec(config.batchSize, UInt(log2Ceil(config.batchSize).W))
+import scala.collection.mutable.ListBuffer
+
+class BatchOutput(dataWidth: Int, infoWidth: Int, config: GatewayConfig) extends Bundle {
+  val data = UInt(dataWidth.W)
+  val info = UInt(infoWidth.W)
   val enable = Bool()
   val step = UInt(config.stepWidth.W)
 }
 
+class BatchInfo extends Bundle {
+  val id = UInt(8.W)
+  val len = UInt(16.W)
+}
+
 object Batch {
-  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): BatchOutput = {
-    val module = Module(new BatchEndpoint(bundles.toSeq.map(_.cloneType), config))
+  def apply(template: Seq[DifftestBundle], bundles: MixedVec[DifftestBundle], config: GatewayConfig): BatchOutput = {
+    val module = Module(new BatchEndpoint(template, bundles.toSeq.map(_.cloneType), config))
     module.in := bundles
     module.out
   }
+
+  def getTemplate(bundles: MixedVec[DifftestBundle]): Seq[DifftestBundle] = {
+    val template = ListBuffer.empty[DifftestBundle]
+    for (gen <- bundles) {
+      if (!template.exists(_.desiredModuleName == gen.desiredModuleName)) {
+        template += gen
+      }
+    }
+    template.toSeq
+  }
 }
 
-class BatchEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+class BatchEndpoint(template: Seq[DifftestBundle], bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
-  val buffer = Mem(config.batchSize, in.cloneType)
-  val out = IO(Output(new BatchOutput(bundles, config)))
 
-  val need_store = WireInit(true.B)
-  if (config.hasGlobalEnable) {
-    need_store := VecInit(in.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
-  }
-  val ptr = RegInit(0.U(log2Ceil(config.batchSize).W))
-  when(need_store) {
-    ptr := ptr + 1.U
-    when(ptr === (config.batchSize - 1).U) {
-      ptr := 0.U
+  def bundleAlign(bundle: DifftestBundle): UInt = {
+    def byteAlign(data: Data): UInt = {
+      val width: Int = data.getWidth + (8 - data.getWidth % 8) % 8
+      data.asTypeOf(UInt(width.W))
     }
-    buffer(ptr) := in
+    val element = ListBuffer.empty[UInt]
+    bundle.elements.toSeq.reverse.foreach { case (name, data) =>
+      if (name != "valid") {
+        data match {
+          case vec: Vec[_] => element ++= vec.map(byteAlign(_))
+          case data: Data  => element += byteAlign(data)
+        }
+      }
+    }
+    MixedVecInit(element.toSeq).asUInt
   }
-  val do_sync = ptr === (config.batchSize - 1).U && need_store
-  for (((data, ifo), idx) <- out.data.zip(out.info).zipWithIndex) {
-    data := buffer(idx)
-    ifo := idx.U
+
+  def getBundleID(name: String): Int = {
+    template.zipWithIndex.filter { case (gen, idx) => gen.desiredModuleName == name }.head._2
   }
-  out.enable := RegNext(do_sync)
-  out.step := Mux(out.enable, config.batchSize.U, 0.U)
+
+  val aligned_data = MixedVecInit(in.map(i => bundleAlign(i)).toSeq)
+
+  val global_enable = WireInit(true.B)
+  if (config.hasGlobalEnable) {
+    global_enable := VecInit(in.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+  }
+
+  val bundleNum = in.length
+  val delayed_enable = Delayer(global_enable, bundleNum)
+  val delayed_data = MixedVecInit(aligned_data.zipWithIndex.map { case (data, i) => Delayer(data, i) }.toSeq)
+  val delayed_valid = VecInit(in.zipWithIndex.map { case (gen, i) =>
+    Delayer(gen.bits.getValid & global_enable, i)
+  }.toSeq)
+
+  // Maxixum 4000 byte packed. Now we set maxium of data byte as 3000, info as 900
+  val MaxDataByteLen = 3600
+  val MaxDataByteWidth = log2Ceil(MaxDataByteLen)
+  val MaxDataBitLen = MaxDataByteLen * 8
+  val infoWidth = (new BatchInfo).getWidth
+  // Append BatchInterval and BatchFinish Info
+  val MaxInfoByteLen = math.min((config.batchSize * (bundleNum + 1) + 1) * (infoWidth / 8), 300)
+  val MaxInfoByteWidth = log2Ceil(MaxInfoByteLen)
+  val MaxInfoBitLen = MaxInfoByteLen * 8
+
+  val data_vec = Reg(MixedVec((1 to bundleNum).map(i => UInt(aligned_data.map(_.getWidth).take(i).sum.W))))
+  val info_vec = Reg(MixedVec((1 to bundleNum).map(i => UInt((i * infoWidth).W))))
+  val data_len_vec = Reg(Vec(bundleNum, UInt(MaxDataByteWidth.W)))
+  val info_len_vec = Reg(Vec(bundleNum, UInt(MaxInfoByteWidth.W)))
+
+  for (idx <- 0 until bundleNum) {
+    val data_len = (aligned_data(idx).getWidth / 8).U
+    val info = Wire(new BatchInfo)
+    info.id := getBundleID(in(idx).desiredModuleName).U
+    info.len := data_len
+    if (idx == 0) {
+      data_vec(idx) := Mux(delayed_valid(idx), delayed_data(idx), 0.U)
+      info_vec(idx) := Mux(delayed_valid(idx), info.asUInt, 0.U)
+      data_len_vec(idx) := Mux(delayed_valid(idx), data_len, 0.U)
+      info_len_vec(idx) := Mux(delayed_valid(idx), (infoWidth / 8).U, 0.U)
+    } else {
+      data_vec(idx) := Mux(delayed_valid(idx), Cat(data_vec(idx - 1), delayed_data(idx)), data_vec(idx - 1))
+      info_vec(idx) := Mux(delayed_valid(idx), Cat(info_vec(idx - 1), info.asUInt), info_vec(idx - 1))
+      data_len_vec(idx) := Mux(delayed_valid(idx), data_len_vec(idx - 1) + data_len, data_len_vec(idx - 1))
+      info_len_vec(idx) := Mux(delayed_valid(idx), info_len_vec(idx - 1) + (infoWidth / 8).U, info_len_vec(idx - 1))
+    }
+  }
+
+  val BatchInterval = WireInit(0.U.asTypeOf(new BatchInfo))
+  val BatchFinish = WireInit(0.U.asTypeOf(new BatchInfo))
+  BatchInterval.id := template.length.U
+  BatchFinish.id := (template.length + 1).U
+  val step_data = WireInit(data_vec(bundleNum - 1))
+  val step_info = Cat(info_vec(bundleNum - 1), BatchInterval.asUInt)
+  val step_data_len = data_len_vec(bundleNum - 1)
+  val step_info_len = info_len_vec(bundleNum - 1) + (infoWidth / 8).U
+
+  val state_data = RegInit(0.U(MaxDataBitLen.W))
+  val state_data_len = RegInit(0.U(MaxDataByteWidth.W))
+  val state_info = RegInit(0.U(MaxInfoBitLen.W))
+  val state_info_len = RegInit(0.U(MaxInfoByteWidth.W))
+  val state_step_cnt = RegInit(0.U(log2Ceil(config.batchSize + 1).W))
+
+  val exceed = (state_data_len +& step_data_len > MaxDataByteLen.U) |
+    (state_info_len +& step_info_len + (infoWidth / 8).U > MaxInfoByteLen.U)
+  val should_tick = delayed_enable && (exceed || state_step_cnt === config.batchSize.U)
+  when(delayed_enable) {
+    when(should_tick) {
+      state_data := step_data
+      state_data_len := step_data_len
+      state_info := step_info
+      state_info_len := step_info_len
+      state_step_cnt := 1.U
+    }.otherwise {
+      state_data := state_data | step_data << (state_data_len << 3)
+      state_data_len := state_data_len + step_data_len
+      state_info := state_info | step_info << (state_info_len << 3)
+      state_info_len := state_info_len + step_info_len
+      state_step_cnt := state_step_cnt + 1.U
+    }
+  }
+
+  val out = IO(Output(new BatchOutput(state_data.getWidth, state_info.getWidth, config)))
+  out.data := state_data
+  out.info := state_info | BatchFinish.asUInt << (state_info_len << 3)
+  out.enable := should_tick
+  out.step := Mux(out.enable, state_step_cnt, 0.U)
 }

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -21,17 +21,14 @@ import chisel3.reflect.DataMirror
 import chisel3.util._
 import difftest.DifftestModule.streamToFile
 import difftest._
-import difftest.gateway.{GatewayBatchBundle, GatewayBundle, GatewayConfig, GatewayResult}
+import difftest.batch.BatchIO
+import difftest.gateway.{GatewayConfig, GatewayResult, GatewaySinkControl}
 
 import scala.collection.mutable.ListBuffer
 
-class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
-  extends ExtModule
-  with HasExtModuleInline
-  with DifftestModule[T] {
+abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModuleInline {
   val clock = IO(Input(Clock()))
   val enable = IO(Input(Bool()))
-  val io = IO(Input(gen))
   val dut_zone = Option.when(config.hasDutZone)(IO(Input(UInt(config.dutZoneWidth.W))))
 
   def getDirectionString(data: Data): String = {
@@ -44,10 +41,11 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
       case width if width > 1 && width <= 8   => if (isC) "uint8_t" else "byte"
       case width if width > 8 && width <= 32  => if (isC) "uint32_t" else "int"
       case width if width > 32 && width <= 64 => if (isC) "uint64_t" else "longint"
-      case _                                  => s"unsupported io type of width ${data.getWidth}!!\n"
+      case width if width > 64                => if (isC) "const svBitVecVal" else s"bit[${width - 1}:0]"
     }
     if (isC) {
-      f"$typeString%-8s $argName"
+      val width = data.getWidth
+      if (width > 64) f"$typeString $argName[${width / 32}]" else f"$typeString%-8s $argName"
     } else {
       val directionString = getDirectionString(data)
       f"$directionString $typeString%8s $argName"
@@ -60,62 +58,38 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
     argString.mkString(" ")
   }
 
-  override def desiredName: String = gen.desiredModuleName
-  val dpicFuncName: String = s"v_difftest_${desiredName.replace("Difftest", "")}"
-  val modPorts: Seq[Seq[(String, Data)]] = {
-    val common = ListBuffer(Seq(("clock", clock)), Seq(("enable", enable)))
-    if (config.hasDutZone) common += Seq(("dut_zone", dut_zone.get))
-    // ExtModule implicitly adds io_* prefix to the IOs (because the IO val is named as io).
-    // This is different from BlackBoxes.
-    common.toSeq ++ io.elements.toSeq.reverse.map { case (name, data) =>
-      data match {
-        case vec: Vec[_] => vec.zipWithIndex.map { case (v, i) => (s"io_${name}_$i", v) }
-        case _           => Seq((s"io_$name", data))
-      }
-    }
+  protected val commonPorts: Seq[(String, Data)] = {
+    val common = Seq(("clock", clock), ("enable", enable))
+    if (config.hasDutZone) common ++ Seq(("dut_zone", dut_zone.get)) else common
   }
-  val dpicFuncArgsWithClock = if (gen.bits.hasValid) {
-    modPorts.filterNot(p => p.length == 1 && p.head._1 == "io_valid")
-  } else modPorts
-  val dpicDropNum = 2
-  val dpicFuncArgs: Seq[Seq[(String, Data)]] = dpicFuncArgsWithClock.drop(2)
-  val dpicFuncAssigns: Seq[String] = {
-    val filters: Seq[(DifftestBundle => Boolean, Seq[String])] = Seq(
-      ((_: DifftestBundle) => true, Seq("io_coreid")),
-      ((_: DifftestBundle) => config.hasDutZone, Seq("dut_zone")),
-      ((x: DifftestBundle) => x.isIndexed, Seq("io_index")),
-      ((x: DifftestBundle) => x.isFlatten, Seq("io_address")),
-    )
-    val rhs = dpicFuncArgs.map(_.map(_._1).filterNot(s => filters.exists(f => f._1(gen) && f._2.contains(s))))
-    val lhs = rhs
-      .map(_.map(_.replace("io_", "")))
-      .flatMap(r =>
-        if (r.length == 1) r
-        else r.map(x => x.slice(0, x.lastIndexOf('_')) + s"[${x.split('_').last}]")
-      )
-    val body = lhs.zip(rhs.flatten).map { case (l, r) => s"packet->$l = $r;" }
-    val validAssign = if (!gen.bits.hasValid || gen.isFlatten) Seq() else Seq("packet->valid = true;")
-    validAssign ++ body
-  }
-  val dpicFuncProto: String =
+  def modPorts: Seq[Seq[(String, Data)]] = commonPorts.map(Seq(_))
+
+  def desiredName: String
+  def dpicFuncName: String = s"v_difftest_${desiredName.replace("Difftest", "")}"
+  def dpicFuncArgs: Seq[Seq[(String, Data)]] =
+    modPorts.filterNot(p => p.length == 1 && commonPorts.exists(_._1 == p.head._1))
+  def dpicFuncProto: String =
     s"""
        |extern "C" void $dpicFuncName (
        |  ${dpicFuncArgs.flatten.map(arg => getDPICArgString(arg._1, arg._2, true)).mkString(",\n  ")}
        |)""".stripMargin
-  val dpicFunc: String = {
+  def getPacketDecl(gen: DifftestBundle, prefix: String, config: GatewayConfig): String = {
     val dut_zone = if (config.hasDutZone) "dut_zone" else "0"
-    val packet = s"DUT_BUF(io_coreid, $dut_zone, 0)->${gen.desiredCppName}"
-    val index = if (gen.isIndexed) "[io_index]" else if (gen.isFlatten) "[io_address]" else ""
+    val dut_index = if (config.isBatch) "dut_index" else "0"
+    val packet = s"DUT_BUF(${prefix}coreid, $dut_zone, $dut_index)->${gen.desiredCppName}"
+    val index = if (gen.isIndexed) s"[${prefix}index]" else if (gen.isFlatten) s"[${prefix}address]" else ""
+    s"auto packet = &($packet$index);"
+  }
+  def dpicFuncAssigns: Seq[String]
+  def dpicFunc: String =
     s"""
        |$dpicFuncProto {
        |  if (!diffstate_buffer) return;
-       |  auto packet = &($packet$index);
        |  ${dpicFuncAssigns.mkString("\n  ")}
        |}
        |""".stripMargin
-  }
 
-  val moduleBody: String = {
+  def moduleBody: String = {
     val dpicDecl =
       // (1) DPI-C function prototype
       s"""
@@ -145,7 +119,7 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
          |$gfifoInitial
          |  always @(posedge clock) begin
          |    if (enable)
-         |    $dpicFuncName (${dpicFuncArgs.flatten.map(_._1).mkString(", ")});
+         |      $dpicFuncName (${dpicFuncArgs.flatten.map(_._1).mkString(", ")});
          |  end
          |`endif
          |`endif
@@ -153,192 +127,158 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
          |""".stripMargin
     modDef
   }
+}
+
+class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig) extends DPICBase(config) with DifftestModule[T] {
+  val io = IO(Input(gen))
+
+  override def desiredName: String = gen.desiredModuleName
+  override def modPorts: Seq[Seq[(String, Data)]] = {
+    super.modPorts ++ io.elements.toSeq.reverse.map { case (name, data) =>
+      data match {
+        case vec: Vec[_] => vec.zipWithIndex.map { case (v, i) => (s"io_${name}_$i", v) }
+        case _           => Seq((s"io_$name", data))
+      }
+    }
+  }
+  override def dpicFuncArgs: Seq[Seq[(String, Data)]] = if (gen.bits.hasValid) {
+    super.dpicFuncArgs.filterNot(p => p.length == 1 && p.head._1 == "io_valid")
+  } else {
+    super.dpicFuncArgs
+  }
+
+  override def dpicFuncAssigns: Seq[String] = {
+    val filters: Seq[(DifftestBundle => Boolean, Seq[String])] = Seq(
+      ((_: DifftestBundle) => true, Seq("io_coreid")),
+      ((x: DifftestBundle) => x.isIndexed, Seq("io_index")),
+      ((x: DifftestBundle) => x.isFlatten, Seq("io_address")),
+    )
+    val rhs = dpicFuncArgs.map(_.map(_._1).filterNot(s => filters.exists(f => f._1(gen) && f._2.contains(s))))
+    val lhs = rhs
+      .map(_.map(_.replace("io_", "")))
+      .flatMap(r =>
+        if (r.length == 1) r
+        else r.map(x => x.slice(0, x.lastIndexOf('_')) + s"[${x.split('_').last}]")
+      )
+    val body = lhs.zip(rhs.flatten).map { case (l, r) => s"packet->$l = $r;" }
+    val packetDecl = Seq(getPacketDecl(gen, "io_", config))
+    val validAssign = if (!gen.bits.hasValid || gen.isFlatten) Seq() else Seq("packet->valid = true;")
+    packetDecl ++ validAssign ++ body
+  }
 
   setInline(s"$desiredName.v", moduleBody)
 }
 
-class DPICBatch[T <: Seq[DifftestBundle]](template: T, bundle: GatewayBatchBundle, config: GatewayConfig)
-  extends ExtModule
-  with HasExtModuleInline {
-  val clock = IO(Input(Clock()))
-  val io = IO(Input(bundle))
-
-  def getModArgString(argName: String, data: Data): String = {
-    val widthString = if (data.getWidth == 1) "      " else f"[${data.getWidth - 1}%2d:0]"
-    s"input $widthString $argName"
-  }
-
-  def getDPICArgString(argName: String, data: Data, isC: Boolean): String = {
-    if (data.getWidth <= 8) {
-      if (isC) s"uint8_t $argName" else s"input byte $argName"
-    } else {
-      if (isC) s"const svBitVecVal $argName[${data.getWidth / 32}]" else s"input bit[${data.getWidth - 1}:0] $argName"
-    }
-  }
+class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: GatewayConfig) extends DPICBase(config) {
+  val io = IO(Input(batchIO))
 
   def getDPICBundleUnpack(gen: DifftestBundle): String = {
     val unpack = ListBuffer.empty[String]
-    def byteCnt(data: Data): Int = (data.getWidth + 7) / 8
-    case class ArgPair(name: String, width: Int, offset: Int)
+    case class ArgPair(name: String, len: Int, offset: Int)
     def getBundleArgs(gen: DifftestBundle): Seq[ArgPair] = {
-      val list = ListBuffer.empty[ArgPair]
-      var offset: Int = 0
-      for ((name, data) <- gen.elements.toSeq.reverse) {
-        if (!(gen.isFlatten && name == "valid")) {
+      def byteCnt(data: Data): Int = (data.getWidth + 7) / 8
+      val argsWithLen = gen.elements.toSeq.reverse
+        .filterNot(gen.isFlatten && _._1 == "valid")
+        .flatMap { case (name, data) =>
           data match {
-            case vec: Vec[_] => {
-              for ((v, i) <- vec.zipWithIndex) {
-                list += ArgPair(s"${name}_$i", byteCnt(v), offset)
-                offset += byteCnt(v)
-              }
-            }
-            case d: Data => {
-              list += ArgPair(name, byteCnt(d), offset)
-              offset += byteCnt(d)
-            }
+            case vec: Vec[_] => vec.zipWithIndex.map { case (v, i) => (s"{${name}_$i}", byteCnt(v)) }
+            case _           => Seq((s"$name", byteCnt(data)))
           }
         }
+      argsWithLen.zipWithIndex.map { case ((name, len), idx) =>
+        val offset = argsWithLen.take(idx).map(_._2).sum
+        ArgPair(name, len, offset)
       }
-      list.toSeq
     }
 
     // Note: filterArgs will not in struct defined, but at the beginning or the end of Bundle
     val bundleArgs = getBundleArgs(gen)
     val filterArgs = Seq("coreid", "index", "address")
     unpack ++= bundleArgs.filter(p => filterArgs.contains(p.name)).map(p => s"${p.name} = data[${p.offset}];")
-    val dut_zone = if (config.hasDutZone) "io_dut_zone" else "0"
-    val packet = s"DUT_BUF(coreid, $dut_zone, dut_index)->${gen.desiredCppName}"
-    val index = if (gen.isIndexed) "[index]" else if (gen.isFlatten) "[address]" else ""
-    unpack += s"auto packet = &($packet$index);"
+    unpack += getPacketDecl(gen, "", config)
     val packedArgs = bundleArgs.filterNot(p => filterArgs.contains(p.name))
     val ptrOffset: String = packedArgs.head.offset match {
       case 0 => ""
       case n => s" + $n"
     }
     unpack += s"memcpy(packet, data$ptrOffset, sizeof(${gen.desiredModuleName}));"
-    unpack += s"data += ${bundleArgs.map(_.width).sum};"
+    unpack += s"data += ${bundleArgs.map(_.len).sum};"
     unpack.toSeq.mkString("\n      ")
   }
 
+  override def modPorts = super.modPorts ++ Seq(Seq(("io_data", io.data)), Seq(("io_info", io.info)))
+
   override def desiredName: String = "DifftestBatch"
-  val dpicFuncName: String = s"v_difftest_${desiredName.replace("Difftest", "")}"
-  val dpicFuncArgs: Seq[(String, Data)] = {
-    val common = Seq(("io_data", io.data), ("io_info", io.info))
-    if (config.hasDutZone) common ++ Seq(("io_dut_zone", io.dut_zone.get)) else common
-  }
-  val dpicFuncProto: String =
-    s"""
-       |extern "C" void $dpicFuncName (
-       |  ${dpicFuncArgs.map(arg => getDPICArgString(arg._1, arg._2, true)).mkString(",\n  ")}
-       |)""".stripMargin
-  val dpicFunc: String = {
+  override def dpicFuncAssigns: Seq[String] = {
     val bundleEnum = template.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchInterval", "BatchFinish")
-    val bundleAssign =
-      (Seq(s"""
-              |    if (id == BatchFinish) {
-              |      break;
-              |    }
-              |    else if (id == BatchInterval && i != 0) {
-              |      dut_index ++;
-              |      continue;
-              |    }
-              |""".stripMargin)
-        ++ template.zipWithIndex.map { case (t, idx) =>
-          s"""
-             |    else if (id == ${bundleEnum(idx)}) {
-             |      ${getDPICBundleUnpack(t)}
-             |    }
+    val bundleAssign = template.zipWithIndex.map { case (t, idx) =>
+      s"""
+         |    else if (id == ${bundleEnum(idx)}) {
+         |      ${getDPICBundleUnpack(t)}
+         |    }
         """.stripMargin
-        }).mkString("")
+    }.mkString("")
 
     val infoLen = io.info.getWidth / 8
-    s"""
-       |enum DifftestBundleType {
-       |  ${bundleEnum.mkString(",\n  ")}
-       |};
-       |$dpicFuncProto {
-       |  if (!diffstate_buffer) return;
-       |  uint64_t offset = 0;
-       |  uint32_t dut_index = 0;
-       |  static uint8_t info[$infoLen];
-       |  memcpy(info, io_info, $infoLen * sizeof(uint8_t));
-       |  uint8_t* data = (uint8_t*)io_data;
-       |  for (int i = 0; i < $infoLen; i++) {
-       |    uint8_t id = info[i];
-       |    uint32_t coreid, index, address;
-       |    $bundleAssign
-       |  }
-       |}
-       |""".stripMargin
-  }
-
-  val modPorts: Seq[(String, Data)] = {
-    Seq(("clock", clock)) ++ io.elements.toSeq.reverse.map { case (name, data) => (s"io_$name", data) }
-  }
-  val moduleBody: String = {
-    val dpicDecl =
-      s"""
-         |import "DPI-C" function void $dpicFuncName (
-         |  ${dpicFuncArgs.map(arg => getDPICArgString(arg._1, arg._2, false)).mkString(",\n  ")}
-         |);
-         |""".stripMargin
-    val gfifoInitial =
-      if (config.isNonBlock)
-        s"""
-           |`ifdef PALLADIUM
-           |initial $$ixc_ctrl("gfifo", "$dpicFuncName");
-           |`endif
-           |""".stripMargin
-      else ""
-    val modPortsString = modPorts.map(i => getModArgString(i._1, i._2)).mkString(",\n  ")
-    s"""
-       |`include "DifftestMacros.v"
-       |module $desiredName(
-       |  $modPortsString
-       |);
-       |`ifndef SYNTHESIS
-       |`ifdef DIFFTEST
-       |$dpicDecl
-       |$gfifoInitial
-       |  always @(posedge clock) begin
-       |    if (io_enable)
-       |      $dpicFuncName (${dpicFuncArgs.map(_._1).mkString(", ")});
-       |  end
-       |`endif
-       |`endif
-       |endmodule
-       |""".stripMargin
+    Seq(s"""
+           |  enum DifftestBundleType {
+           |  ${bundleEnum.mkString(",\n  ")}
+           |  };
+           |
+           |  uint64_t offset = 0;
+           |  uint32_t dut_index = 0;
+           |  static uint8_t info[$infoLen];
+           |  memcpy(info, io_info, $infoLen * sizeof(uint8_t));
+           |  uint8_t* data = (uint8_t*)io_data;
+           |  for (int i = 0; i < $infoLen; i++) {
+           |    uint8_t id = info[i];
+           |    uint32_t coreid, index, address;
+           |    if (id == BatchFinish) {
+           |      break;
+           |    }
+           |    else if (id == BatchInterval && i != 0) {
+           |      dut_index ++;
+           |      continue;
+           |    }
+           |    $bundleAssign
+           |  }
+           |""".stripMargin)
   }
 
   setInline(s"$desiredName.v", moduleBody)
 }
 
-private class DummyDPICWrapper[T <: DifftestBundle](gen: T, config: GatewayConfig) extends Module {
-  val io = IO(Input(new GatewayBundle(gen, config)))
+private class DummyDPICWrapper(gen: DifftestBundle, config: GatewayConfig) extends Module {
+  val control = IO(Input(new GatewaySinkControl(config)))
+  val io = IO(Input(gen))
   val dpic = Module(new DPIC(gen, config))
   dpic.clock := clock
-  dpic.enable := io.data.bits.getValid && io.enable
-  dpic.io := io.data
-  if (config.hasDutZone) dpic.dut_zone.get := io.dut_zone.get
+  dpic.enable := io.bits.getValid && control.enable
+  if (config.hasDutZone) dpic.dut_zone.get := control.dut_zone.get
+  dpic.io := io
 }
 
-private class DummyDPICBatchWrapper[T <: Seq[DifftestBundle]](
-  template: T,
-  bundle: GatewayBatchBundle,
+private class DummyDPICBatchWrapper(
+  template: Seq[DifftestBundle],
+  batchIO: BatchIO,
   config: GatewayConfig,
 ) extends Module {
-  val io = IO(Input(bundle))
-  val dpic = Module(new DPICBatch(template, bundle, config))
+  val control = IO(Input(new GatewaySinkControl(config)))
+  val io = IO(Input(batchIO))
+  val dpic = Module(new DPICBatch(template, batchIO, config))
   dpic.clock := clock
+  dpic.enable := control.enable
+  if (config.hasDutZone) dpic.dut_zone.get := control.dut_zone.get
   dpic.io := io
 }
 
 object DPIC {
   val interfaces = ListBuffer.empty[(String, String, String)]
 
-  def apply(bundle: GatewayBundle, config: GatewayConfig): Unit = {
-    val module = Module(new DummyDPICWrapper(bundle.data.cloneType, config))
-    module.io := bundle
+  def apply(control: GatewaySinkControl, io: DifftestBundle, config: GatewayConfig): Unit = {
+    val module = Module(new DummyDPICWrapper(chiselTypeOf(io), config))
+    module.control := control
+    module.io := io
     val dpic = module.dpic
     if (!interfaces.map(_._1).contains(dpic.dpicFuncName)) {
       val interface = (dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc)
@@ -346,9 +286,10 @@ object DPIC {
     }
   }
 
-  def batch(template: Seq[DifftestBundle], bundle: GatewayBatchBundle, config: GatewayConfig): Unit = {
-    val module = Module(new DummyDPICBatchWrapper(template.map(_.cloneType), bundle.cloneType, config))
-    module.io := bundle
+  def batch(template: Seq[DifftestBundle], control: GatewaySinkControl, io: BatchIO, config: GatewayConfig): Unit = {
+    val module = Module(new DummyDPICBatchWrapper(template, chiselTypeOf(io), config))
+    module.control := control
+    module.io := io
     val dpic = module.dpic
     interfaces += ((dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc))
   }

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -33,7 +33,6 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
   val enable = IO(Input(Bool()))
   val io = IO(Input(gen))
   val dut_zone = Option.when(config.hasDutZone)(IO(Input(UInt(config.dutZoneWidth.W))))
-  val dut_index = Option.when(config.isBatch)(IO(Input(UInt(log2Ceil(config.batchSize).W))))
 
   def getDirectionString(data: Data): String = {
     if (DataMirror.directionOf(data) == ActualDirection.Input) "input " else "output"
@@ -66,7 +65,6 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
   val modPorts: Seq[Seq[(String, Data)]] = {
     val common = ListBuffer(Seq(("clock", clock)), Seq(("enable", enable)))
     if (config.hasDutZone) common += Seq(("dut_zone", dut_zone.get))
-    if (config.isBatch) common += Seq(("dut_index", dut_index.get))
     // ExtModule implicitly adds io_* prefix to the IOs (because the IO val is named as io).
     // This is different from BlackBoxes.
     common.toSeq ++ io.elements.toSeq.reverse.map { case (name, data) =>
@@ -85,7 +83,6 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
     val filters: Seq[(DifftestBundle => Boolean, Seq[String])] = Seq(
       ((_: DifftestBundle) => true, Seq("io_coreid")),
       ((_: DifftestBundle) => config.hasDutZone, Seq("dut_zone")),
-      ((_: DifftestBundle) => config.isBatch, Seq("dut_index")),
       ((x: DifftestBundle) => x.isIndexed, Seq("io_index")),
       ((x: DifftestBundle) => x.isFlatten, Seq("io_address")),
     )
@@ -107,8 +104,7 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
        |)""".stripMargin
   val dpicFunc: String = {
     val dut_zone = if (config.hasDutZone) "dut_zone" else "0"
-    val dut_index = if (config.isBatch) "dut_index" else "0"
-    val packet = s"DUT_BUF(io_coreid, $dut_zone, $dut_index)->${gen.desiredCppName}"
+    val packet = s"DUT_BUF(io_coreid, $dut_zone, 0)->${gen.desiredCppName}"
     val index = if (gen.isIndexed) "[io_index]" else if (gen.isFlatten) "[io_address]" else ""
     s"""
        |$dpicFuncProto {
@@ -161,6 +157,185 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig)
   setInline(s"$desiredName.v", moduleBody)
 }
 
+class DPICBatch[T <: Seq[DifftestBundle]](template: T, bundle: GatewayBatchBundle, config: GatewayConfig)
+  extends ExtModule
+  with HasExtModuleInline {
+  val clock = IO(Input(Clock()))
+  val io = IO(Input(bundle))
+
+  def getModArgString(argName: String, data: Data): String = {
+    val widthString = if (data.getWidth == 1) "      " else f"[${data.getWidth - 1}%2d:0]"
+    s"input $widthString $argName"
+  }
+
+  def getDPICArgString(argName: String, data: Data, isC: Boolean): String = {
+    if (data.getWidth <= 8) {
+      if (isC) s"uint8_t $argName" else s"input byte $argName"
+    } else {
+      if (isC) s"const svBitVecVal $argName[${data.getWidth / 32}]" else s"input bit[${data.getWidth - 1}:0] $argName"
+    }
+  }
+
+  def getDPICBundleUnpack(gen: DifftestBundle): String = {
+    val unpack = ListBuffer.empty[String]
+    def byteCnt(data: Data): Int = (data.getWidth + (8 - data.getWidth % 8) % 8) / 8
+    case class ArgPair(name: String, width: Int, offset: Int, isVec: Boolean)
+    val argsWithWidthOffset: Seq[ArgPair] = {
+      val list = ListBuffer.empty[ArgPair]
+      var offset: Int = 0
+      for ((name, data) <- gen.elements.toSeq.reverse) {
+        if (name != "valid") {
+          data match {
+            case vec: Vec[_] => {
+              for ((v, i) <- vec.zipWithIndex) {
+                list += ArgPair(s"${name}_$i", byteCnt(v), offset, true)
+                offset += byteCnt(v)
+              }
+            }
+            case d: Data => {
+              list += ArgPair(name, byteCnt(d), offset, false)
+              offset += byteCnt(d)
+            }
+          }
+        }
+      }
+      list.toSeq
+    }
+    def varAssign(pair: ArgPair, prefix: String): String = {
+      val rhs = (0 until pair.width).map { i =>
+        val appendOffset = if (i != 0) s" << ${8 * i}" else ""
+        s"(uint${pair.width * 8}_t)data[offset + ${pair.offset + i}]$appendOffset"
+      }.mkString(" |\n        ")
+      val lhs = (pair.name, pair.isVec) match {
+        case (x, true)  => x.slice(0, x.lastIndexOf('_')) + s"[${x.split('_').last}]"
+        case (x, false) => x
+      }
+      s"$prefix$lhs = $rhs;"
+    }
+    val filterIn = ListBuffer("coreid")
+    val index = if (gen.isIndexed) {
+      filterIn += "index"
+      "[index]"
+    } else if (gen.isFlatten) {
+      filterIn += "address"
+      "[address]"
+    } else {
+      ""
+    }
+    unpack ++= argsWithWidthOffset.filter(p => filterIn.contains(p.name)).map(p => varAssign(p, ""))
+    val dut_zone = if (config.hasDutZone) "io_dut_zone" else "0"
+    val packet = s"DUT_BUF(coreid, $dut_zone, dut_index)->${gen.desiredCppName}"
+    unpack += s"auto packet = &($packet$index);"
+    if (gen.bits.hasValid && !gen.isFlatten) unpack += "packet->valid = true;"
+    val filterOut = Seq("coreid", "index", "address", "valid")
+    unpack ++= argsWithWidthOffset.filterNot(p => filterOut.contains(p.name)).map(p => varAssign(p, "packet->"))
+    unpack.toSeq.mkString("\n      ")
+  }
+
+  override def desiredName: String = "DifftestBatch"
+  val dpicFuncName: String = s"v_difftest_${desiredName.replace("Difftest", "")}"
+  val dpicFuncArgs: Seq[(String, Data)] = {
+    val common = Seq(("io_data", io.data), ("io_info", io.info))
+    if (config.hasDutZone) common ++ Seq(("io_dut_zone", io.dut_zone.get)) else common
+  }
+  val dpicFuncProto: String =
+    s"""
+       |extern "C" void $dpicFuncName (
+       |  ${dpicFuncArgs.map(arg => getDPICArgString(arg._1, arg._2, true)).mkString(",\n  ")}
+       |)""".stripMargin
+  val dpicFunc: String = {
+    val byteUnpack = dpicFuncArgs
+      .filter(_._2.getWidth > 8)
+      .map { case (name, data) =>
+        val array = name.replace("io_", "")
+        s"""
+           |  static uint8_t $array[${data.getWidth / 8}];
+           |  for (int i = 0; i < ${data.getWidth / 32}; i++) {
+           |    $array[i * 4] = (uint8_t)($name[i] & 0xFF);
+           |    $array[i * 4 + 1] = (uint8_t)(($name[i] >> 8) & 0xFF);
+           |    $array[i * 4 + 2] = (uint8_t)(($name[i] >> 16) & 0xFF);
+           |    $array[i * 4 + 3] = (uint8_t)(($name[i] >> 24) & 0xFF);
+           |  }
+           |""".stripMargin
+      }
+      .mkString("")
+    val bundleEnum = template.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchInterval", "BatchFinish")
+    val bundleAssign = template.zipWithIndex.map { case (t, idx) =>
+      s"""
+         |    else if (id == ${bundleEnum(idx)}) {
+         |      ${getDPICBundleUnpack(t)}
+         |    }
+        """.stripMargin
+    }.mkString("")
+    val infoLen = io.info.getWidth / 8
+    s"""
+       |enum DifftestBundle {
+       |  ${bundleEnum.mkString(",\n  ")}
+       |};
+       |$dpicFuncProto {
+       |  if (!diffstate_buffer) return;
+       |  uint64_t offset = 0;
+       |  uint32_t dut_index = 0;
+       |$byteUnpack
+       |  for (int i = 0; i < $infoLen; i+=3) {
+       |    uint8_t id = (uint8_t)info[i+2];
+       |    uint16_t len = (uint16_t)info[i+1] << 8 | (uint16_t)info[i];
+       |    uint32_t coreid, index, address;
+       |    if (id == BatchFinish) {
+       |      break;
+       |    }
+       |    else if (id == BatchInterval && i != 0) {
+       |      dut_index ++;
+       |      continue;
+       |    }
+       |    $bundleAssign
+       |    offset += len;
+       |  }
+       |}
+       |""".stripMargin
+  }
+
+  val modPorts: Seq[(String, Data)] = {
+    Seq(("clock", clock)) ++ io.elements.toSeq.reverse.map { case (name, data) => (s"io_$name", data) }
+  }
+  val moduleBody: String = {
+    val dpicDecl =
+      s"""
+         |import "DPI-C" function void $dpicFuncName (
+         |  ${dpicFuncArgs.map(arg => getDPICArgString(arg._1, arg._2, false)).mkString(",\n  ")}
+         |);
+         |""".stripMargin
+    val gfifoInitial =
+      if (config.isNonBlock)
+        s"""
+           |`ifdef PALLADIUM
+           |initial $$ixc_ctrl("gfifo", "$dpicFuncName");
+           |`endif
+           |""".stripMargin
+      else ""
+    val modPortsString = modPorts.map(i => getModArgString(i._1, i._2)).mkString(",\n  ")
+    s"""
+       |`include "DifftestMacros.v"
+       |module $desiredName(
+       |  $modPortsString
+       |);
+       |`ifndef SYNTHESIS
+       |`ifdef DIFFTEST
+       |$dpicDecl
+       |$gfifoInitial
+       |  always @(posedge clock) begin
+       |    if (io_enable)
+       |      $dpicFuncName (${dpicFuncArgs.map(_._1).mkString(", ")});
+       |  end
+       |`endif
+       |`endif
+       |endmodule
+       |""".stripMargin
+  }
+
+  setInline(s"$desiredName.v", moduleBody)
+}
+
 private class DummyDPICWrapper[T <: DifftestBundle](gen: T, config: GatewayConfig) extends Module {
   val io = IO(Input(new GatewayBundle(gen, config)))
   val dpic = Module(new DPIC(gen, config))
@@ -170,23 +345,15 @@ private class DummyDPICWrapper[T <: DifftestBundle](gen: T, config: GatewayConfi
   if (config.hasDutZone) dpic.dut_zone.get := io.dut_zone.get
 }
 
-private class DummyDPICBatchWrapper[T <: Seq[DifftestBundle]](bundles: T, config: GatewayConfig) extends Module {
-  val io = IO(Input(new GatewayBatchBundle(bundles, config)))
-  val interfaces = ListBuffer.empty[(String, String, String)]
-  for ((group, ifo) <- io.data.zip(io.info)) {
-    for (gen <- group) {
-      val dpic = Module(new DPIC(gen.cloneType, config))
-      dpic.clock := clock
-      dpic.enable := gen.bits.getValid && io.enable
-      dpic.io := gen
-      if (config.hasDutZone) dpic.dut_zone.get := io.dut_zone.get
-      dpic.dut_index.get := ifo
-      if (!interfaces.map(_._1).contains(dpic.dpicFuncName)) {
-        val interface = (dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc)
-        interfaces += interface
-      }
-    }
-  }
+private class DummyDPICBatchWrapper[T <: Seq[DifftestBundle]](
+  template: T,
+  bundle: GatewayBatchBundle,
+  config: GatewayConfig,
+) extends Module {
+  val io = IO(Input(bundle))
+  val dpic = Module(new DPICBatch(template, bundle, config))
+  dpic.clock := clock
+  dpic.io := io
 }
 
 object DPIC {
@@ -202,10 +369,11 @@ object DPIC {
     }
   }
 
-  def batch(template: MixedVec[DifftestBundle], bundle: GatewayBatchBundle, config: GatewayConfig): Unit = {
-    val module = Module(new DummyDPICBatchWrapper(template.toSeq.map(_.cloneType), config))
+  def batch(template: Seq[DifftestBundle], bundle: GatewayBatchBundle, config: GatewayConfig): Unit = {
+    val module = Module(new DummyDPICBatchWrapper(template.map(_.cloneType), bundle.cloneType, config))
     module.io := bundle
-    interfaces ++= module.interfaces.toSeq
+    val dpic = module.dpic
+    interfaces += ((dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc))
   }
 
   def collect(): GatewayResult = {
@@ -219,6 +387,9 @@ object DPIC {
     interfaceCpp += ""
     interfaceCpp += "#include <cstdint>"
     interfaceCpp += "#include \"diffstate.h\""
+    interfaceCpp += "#ifdef CONFIG_DIFFTEST_BATCH"
+    interfaceCpp += "#include \"svdpi.h\""
+    interfaceCpp += "#endif // CONFIG_DIFFTEST_BATCH"
     interfaceCpp += ""
     interfaceCpp +=
       """

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -262,7 +262,6 @@ object DifftestModule {
   private val instances = ListBuffer.empty[(DifftestBundle, String)]
   private val cppMacros = ListBuffer.empty[String]
   private val vMacros = ListBuffer.empty[String]
-  private var structPacked = false
 
   def apply[T <: DifftestBundle](
     gen: T,
@@ -295,10 +294,9 @@ object DifftestModule {
     cppMacros ++= gateway.cppMacros
     vMacros ++= gateway.vMacros
     instances ++= gateway.instances
-    structPacked = gateway.structPacked.getOrElse(false)
 
     if (cppHeader.isDefined) {
-      generateCppHeader(cpu, cppHeader.get)
+      generateCppHeader(cpu, cppHeader.get, gateway.structPacked.getOrElse(false))
     }
     generateVeriogHeader()
 
@@ -328,7 +326,7 @@ object DifftestModule {
     difftest
   }
 
-  def generateCppHeader(cpu: String, style: String): Unit = {
+  def generateCppHeader(cpu: String, style: String, structPacked: Boolean): Unit = {
     val difftestCpp = ListBuffer.empty[String]
     difftestCpp += "#ifndef __DIFFSTATE_H__"
     difftestCpp += "#define __DIFFSTATE_H__"

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -72,6 +72,7 @@ case class GatewayResult(
   cppMacros: Seq[String] = Seq(),
   vMacros: Seq[String] = Seq(),
   instances: Seq[(DifftestBundle, String)] = Seq(),
+  structPacked: Option[Boolean] = None,
   step: Option[UInt] = None,
 ) {
   def +(that: GatewayResult): GatewayResult = {
@@ -79,6 +80,7 @@ case class GatewayResult(
       cppMacros = cppMacros ++ that.cppMacros,
       vMacros = vMacros ++ that.vMacros,
       instances = instances ++ that.instances,
+      structPacked = if (structPacked.isDefined) structPacked else that.structPacked,
       step = if (step.isDefined) step else that.step,
     )
   }
@@ -114,6 +116,7 @@ object Gateway {
       val endpoint = Module(new GatewayEndpoint(instances.toSeq, config))
       GatewayResult(
         instances = endpoint.instances,
+        structPacked = Some(config.isBatch),
         step = Some(endpoint.step),
       )
     } else {

--- a/vcs.mk
+++ b/vcs.mk
@@ -50,7 +50,7 @@ endif
 endif
 
 ifeq ($(VCS),verilator)
-VCS_FLAGS += --exe --cc --main --top-module $(VCS_TOP) -Wno-WIDTH
+VCS_FLAGS += --exe --cc --main --top-module $(VCS_TOP) -Wno-WIDTH --max-num-width 150000
 VCS_FLAGS += --instr-count-dpi 1 --timing +define+VERILATOR_5
 VCS_FLAGS += -Mdir $(VCS_BUILD_DIR)  --compiler gcc
 VCS_CXXFLAGS += -std=c++20

--- a/verilator.mk
+++ b/verilator.mk
@@ -99,6 +99,7 @@ VERILATOR_FLAGS =                   \
   +define+RANDOMIZE_GARBAGE_ASSIGN  \
   +define+RANDOMIZE_DELAY=0         \
   -Wno-STMTDLY -Wno-WIDTH           \
+  --max-num-width 150000            \
   --assert --x-assign unique        \
   --stats-vars                      \
   --output-split 30000              \


### PR DESCRIPTION
We pack DPIC of DifftestBundles on Hardware and unpack it in Software. So tens of DPIC called times will be reduced to one, which reduce sync times in platform such as palladium.

It can speed up full-difftest of XiangShan from 0.23MHz to 0.29MHz with GlobalEnable,Squash and Gfifo(Non-block) in Palladium. Without Gfifo, it can speed up from 0.025 MHz to 0.11MHz.

Difftest cycle delayed for DifftestBundles to collect valid bundles in bundleNum cycles, which cause delayed comparision result.

BatchInterval and BatchFinish are appended to infoVec to seperate DPIC packed for different Cycle. Other elements contains BundleType and BundleLen to help unpack DataVec.

Now we set maximum data byte packed as 3900, and maximum info byte packed as 90, because Palladium limits total bytes of gfifo param should less than 4000.

We add `--max-num-width` verilator args to increase bit width limits. See related issue https://github.com/verilator/verilator/issues/2082

For misalignment of struct member, we add packed attribute to struct declaration so all member will be aligned by byte, which helps use memcpy for DPIC.

Note: When run full-difftest in XiangShan with Batch mode, it is possible to contains only one cycle DPICs each time for larger possible maximum bytes each cycle. So diffStateSelect should also be open for VCS and Palladium