### PR TITLE
palladium: add scripts

### DIFF
--- a/palladium.mk
+++ b/palladium.mk
@@ -1,6 +1,7 @@
 PLDM_TB_TOP  		 = tb_top
 PLDM_TOP_MODULE 	 = $(SIM_TOP)
 
+PLDM_SCRIPTS_DIR 	 = $(abspath ./scripts/palladium)
 PLDM_BUILD_DIR 		 = $(abspath $(BUILD_DIR)/pldm-compile)
 PLDM_CC_OBJ_DIR	 	 = $(abspath $(PLDM_BUILD_DIR)/cc_obj)
 

--- a/scripts/palladium/argConfigs.qel
+++ b/scripts/palladium/argConfigs.qel
@@ -1,0 +1,4 @@
+* $test$plusargs TB_IMPORT
+* $value$plusargs TB_IMPORT
+* $finish TB_IMPORT
+* $random TB_IMPORT

--- a/scripts/palladium/clock_gen.xel
+++ b/scripts/palladium/clock_gen.xel
@@ -1,0 +1,2 @@
+clockOption -add {technology CAKE 1}
+clockFrequency -add {clock 50MHz}

--- a/scripts/palladium/compilerOptions.qel
+++ b/scripts/palladium/compilerOptions.qel
@@ -1,0 +1,19 @@
+emulatorConfiguration -add "host $env(PLDM_HOST)" {boards *}
+
+###########################
+# compilerOption
+###########################
+# compilerOption -add {visionMode FV}
+
+
+###########################
+# precompileOption
+###########################
+precompileOption -add noReset1X
+precompileOption -add keepSourceless
+
+###########################
+# compileFindOptions
+###########################
+set    compileScript "compileFind -all -max_trials 3 -crit_paths 100 -names_crit"
+append compileScript ";userData -dump all ud.dump"

--- a/scripts/palladium/run.tcl
+++ b/scripts/palladium/run.tcl
@@ -1,0 +1,6 @@
+debug .
+host $env(PLDM_HOST)
+xc on -zt0 -xt0 -tbrun
+date
+run -swap
+run

--- a/scripts/palladium/run_debug.tcl
+++ b/scripts/palladium/run_debug.tcl
@@ -1,0 +1,11 @@
+debug .
+host $env(PLDM_HOST)
+xc xt0 zt0 on -tbrun
+database -open pldm_db
+probe -create -all -depth all tb_top -database pldm_db
+xeset traceMemSize 20000
+xeset triggerPos 2
+run -swap
+run
+database -upload
+xc off


### PR DESCRIPTION
Now we release related palladium scripts and user should set PLDM_HOST for internal information.
We use wildcard for boards occupation in compilerOptions.qel, it can automatically choose approprate boards count. User can also set it manully like {boards 0+1.1+1.2}, which means occupy 1 board and 2 extra domains. It can be estimated by gate count in xe.msg.