### PR TITLE
Fix DPIC arg declaration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -308,19 +308,19 @@ jobs:
             rm -r difftest
             cp -r $GITHUB_WORKSPACE .
 
-      - name: Verilator Build with VCS Top (with Select)
+      - name: Verilator Build with VCS Top (with DutZone)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            sed -i 's/diffstateSelect: Boolean = false/diffstateSelect: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/hasDutZone: Boolean = false/hasDutZone: Boolean = true/' difftest/src/main/scala/Gateway.scala
             make simv VCS=verilator -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
-      - name: Verilator Build with VCS Top (with Squash Select Batch and Global Enable)
+      - name: Verilator Build with VCS Top (with Squash DutZone Batch and Global Enable)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
@@ -328,7 +328,7 @@ jobs:
             source ./env.sh
             make clean
             sed -i 's/isSquash: Boolean = false/isSquash: Boolean = true/' difftest/src/main/scala/Gateway.scala
-            sed -i 's/diffstateSelect: Boolean = false/diffstateSelect: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/hasDutZone: Boolean = false/hasDutZone: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/isBatch: Boolean = false/isBatch: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/hasGlobalEnable: Boolean = false/hasGlobalEnable: Boolean = true/' difftest/src/main/scala/Gateway.scala
             make simv VCS=verilator -j2

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -58,11 +58,11 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
     argString.mkString(" ")
   }
 
-  protected val commonPorts: Seq[(String, Data)] = {
-    val common = Seq(("clock", clock), ("enable", enable))
-    if (config.hasDutZone) common ++ Seq(("dut_zone", dut_zone.get)) else common
+  protected val commonPorts = Seq(("clock", clock), ("enable", enable))
+  def modPorts: Seq[Seq[(String, Data)]] = {
+    val ports = if (config.hasDutZone) commonPorts ++ Seq(("dut_zone", dut_zone.get)) else commonPorts
+    ports.map(Seq(_))
   }
-  def modPorts: Seq[Seq[(String, Data)]] = commonPorts.map(Seq(_))
 
   def desiredName: String
   def dpicFuncName: String = s"v_difftest_${desiredName.replace("Difftest", "")}"
@@ -149,7 +149,7 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig) extends DPICBase(
 
   override def dpicFuncAssigns: Seq[String] = {
     val filters: Seq[(DifftestBundle => Boolean, Seq[String])] = Seq(
-      ((_: DifftestBundle) => true, Seq("io_coreid")),
+      ((_: DifftestBundle) => true, Seq("io_coreid", "dut_zone")),
       ((x: DifftestBundle) => x.isIndexed, Seq("io_index")),
       ((x: DifftestBundle) => x.isFlatten, Seq("io_address")),
     )

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -31,13 +31,12 @@ case class GatewayConfig(
   isSquash: Boolean = false,
   squashReplay: Boolean = false,
   replaySize: Int = 256,
-  diffStateSelect: Boolean = false,
+  hasDutZone: Boolean = false,
   isBatch: Boolean = false,
   batchSize: Int = 32,
   isNonBlock: Boolean = false,
 ) {
   if (squashReplay) require(isSquash)
-  def hasDutZone: Boolean = diffStateSelect
   def dutZoneSize: Int = if (hasDutZone) 2 else 1
   def dutZoneWidth: Int = log2Ceil(dutZoneSize)
   def dutBufLen: Int = if (isBatch) batchSize else 1
@@ -45,7 +44,7 @@ case class GatewayConfig(
   def stepWidth: Int = log2Ceil(maxStep + 1)
   def hasDeferredResult: Boolean = isNonBlock
   def needTraceInfo: Boolean = squashReplay
-  def needEndpoint: Boolean = hasGlobalEnable || diffStateSelect || isBatch || isSquash
+  def needEndpoint: Boolean = hasGlobalEnable || hasDutZone || isBatch || isSquash
   def needPreprocess: Boolean = hasDutZone || isBatch || isSquash || needTraceInfo
   // Macros Generation for Cpp and Verilog
   def cppMacros: Seq[String] = {


### PR DESCRIPTION
CI used to have a spelling mistake of diffStateSelect, which cause sed incorrectly. Now we rename it to hasDutZone directly, means we have different zones of DUT_buffer, each zone may have 1 or batchSize space.

We clearify inherit and override of DPIC. DPIC/DPICBatch should override modPorts corresponding to input format. CommonPorts(clock, enable) will be filtered from DPICargs, other ports will be used in DPICAssigns