### PR TITLE
Squash replay: optimized by NEMU store log

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,7 +321,7 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
             cd difftest && git restore src
 
-      - name: Verilator Build with VCS Top (with Squash DutZone Batch and Global Enable PerfCnt)
+      - name: Verilator Build with VCS Top (with GlobalEnable DutZone Squash SquashReplay Batch PerfCnt)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
@@ -330,6 +330,7 @@ jobs:
             make clean
             sed -i 's/isSquash: Boolean = false/isSquash: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/hasDutZone: Boolean = false/hasDutZone: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/squashReplay: Boolean = false/squashReplay: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/isBatch: Boolean = false/isBatch: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/hasGlobalEnable: Boolean = false/hasGlobalEnable: Boolean = true/' difftest/src/main/scala/Gateway.scala
             make simv DIFFTEST_PERFCNT=1 VCS=verilator -j2

--- a/config/config.h
+++ b/config/config.h
@@ -113,7 +113,7 @@ extern unsigned long EMU_FLASH_SIZE;
 // whether to check l2tlb response
 // #define DEBUG_L2TLB
 
-// whether to enable REF record origin data of memory and restore
+// whether to enable REF/GoldenMemory record origin data of memory and restore
 #ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
 #define ENABLE_STORE_LOG
 #endif // CONFIG_DIFFTEST_SQUASH_REPLAY
@@ -156,7 +156,6 @@ extern unsigned long EMU_FLASH_SIZE;
 #ifndef DEBUG_MEM_BASE
 #define DEBUG_MEM_BASE 0x38020000
 #endif
-
 
 // -----------------------------------------------------------------------
 // Do not touch

--- a/config/config.h
+++ b/config/config.h
@@ -113,6 +113,11 @@ extern unsigned long EMU_FLASH_SIZE;
 // whether to check l2tlb response
 // #define DEBUG_L2TLB
 
+// whether to enable REF record origin data of memory and restore
+#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
+#define ENABLE_STORE_LOG
+#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
+
 // -----------------------------------------------------------------------
 // Simulator run ahead config
 // -----------------------------------------------------------------------
@@ -151,6 +156,7 @@ extern unsigned long EMU_FLASH_SIZE;
 #ifndef DEBUG_MEM_BASE
 #define DEBUG_MEM_BASE 0x38020000
 #endif
+
 
 // -----------------------------------------------------------------------
 // Do not touch

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -171,8 +171,6 @@ void Difftest::update_nemuproxy(int coreid, size_t ram_size = 0) {
   proxy = new REF_PROXY(coreid, ram_size);
 #ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
   proxy_ss = (REF_PROXY*)malloc(sizeof(REF_PROXY));
-  squash_memsize = ram_size;
-  squash_membuf = (char *)malloc(squash_memsize);
 #endif // CONFIG_DIFFTEST_SQUASH_REPLAY
 }
 
