### PR TITLE
palladium: fix scripts

### DIFF
--- a/palladium.mk
+++ b/palladium.mk
@@ -117,7 +117,7 @@ pldm-run: $(PLDM_BUILD_DIR)
 
 pldm-debug: $(PLDM_BUILD_DIR)
 	cd $(PLDM_BUILD_DIR) 					&& \
-	xeDebug $(XMSIM_FLAGS) -gui -xedebugargs -fsdb -input $(PLDM_SCRIPTS_DIR)/run_debug.tcl -l debug-$$(date +%Y%m%d-%H%M%S).log
+	xeDebug $(XMSIM_FLAGS) -fsdb -input $(PLDM_SCRIPTS_DIR)/run_debug.tcl -l debug-$$(date +%Y%m%d-%H%M%S).log
 
 pldm-clean:
 	rm -rf $(PLDM_BUILD_DIR)

--- a/scripts/palladium/run.tcl
+++ b/scripts/palladium/run.tcl
@@ -4,3 +4,4 @@ xc on -zt0 -xt0 -tbrun
 date
 run -swap
 run
+exit

--- a/scripts/palladium/run_debug.tcl
+++ b/scripts/palladium/run_debug.tcl
@@ -9,3 +9,4 @@ run -swap
 run
 database -upload
 xc off
+exit


### PR DESCRIPTION
We add exit at the end of run/debug scripts to make simualation exit automatically.
And we disable gui windows for debug by default.