### PR TITLE
emu: fix default return val of difftest_nstep

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -75,7 +75,7 @@ int difftest_nstep(int step, bool enable_diff) {
     if (status != STATE_RUNNING)
       return status;
   }
-  return 0;
+  return STATE_RUNNING;
 }
 
 void difftest_switch_zone() {


### PR DESCRIPTION
The default running status val is -1 for emu, 0 for simv. difftest_nstep perform n step comparison for emu, it should return STATE_RUNNING instead of 0 by defualt.

We fix the problem caused by PR(https://github.com/OpenXiangShan/difftest/pull/308)