### PR TITLE
vcs: add dramsim on emu run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,12 +115,7 @@ endif
 # co-simulation with DRAMsim3
 ifeq ($(WITH_DRAMSIM3),1)
 SIM_CXXFLAGS += -I$(DRAMSIM3_HOME)/src
-SYSTEM_VAR = $(shell uname -a)
-ifeq ($(findstring "Ubuntu",$(SYSTEM_VAR)),)  
-	SIM_CXXFLAGS += -DWITH_DRAMSIM3 -DDRAMSIM3_CONFIG=\\\"$(DRAMSIM3_HOME)/configs/XiangShan.ini\\\" -DDRAMSIM3_OUTDIR=\\\"$(BUILD_DIR)\\\"
-else
-	SIM_CXXFLAGS += -DWITH_DRAMSIM3 -DDRAMSIM3_CONFIG=\"$(DRAMSIM3_HOME)/configs/XiangShan.ini\" -DDRAMSIM3_OUTDIR=\"$(BUILD_DIR)\"
-endif
+SIM_CXXFLAGS += -DWITH_DRAMSIM3 -DDRAMSIM3_CONFIG=\\\"$(DRAMSIM3_HOME)/configs/XiangShan.ini\\\" -DDRAMSIM3_OUTDIR=\\\"$(BUILD_DIR)\\\"
 SIM_LDFLAGS  += $(DRAMSIM3_HOME)/build/libdramsim3.a
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,12 @@ endif
 # co-simulation with DRAMsim3
 ifeq ($(WITH_DRAMSIM3),1)
 SIM_CXXFLAGS += -I$(DRAMSIM3_HOME)/src
-SIM_CXXFLAGS += -DWITH_DRAMSIM3 -DDRAMSIM3_CONFIG=\\\"$(DRAMSIM3_HOME)/configs/XiangShan.ini\\\" -DDRAMSIM3_OUTDIR=\\\"$(BUILD_DIR)\\\"
+SYSTEM_VAR = $(shell uname -a)
+ifeq ($(findstring "Ubuntu",$(SYSTEM_VAR)),)  
+	SIM_CXXFLAGS += -DWITH_DRAMSIM3 -DDRAMSIM3_CONFIG=\\\"$(DRAMSIM3_HOME)/configs/XiangShan.ini\\\" -DDRAMSIM3_OUTDIR=\\\"$(BUILD_DIR)\\\"
+else
+	SIM_CXXFLAGS += -DWITH_DRAMSIM3 -DDRAMSIM3_CONFIG=\"$(DRAMSIM3_HOME)/configs/XiangShan.ini\" -DDRAMSIM3_OUTDIR=\"$(BUILD_DIR)\"
+endif
 SIM_LDFLAGS  += $(DRAMSIM3_HOME)/build/libdramsim3.a
 endif
 

--- a/palladium.mk
+++ b/palladium.mk
@@ -27,6 +27,9 @@ PLDM_MACRO_FLAGS 	+= $(PLDM_EXTRA_MACRO)
 ifeq ($(WORKLOAD_SWITCH),1)
 PLDM_MACRO_FLAGS  	+= +define+ENABLE_WORKLOAD_SWITCH
 endif
+ifeq ($(WITH_DRAMSIM3),1)
+PLDM_MACRO_FLAGS  	+= +define+WITH_DRAMSIM3
+endif
 
 # UA Args
 IXCOM_FLAGS  	 = -clean -64 -ua +sv +ignoreSimVerCheck +xe_alt_xlm
@@ -79,6 +82,10 @@ PLDM_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(PLDM_CSRC_DIR) -name "*.cpp")
 PLDM_CXXFLAGS 	 = -m64 -c -fPIC -g -std=c++11 -I$(PLDM_IXCOM) -I$(PLDM_SIMTOOL)
 PLDM_CXXFLAGS 	+= $(SIM_CXXFLAGS) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
 
+ifeq ($(WITH_DRAMSIM3),1)
+PLDM_LD_LIB  	 = -L $(DRAMSIM3_HOME)/ -ldramsim3 -Wl,-rpath-link=$(DRAMSIM3_HOME)/libdramsim3.so
+endif
+
 # XMSIM Flags
 XMSIM_FLAGS 	 = --xmsim -64 +xcprof -profile -PROFTHREAD
 ifneq ($(SYNTHESIS), 1)
@@ -111,7 +118,7 @@ pldm-build: $(PLDM_BUILD_DIR) $(PLDM_VFILELIST) $(PLDM_CC_OBJ_DIR)
 	ixcom $(IXCOM_FLAGS) -l $(PLDM_BUILD_DIR)/ixcom.log	&& \
 	cd $(PLDM_CC_OBJ_DIR) 					&& \
 	$(CC) $(PLDM_CXXFLAGS) $(PLDM_CXXFILES)			&& \
-	$(CC) -o $(DPILIB_EMU) -m64 -shared *.o
+	$(CC) -o $(DPILIB_EMU) -m64 -shared *.o $(PLDM_LD_LIB)
 endif
 
 pldm-run: $(PLDM_BUILD_DIR)

--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -444,14 +444,19 @@ void dramsim3_init() {
 }
 
 void dramsim3_step() {
+  if (dram == NULL)
+    return;
   dram->tick();
 }
 
 void dramsim3_finish() {
   delete dram;
+  dram = NULL;
 }
 
 uint64_t memory_response(bool isWrite) {
+  if (dram == NULL)
+    return 0;
   auto response = (isWrite) ? dram->check_write_response() : dram->check_read_response();
   if (response) {
     auto meta = static_cast<dramsim3_meta *>(response->req->meta);
@@ -464,6 +469,8 @@ uint64_t memory_response(bool isWrite) {
 }
 
 bool memory_request(uint64_t address, uint32_t id, bool isWrite) {
+  if (dram == NULL)
+    return false;
   if (dram->will_accept(address, isWrite)) {
     auto req = new CoDRAMRequest();
     auto meta = new dramsim3_meta;

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -179,6 +179,12 @@ void difftest_deferred_result(uint8_t result) {
 }
 #endif // CONFIG_DIFFTEST_DEFERRED_RESULT
 
+#ifdef WITH_DRAMSIM3
+extern "C" void simv_tick() {
+  dramsim3_step();
+}
+#endif
+
 void simv_finish() {
   common_finish();
   flash_finish();

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -24,6 +24,9 @@ import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
 import "DPI-C" function byte simv_init();
 import "DPI-C" function void set_max_instrs(longint mc);
+`ifdef WITH_DRAMSIM3
+import "DPI-C" function void simv_tick();
+`endif // WITH_DRAMSIM3
 `ifdef ENABLE_WORKLOAD_SWITCH
 import "DPI-C" function void set_workload_list(string path);
 `endif // ENABLE_WORKLOAD_SWITCH
@@ -256,6 +259,11 @@ always @(posedge clock) begin
     end
 
 `ifndef TB_NO_DPIC
+`ifdef WITH_DRAMSIM3
+    if (n_cycles) begin
+      simv_tick();
+    end
+`endif // WITH_DRAMSIM3
     // difftest
     if (!n_cycles) begin
       if (simv_init()) begin


### PR DESCRIPTION
Support for enabling dramsim3 programs to run on Paradine. DRAMSIM3_HOME Note: Recompile dramsim3 on Paladin and set DRAMSIM3_HOME, then add DRAMSIM3_HOME to LD_LIBRARY_PATH so that it links to the dynamic library correctly