### PR TITLE
simv, emu: set dut before checking difftest_state

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -82,9 +82,14 @@ void difftest_switch_zone() {
     diffstate_buffer[i]->switch_zone();
   }
 }
-int difftest_step() {
+void difftest_set_dut() {
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i]->dut = diffstate_buffer[i]->next();
+  }
+}
+int difftest_step() {
+  difftest_set_dut();
+  for (int i = 0; i < NUM_CORES; i++) {
     int ret = difftest[i]->step();
     if (ret) {
       return ret;

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -62,19 +62,20 @@ int difftest_state() {
   return -1;
 }
 
-int difftest_nstep(int step) {
-  int last_trap_code = STATE_RUNNING;
+int difftest_nstep(int step, bool enable_diff) {
   difftest_switch_zone();
   for (int i = 0; i < step; i++) {
-    if (difftest_step()) {
-      last_trap_code = STATE_ABORT;
-      return last_trap_code;
+    if (enable_diff) {
+      if (difftest_step())
+        return STATE_ABORT;
+    } else {
+      difftest_set_dut();
     }
-    last_trap_code = difftest_state();
-    if (last_trap_code != STATE_RUNNING)
-      return last_trap_code;
+    int status = difftest_state();
+    if (status != STATE_RUNNING)
+      return status;
   }
-  return last_trap_code;
+  return 0;
 }
 
 void difftest_switch_zone() {

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -392,7 +392,7 @@ protected:
 extern Difftest **difftest;
 int difftest_init();
 
-int difftest_nstep(int step);
+int difftest_nstep(int step, bool enable_diff);
 void difftest_switch_zone();
 void difftest_set_dut();
 int difftest_step();

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -394,6 +394,7 @@ int difftest_init();
 
 int difftest_nstep(int step);
 void difftest_switch_zone();
+void difftest_set_dut();
 int difftest_step();
 int difftest_state();
 void difftest_finish();

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -125,6 +125,13 @@ extern "C" uint8_t simv_step() {
     return SIMV_FAIL;
   }
 
+  if (enable_difftest) {
+    if (difftest_step())
+      return SIMV_FAIL;
+  } else {
+    difftest_set_dut();
+  }
+
   if (difftest_state() != -1) {
     int trapCode = difftest_state();
     for (int i = 0; i < NUM_CORES; i++) {
@@ -151,14 +158,7 @@ extern "C" uint8_t simv_step() {
     }
   }
 
-  if (enable_difftest) {
-    if (difftest_step())
-      return SIMV_FAIL;
-    else
-      return 0;
-  } else {
-    return 0;
-  }
+  return 0;
 }
 
 #ifdef CONFIG_DIFFTEST_DEFERRED_RESULT

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -782,11 +782,7 @@ int Emulator::tick() {
     difftest_trace_write(step);
   }
 
-  if (args.enable_diff) {
-    trapCode = difftest_nstep(step);
-  } else {
-    trapCode = difftest_state();
-  }
+  trapCode = difftest_nstep(step, args.enable_diff);
 
   if (trapCode != STATE_RUNNING) {
 #ifdef FUZZER_LIB


### PR DESCRIPTION
In batch mode, dut may point to serveral possible position of diffstate_buffer. Trap check in difftest_state also relies on correct dut position. So we should set dut before difftest_state. 

Previously we set dut only when difftest_step, however even disable diff(difftest without proxy), we should also set correct dut ptr. So we seperate the logic into difftest_set_dut for both diff/no-diff, and difftest_step will also call it. Same change applys for both simv and emu.

This problem is hidden before, because trap may be check by next step of same batch occasionally. Failure occus when trap happens at last step of batch.