### PR TITLE
Fix Palladium CFLAGS for path parse

### DIFF
--- a/palladium.mk
+++ b/palladium.mk
@@ -77,7 +77,7 @@ DPILIB_EMU    	 = $(PLDM_BUILD_DIR)/libdpi_emu.so
 PLDM_CSRC_DIR 	 = $(abspath ./src/test/csrc/vcs)
 PLDM_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(PLDM_CSRC_DIR) -name "*.cpp")
 PLDM_CXXFLAGS 	 = -m64 -c -fPIC -g -std=c++11 -I$(PLDM_IXCOM) -I$(PLDM_SIMTOOL)
-PLDM_CXXFLAGS 	+= $(SIM_CXXFLAGS) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
+PLDM_CXXFLAGS 	+= $(subst \\\", \", $(SIM_CXXFLAGS)) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
 
 # XMSIM Flags
 XMSIM_FLAGS 	 = --xmsim -64 +xcprof -profile -PROFTHREAD


### PR DESCRIPTION
Previou for Verilator/VCS, SIM_CXXFLAGS will be passed twice, so we use \\\" for path, make it visible as " inside the code. 
For Palladium, we pass these CFLAGS directly to gcc, so we should replace \\\" with \", to make it treat correctly in compilation.