### PR TITLE
Add TB_NO_DPIC/SYNTHESIS macros around all DPIC funcs

### DIFF
--- a/palladium.mk
+++ b/palladium.mk
@@ -54,12 +54,7 @@ endif
 IXCOM_FLAGS 	+= +tfconfig+$(PLDM_SCRIPTS_DIR)/argConfigs.qel
 
 # Verilog Files
-PLDM_VSRC_DIR  	 = $(RTL_DIR) $(GEN_VSRC_DIR)
-ifeq ($(SYNTHESIS), 1)
-PLDM_VSRC_DIR 	+= $(abspath ./src/test/vsrc/vcs) $(abspath ./src/test/vsrc/common/SimJTAG.v)
-else
-PLDM_VSRC_DIR 	+= $(abspath ./src/test/vsrc)
-endif
+PLDM_VSRC_DIR  	 = $(RTL_DIR) $(GEN_VSRC_DIR) $(abspath ./src/test/vsrc)
 PLDM_VFILELIST 	 = $(PLDM_BUILD_DIR)/vfiles.f
 IXCOM_FLAGS   	+= -F $(PLDM_VFILELIST)
 

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -174,6 +174,8 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |  output reg enable
        |);
        |
+       |`ifndef SYNTHESIS
+       |`ifdef DIFFTEST
        |import "DPI-C" context function void set_squash_scope();
        |
        |initial begin
@@ -188,6 +190,8 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |  enable = en;
        |endtask
        |$replay_task
+       |`endif // DIFFTEST
+       |`endif // SYNTHESIS
        |
        |// For the simulation argument +squash_cycles=N
        |reg [63:0] squash_cycles;

--- a/src/test/vsrc/common/SimJTAG.v
+++ b/src/test/vsrc/common/SimJTAG.v
@@ -1,8 +1,8 @@
 // See LICENSE.SiFive for license details.
 //VCS coverage exclude_file
-`ifdef SYNTHESIS
+`ifdef TB_NO_DPIC
     `define DISABLE_SIMJTAG_DPIC
-`endif // SYNTHESIS
+`endif // TB_NO_DPIC
 `ifndef DISABLE_SIMJTAG_DPIC
 import "DPI-C" function int jtag_tick
 (

--- a/src/test/vsrc/common/assert.v
+++ b/src/test/vsrc/common/assert.v
@@ -14,7 +14,9 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+`ifndef TB_NO_DPIC
 import "DPI-C" function void xs_assert
 (
   input  longint    line
 );
+`endif

--- a/src/test/vsrc/common/ref.v
+++ b/src/test/vsrc/common/ref.v
@@ -14,12 +14,14 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+`ifndef TB_NO_DPIC
 import "DPI-C" function byte pte_helper (
   input  longint satp,
   input  longint vpn,
   output longint pte,
   output byte    level
 );
+`endif // TB_NO_DPIC
 
 module PTEHelper(
   input             clock,
@@ -32,17 +34,21 @@ module PTEHelper(
 );
   always @(posedge clock) begin
     if (enable) begin
+`ifndef TB_NO_DPIC
       pf <= pte_helper(satp, vpn, pte, level);
+`endif // TB_NO_DPIC
     end
   end
 endmodule
 
+`ifndef TB_NO_DPIC
 import "DPI-C" function longint amo_helper(
   input byte    cmd,
   input longint addr,
   input longint wdata,
   input byte    mask
 );
+`endif // TB_NO_DPIC
 
 module AMOHelper(
   input             clock,
@@ -56,7 +62,9 @@ module AMOHelper(
 
   always @(posedge clock) begin
     if (enable) begin
+`ifndef TB_NO_DPIC
       rdata <= amo_helper(cmd, addr, wdata, mask);
+`endif // TB_NO_DPIC
     end
   end
 

--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -1,4 +1,5 @@
 `include "DifftestMacros.v"
+`ifndef TB_NO_DPIC
 `ifdef CONFIG_DIFFTEST_DEFERRED_RESULT
 module DeferredControl(
   input clock,
@@ -46,3 +47,4 @@ end
 
 endmodule;
 `endif // CONFIG_DIFFTEST_DEFERRED_RESULT
+`endif // TB_NO_DPIC

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -133,6 +133,11 @@ initial begin
     set_no_diff();
   end
 `ifdef ENABLE_WORKLOAD_SWITCH
+  // set exit instrs const
+  if ($test$plusargs("max-instrs")) begin
+    $value$plusargs("max-instrs=%d", max_instrs);
+    set_max_instrs(max_instrs);
+  end
   // set workload list
   if ($test$plusargs("workload-list")) begin
     $value$plusargs("workload-list=%s", workload_list);
@@ -149,11 +154,6 @@ initial begin
   if ($test$plusargs("max-cycles")) begin
     $value$plusargs("max-cycles=%d", max_cycles);
     $display("set max cycles: %d", max_cycles);
-  end
-  // set exit instrs const
-  if ($test$plusargs("max-instrs")) begin
-    $value$plusargs("max-instrs=%d", max_instrs);
-    set_max_instrs(max_instrs);
   end
 end
 


### PR DESCRIPTION
We add SYNTHESIS macros around generated DPIC funcs, and TB_NO_DPIC macros around DPIC funcs in fixed vsrc of TB.

With this change, difftest with non-default GatewayConfig can run in both SYNTHESIS or not.