### PR TITLE
InternalStep: pack Data transmit and Step control

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -321,18 +321,50 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
             cd difftest && git restore src
 
-      - name: Verilator Build with VCS Top (with GlobalEnable DutZone Squash SquashReplay Batch PerfCnt)
+      - name: Verilator Build with VCS Top (with Batch InternalStep PerfCnt)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            sed -i 's/isSquash: Boolean = false/isSquash: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/isBatch: Boolean = false/isBatch: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/hasInternalStep: Boolean = false/hasInternalStep: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            make simv DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
+            cd difftest && git restore src
+
+      - name: Verilator Build with VCS Top (with DutZone GlobalEnable Squash SquashReplay Batch PerfCnt)
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
             sed -i 's/hasDutZone: Boolean = false/hasDutZone: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/hasGlobalEnable: Boolean = false/hasGlobalEnable: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/isSquash: Boolean = false/isSquash: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/squashReplay: Boolean = false/squashReplay: Boolean = true/' difftest/src/main/scala/Gateway.scala
             sed -i 's/isBatch: Boolean = false/isBatch: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            make simv DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
+            cd difftest && git restore src
+
+      - name: Verilator Build with VCS Top (with GlobalEnable Squash SquashReplay Batch InternalStep NonBlock PerfCnt)
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
             sed -i 's/hasGlobalEnable: Boolean = false/hasGlobalEnable: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/isSquash: Boolean = false/isSquash: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/squashReplay: Boolean = false/squashReplay: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/isBatch: Boolean = false/isBatch: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/hasInternalStep: Boolean = false/hasInternalStep: Boolean = true/' difftest/src/main/scala/Gateway.scala
+            sed -i 's/isNonBlock: Boolean = false/isNonBlock: Boolean = true/' difftest/src/main/scala/Gateway.scala
             make simv DIFFTEST_PERFCNT=1 VCS=verilator -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so

--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -85,12 +85,12 @@ class BatchEndpoint(template: Seq[DifftestBundle], bundles: Seq[DifftestBundle],
     Delayer(gen.bits.getValid & global_enable, i)
   }.toSeq)
 
-  val MaxDataByteLen = 3900
+  val MaxDataByteLen = config.batchArgByteLen._1
   val MaxDataByteWidth = log2Ceil(MaxDataByteLen)
   val MaxDataBitLen = MaxDataByteLen * 8
   val infoWidth = (new BatchInfo).getWidth
   // Append BatchInterval and BatchFinish Info
-  val MaxInfoByteLen = math.min((config.batchSize * (bundleNum + 1) + 1) * (infoWidth / 8), 90)
+  val MaxInfoByteLen = math.min((config.batchSize * (bundleNum + 1) + 1) * (infoWidth / 8), config.batchArgByteLen._2)
   val MaxInfoByteWidth = log2Ceil(MaxInfoByteLen)
   val MaxInfoBitLen = MaxInfoByteLen * 8
 

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -186,13 +186,15 @@ extern "C" void simv_nstep(uint8_t step) {
     return;
 #else
 extern "C" uint8_t simv_nstep(uint8_t step) {
-#endif // CONFIG_DIFFTEST_DEFERRED_RESULT
-#ifdef CONFIG_DIFFTEST_PERFCNT
-  difftest_calls[perf_simv_nstep]++;
-  difftest_bytes[perf_simv_nstep] += 1;
-#endif // CONFIG_DIFFTEST_PERFCNT
   if (difftest == NULL)
     return 0;
+#endif // CONFIG_DIFFTEST_DEFERRED_RESULT
+#ifdef CONFIG_DIFFTEST_PERFCNT
+#ifndef CONFIG_DIFFTEST_INTERNAL_STEP
+  difftest_calls[perf_simv_nstep]++;
+  difftest_bytes[perf_simv_nstep] += 1;
+#endif // CONFIG_DIFFTEST_INTERNAL_STEP
+#endif // CONFIG_DIFFTEST_PERFCNT
   difftest_switch_zone();
   for (int i = 0; i < step; i++) {
     int ret = simv_step();

--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -3,11 +3,12 @@
 module DeferredControl(
   input clock,
   input reset,
+`ifndef CONFIG_DIFFTEST_INTERNAL_STEP
   input [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] step,
+`endif // CONFIG_DIFFTEST_INTERNAL_STEP
   output reg [7:0] simv_result
 );
 
-import "DPI-C" function void simv_nstep(byte step);
 import "DPI-C" context function void set_deferred_result_scope();
 
 initial begin
@@ -20,15 +21,18 @@ function void set_deferred_result(byte result);
   simv_result = result;
 endfunction
 
+`ifdef PALLADIUM
+initial $ixc_ctrl("sfifo", "set_deferred_result");
+`endif // PALLADIUM
+
+`ifndef CONFIG_DIFFTEST_INTERNAL_STEP
+import "DPI-C" function void simv_nstep(int step);
+
 `ifdef CONFIG_DIFFTEST_NONBLOCK
 `ifdef PALLADIUM
 initial $ixc_ctrl("gfifo", "simv_nstep");
 `endif // PALLADIUM
 `endif // CONFIG_DIFFTEST_NONBLOCK
-
-`ifdef PALLADIUM
-initial $ixc_ctrl("sfifo", "set_deferred_result");
-`endif // PALLADIUM
 
 always @(posedge clock) begin
   if (reset) begin
@@ -38,6 +42,7 @@ always @(posedge clock) begin
     simv_nstep(step);
   end
 end
+`endif // CONFIG_DIFFTEST_INTERNAL_STEP
 
 endmodule;
 `endif // CONFIG_DIFFTEST_DEFERRED_RESULT

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -226,7 +226,9 @@ wire [7:0] simv_result;
 DeferredControl deferred(
   .clock(clock),
   .reset(reset),
+`ifndef CONFIG_DIFFTEST_INTERNAL_STEP
   .step(difftest_step),
+`endif // CONFIG_DIFFTEST_INTERNAL_STEP
   .simv_result(simv_result)
 );
 `else


### PR DESCRIPTION
* Configurable batchByteLen:  

For better performace without GFIFO. In palladium, we can pass maximum 4000 byte in Gfifo Func (enable isNonBlock), and 8000 byte in Other Func.
With configurable byteLen, speed will increase from 70 K to 98 K without GFIFO.

* Interval step: pack Data transmit and Step control   

Previous when batch is not supported, we use multiple DPIC func to transmit DiffState. Since the DPIC order in one beat is uncertain, we use the step to mark the transmission is finished.

With batch mode, data will be transmit at single func, so we can also pack step to reduce sync times. It can reduce DPIC calls to half. Speed will increase from 95 K to 98 K without GFIFO, 26 K to 27.5 K with GFIFO.

When IntervalStep is enable, step in TOP IO will be default 0. We hold this unused signal for fixed TOP IO interface.

By the way, when the feature is supported. DUT will only use a single port to interface with REF. This helps us to migrate Difftest for other platform.

