### PR TITLE
Difftest: delay step for both emu and simv

### DIFF
--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -151,7 +151,7 @@ class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) exten
   val step = IO(Output(UInt(config.stepWidth.W)))
   if (config.isBatch) {
     val batch = Batch(squashed, config)
-    step := batch.step
+    step := RegNext(batch.step, 0.U)
     if (config.hasDutZone) zoneControl.get.enable := batch.enable
 
     val bundle = Wire(new GatewayBatchBundle(squashed.toSeq.map(_.cloneType), config))
@@ -166,7 +166,7 @@ class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) exten
     if (config.hasGlobalEnable) {
       squashed_enable := VecInit(squashed.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
     }
-    step := Mux(squashed_enable, 1.U, 0.U)
+    step := RegNext(squashed_enable, 0.U)
     if (config.hasDutZone) zoneControl.get.enable := squashed_enable
 
     for (id <- 0 until squashed.length) {

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -175,22 +175,12 @@ always @(posedge clock) begin
 end
 
 `ifndef TB_NO_DPIC
-reg [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] difftest_step_delay;
-always @(posedge clock) begin
-  if (reset) begin
-    difftest_step_delay <= 0;
-  end
-  else begin
-    difftest_step_delay <= difftest_step;
-  end
-end
-
 `ifdef CONFIG_DIFFTEST_DEFERRED_RESULT
 wire simv_result;
 DeferredControl deferred(
   .clock(clock),
   .reset(reset),
-  .step(difftest_step_delay),
+  .step(difftest_step),
   .simv_result(simv_result)
 );
 `endif // CONFIG_DIFFTEST_DEFERRED_RESULT
@@ -221,9 +211,9 @@ always @(posedge clock) begin
       $finish();
     end
 `else
-    else if (|difftest_step_delay) begin
+    else if (|difftest_step) begin
       // check errors
-      if (simv_nstep(difftest_step_delay)) begin
+      if (simv_nstep(difftest_step)) begin
         $display("DIFFTEST FAILED at cycle %d", n_cycles);
         $finish();
       end


### PR DESCRIPTION
For simv, we delay step to ensure DPIC_step behind DPIC_transfer. For emu, when signal enable is high on current cycle, it will be read by Software, however DPIC will be called next cycle because verilog will use previous cycle signals as always block condition.

Such problem is not exposed when step size is fixed, so emu used to step before DPIC. Now we move delay logic to Gateway, so it can be shared by both emu and simv.