### PR TITLE
vcs: enable search for missing sv files

### DIFF
--- a/vcs.mk
+++ b/vcs.mk
@@ -75,7 +75,7 @@ VCS_FLAGS += +define+UNIT_DELAY +define+no_warning
 # C++ flags
 VCS_FLAGS += -CFLAGS "$(VCS_CXXFLAGS)" -LDFLAGS "$(VCS_LDFLAGS)"
 # search build for other missing verilog files
-VCS_FLAGS += -y $(RTL_DIR) +libext+.v
+VCS_FLAGS += -y $(RTL_DIR) +libext+.v +libext+.sv
 # search generated-src for verilog included files
 VCS_FLAGS += +incdir+$(GEN_VSRC_DIR)
 # enable fsdb dump


### PR DESCRIPTION
Now we may generate RTL to .sv, we should also search for .sv files for VCS.
By the way, previously use vcs=verilator will not trigger error because verilator will search files automatically. 