@@ -189,7 +187,8 @@ void Difftest::squash_snapshot() {
   memcpy(state_ss, state, sizeof(DiffState));
   memcpy(proxy_ss, proxy, sizeof(REF_PROXY));
   proxy->ref_csrcpy(squash_csr_buf, REF_TO_DUT);
-  proxy->ref_memcpy(PMEM_BASE, squash_membuf, squash_memsize, REF_TO_DUT);
+  proxy->ref_store_log_reset();
+  proxy->set_store_log(true);
 }
 
 void Difftest::squash_replay() {
@@ -199,7 +198,7 @@ void Difftest::squash_replay() {
   memcpy(proxy, proxy_ss, sizeof(REF_PROXY));
   proxy->ref_regcpy(&proxy->regs_int, DUT_TO_REF, false);
   proxy->ref_csrcpy(squash_csr_buf, DUT_TO_REF);
-  proxy->ref_memcpy(PMEM_BASE, squash_membuf, squash_memsize, DUT_TO_REF);
+  proxy->ref_store_log_restore();
   difftest_squash_replay(replay_idx);
 }
 #endif // CONFIG_DIFFTEST_SQUASH_REPLAY
@@ -216,6 +215,8 @@ int Difftest::step() {
   isSquash = squash_check();
   if (isSquash) {
     squash_snapshot();
+  } else {
+    proxy->set_store_log(false);
   }
 #endif // CONFIG_DIFFTEST_SQUASH_REPLAY
 

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -368,8 +368,6 @@ protected:
   DiffState *state_ss = NULL;
   REF_PROXY *proxy_ss = NULL;
   uint64_t squash_csr_buf[4096];
-  long squash_memsize;
-  char *squash_membuf;
   bool squash_check();
   void squash_snapshot();
   void squash_replay();

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -366,7 +366,8 @@ protected:
   int replay_idx;
 
   DiffState *state_ss = NULL;
-  REF_PROXY *proxy_ss = NULL;
+  int proxy_reg_size = 0;
+  uint8_t *proxy_reg_ss = NULL;
   uint64_t squash_csr_buf[4096];
   bool squash_check();
   void squash_snapshot();

--- a/src/test/csrc/difftest/goldenmem.h
+++ b/src/test/csrc/difftest/goldenmem.h
@@ -45,4 +45,9 @@ void paddr_write(uint64_t addr, word_t data, int len);
 bool is_sfence_safe(uint64_t addr, int len);
 bool in_pmem(uint64_t addr);
 
+#ifdef ENABLE_STORE_LOG
+void goldenmem_set_store_log(bool enable);
+void goldenmem_store_log_reset();
+void goldenmem_store_log_restore();
+#endif
 #endif

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -72,6 +72,11 @@ AbstractRefProxy::AbstractRefProxy(int coreid, size_t ram_size, const char *env,
     ref_set_ramsize(ram_size);
   }
 
+#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
+  check_and_assert(ref_store_log_reset);
+  check_and_assert(ref_store_log_restore);
+#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
+
   ref_init();
 }
 

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -72,10 +72,10 @@ AbstractRefProxy::AbstractRefProxy(int coreid, size_t ram_size, const char *env,
     ref_set_ramsize(ram_size);
   }
 
-#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
+#ifdef ENABLE_STORE_LOG
   check_and_assert(ref_store_log_reset);
   check_and_assert(ref_store_log_restore);
-#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
+#endif // ENABLE_STORE_LOG
 
   ref_init();
 }

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -222,6 +222,20 @@ public:
   }
 #endif // ENABLE_STORE_LOG
 
+  inline int get_reg_size() {
+    return sizeof(DifftestArchIntRegState) + sizeof(DifftestCSRState) + sizeof(uint64_t)
+#ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
+    + sizeof(DifftestArchFpRegState)
+#endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
+#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
+    + sizeof(DifftestArchVecRegState)
+#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
+#ifdef CONFIG_DIFFTEST_VECCSRSTATE
+    + sizeof(DifftestVecCSRState)
+#endif // CONFIG_DIFFTEST_VECCSRSTATE
+    ;
+  }
+
   inline int get_status() {
     return ref_status ? ref_status() : 0;
   }

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -70,6 +70,7 @@ class RefProxyConfig {
 public:
   bool ignore_illegal_mem_access = false;
   bool debug_difftest = false;
+  bool enable_store_log = false;
 };
 
 #define REF_BASE(f)                                                           \
@@ -92,6 +93,14 @@ public:
 #define REF_RUN_AHEAD(f)
 #endif
 
+#ifdef ENABLE_STORE_LOG
+#define REF_STORE_LOG(f) \
+  f(ref_store_log_reset, difftest_store_log_reset, void, )                    \
+  f(ref_store_log_restore, difftest_store_log_restore, void, )
+#else
+#define REF_STORE_LOG(f)
+#endif
+
 #ifdef DEBUG_MODE_DIFF
 #define REF_DEBUG_MODE(f) \
   f(debug_mem_sync, debug_mem_sync, void, uint64_t, void *, size_t)
@@ -102,6 +111,7 @@ public:
 #define REF_ALL(f) \
   REF_BASE(f)       \
   REF_RUN_AHEAD(f)  \
+  REF_STORE_LOG(f)  \
   REF_DEBUG_MODE(f)
 
 #define REF_OPTIONAL(f)                                                       \
@@ -204,6 +214,13 @@ public:
     config.ignore_illegal_mem_access = ignored;
     sync_config();
   }
+
+#ifdef ENABLE_STORE_LOG
+  inline void set_store_log(bool enable = false) {
+    config.enable_store_log = enable;
+    sync_config();
+  }
+#endif // ENABLE_STORE_LOG
 
   inline int get_status() {
     return ref_status ? ref_status() : 0;


### PR DESCRIPTION
Previous we use naive memcpy for NEMU memory snapshot. Now we complete more efficient memory snapshot and recovery with NEMU store log.

Call ref_store_log_reset and set_store_log, then we can record origin data of every pmem_write for this execution. When REF and DUT comparation trigger error, call ref_store_log_restore, then memory will recover in reverse order.

ENABLE_STORE_LOG macro added to config.