### PR TITLE
vcs: add support for --max-instrs option

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -30,6 +30,7 @@ static bool has_reset = false;
 static char bin_file[256] = "ram.bin";
 static char *flash_bin_file = NULL;
 static bool enable_difftest = true;
+static uint64_t max_instrs = 0;
 
 extern "C" void set_bin_file(char *s) {
   printf("ram image:%s\n",s);
@@ -40,6 +41,10 @@ extern "C" void set_flash_bin(char *s) {
   printf("flash image:%s\n",s);
   flash_bin_file = (char *)malloc(256);
   strcpy(flash_bin_file, s);
+}
+
+extern "C" void set_max_instrs(uint64_t mc) {
+  max_instrs = mc;
 }
 
 extern const char *difftest_ref_so;
@@ -84,6 +89,14 @@ extern "C" int simv_step() {
         eprintf(ANSI_COLOR_RED "Unknown trap code: %d\n" ANSI_COLOR_RESET, trapCode);
     }
     return trapCode + 1;
+  }
+
+  if (max_instrs != 0) { // 0 for no limit
+    auto trap = difftest[0]->get_trap_event();
+    if(max_instrs < trap->instrCnt) {
+      eprintf(ANSI_COLOR_GREEN "EXCEEDED MAX INSTR: %ld\n" ANSI_COLOR_RESET,max_instrs);
+      return 3;// STATE_LIMIT_EXCEEDED
+    }
   }
 
   if (enable_difftest) {

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -23,6 +23,7 @@ import "DPI-C" function void set_flash_bin(string bin);
 import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
 import "DPI-C" function void simv_init();
+import "DPI-C" function void set_max_instrs(longint mc);
 `ifndef CONFIG_DIFFTEST_DEFERRED_RESULT
 import "DPI-C" function int simv_nstep(int step);
 `endif // CONFIG_DIFFTEST_DEFERRED_RESULT
@@ -55,6 +56,7 @@ string bin_file;
 string flash_bin_file;
 string wave_type;
 string diff_ref_so;
+reg [63:0] max_instrs;
 reg [63:0] max_cycles;
 
 initial begin
@@ -124,6 +126,11 @@ initial begin
   if ($test$plusargs("max-cycles")) begin
     $value$plusargs("max-cycles=%d", max_cycles);
     $display("set max cycles: %d", max_cycles);
+  end
+  // set exit instrs const
+  if ($test$plusargs("max-instrs")) begin
+    $value$plusargs("max-instrs=%d", max_instrs);
+    set_max_instrs(max_instrs);
   end
 end
 


### PR DESCRIPTION
Add a per-instruction counter to exit, primarily for checkpoint testing