### PR TITLE
Add the reflective DataMirror for future methods

### DIFF
--- a/src/main/scala/common/LogPerfControl.scala
+++ b/src/main/scala/common/LogPerfControl.scala
@@ -15,8 +15,9 @@
 
 package difftest.common
 
-import chisel3.util._
 import chisel3._
+import chisel3.util._
+import difftest.util.DataMirror._
 
 class LogPerfControl extends Bundle {
   val timer = UInt(64.W)
@@ -55,12 +56,8 @@ private class LogPerfHelper extends BlackBox with HasBlackBoxInline {
 }
 
 object LogPerfControl {
-  def apply(): LogPerfControl = {
-    Module(new LogPerfHelper).io
-  }
-
   private val instances = scala.collection.mutable.ListBuffer.empty[LogPerfControl]
-  def reuse(checker: LogPerfControl => Boolean): LogPerfControl = {
-    instances.find(checker).getOrElse(instances.addOne(apply()).last)
-  }
+  private def instantiate(): LogPerfControl = instances.addOne(WireInit(Module(new LogPerfHelper).io)).last
+
+  def apply(): LogPerfControl = instances.find(_.isVisible).getOrElse(instantiate())
 }

--- a/src/main/scala/util/DataMirror.scala
+++ b/src/main/scala/util/DataMirror.scala
@@ -1,0 +1,37 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.util
+
+import chisel3._
+
+import scala.reflect.runtime.currentMirror
+import scala.reflect.runtime.universe._
+
+private[difftest] object DataMirror {
+  private def loadMethodOfObject(methodName: String, objectName: String): Option[MethodMirror] = {
+    val moduleSymb = currentMirror.staticModule(objectName)
+    val methodSymb = moduleSymb.info.decls.find(m => m.isMethod && m.name.toString == methodName).map(_.asMethod)
+    val obj = currentMirror.reflectModule(moduleSymb).instance
+    methodSymb.map(s => currentMirror.reflect(obj).reflectMethod(s))
+  }
+
+  implicit class DataMirrorLoader(data: Data) {
+    def isVisible: Boolean = {
+      val method = loadMethodOfObject("isVisible", "chisel3.reflect.DataMirror")
+      method.exists(_.apply(data).asInstanceOf[Boolean])
+    }
+  }
+}


### PR DESCRIPTION
This commit brings a DataMirror in the difftest.util package. It now includes a method called isVisible which returns the visibility of a Data object, which was originally brought into Chisel 6.1.0 for the first time.

Since this method does not exist in older versions of Chisel, and DiffTest must be compatible with legacy versions of Chisel, we use Scala reflection features to load this method dynamically. If not found, this method always returns false.