### PR TITLE
simv: add default /dev/zero for +workload

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -30,7 +30,7 @@
 #endif // CONFIG_DIFFTEST_PERFCNT
 
 static bool has_reset = false;
-static char bin_file[256] = "ram.bin";
+static char bin_file[256] = "/dev/zero";
 static char *flash_bin_file = NULL;
 static bool enable_difftest = true;
 static uint64_t max_instrs = 0;


### PR DESCRIPTION
/dev/zero can be seen as a file with only NULL. This change enable us to use only +flash to set workload for bootrom(flash).