### PR TITLE
Add built-in Perf for difftest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -304,7 +304,7 @@ jobs:
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            make simv MILL_ARGS="--difftest-config Z" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            make simv MILL_ARGS="--difftest-config ZP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
@@ -315,7 +315,7 @@ jobs:
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            make simv MILL_ARGS="--difftest-config BI" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            make simv MILL_ARGS="--difftest-config BIP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
@@ -326,7 +326,7 @@ jobs:
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            make simv MILL_ARGS="--difftest-config ZESRB" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            make simv MILL_ARGS="--difftest-config ZESRBP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
@@ -337,7 +337,7 @@ jobs:
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            make simv MILL_ARGS="--difftest-config ESRBIN" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            make simv MILL_ARGS="--difftest-config ESRBINP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 

--- a/scripts/palladium/argConfigs.qel
+++ b/scripts/palladium/argConfigs.qel
@@ -2,3 +2,4 @@
 * $value$plusargs TB_IMPORT
 * $finish TB_IMPORT
 * $random TB_IMPORT
+* $fwrite GFIFO

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -36,6 +36,7 @@ case class GatewayConfig(
   batchSize: Int = 32,
   hasInternalStep: Boolean = false,
   isNonBlock: Boolean = false,
+  hasBuiltInPerf: Boolean = false,
 ) {
   def dutZoneSize: Int = if (hasDutZone) 2 else 1
   def dutZoneWidth: Int = log2Ceil(dutZoneSize)
@@ -105,6 +106,7 @@ object Gateway {
       case 'B' => config = config.copy(isBatch = true)
       case 'I' => config = config.copy(hasInternalStep = true)
       case 'N' => config = config.copy(isNonBlock = true)
+      case 'P' => config = config.copy(hasBuiltInPerf = true)
       case x   => println(s"Unknown Gateway Config $x")
     }
     config.check()

--- a/src/main/scala/common/LogPerfControl.scala
+++ b/src/main/scala/common/LogPerfControl.scala
@@ -61,3 +61,15 @@ object LogPerfControl {
 
   def apply(): LogPerfControl = instances.find(_.isVisible).getOrElse(instantiate())
 }
+
+object DifftestPerf {
+  def apply(perfName: String, perfCnt: UInt) = {
+    val helper = LogPerfControl.apply()
+    val counter = RegInit(0.U(64.W))
+    val next_counter = WireInit(counter + perfCnt)
+    counter := Mux(helper.clean, 0.U, next_counter)
+    when(helper.dump) {
+      printf(p"[DIFFTEST_PERF][time=${helper.timer}] $perfName, $next_counter\n")
+    }
+  }
+}

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -213,7 +213,6 @@ SimTop sim(
 
 assign difftest_logCtrl_level = 0;
 assign difftest_perfCtrl_clean = 0;
-assign difftest_perfCtrl_dump = 0;
 assign difftest_uart_in_ch = 8'hff;
 
 always @(posedge clock) begin
@@ -242,6 +241,12 @@ initial simv_result = 0;
 `ifdef ENABLE_WORKLOAD_SWITCH
 assign workload_switch = simv_result == `SIMV_DONE;
 `endif // ENABLE_WORKLOAD_SWITCH
+`endif // TB_NO_DPIC
+
+`ifndef TB_NO_DPIC
+assign difftest_perfCtrl_dump = simv_result != 0;
+`else
+assign difftest_perfCtrl_dump = 0;
 `endif // TB_NO_DPIC
 
 reg [63:0] n_cycles;


### PR DESCRIPTION
We will dump built-in Perf for difftest at the end of simulation. These printfs can be controled by difftest_perfCtrl_dump.

For emu, we call `Emulator::trigger_stat_dump`. For simv, we raise difftest_perfCtrl_dump when simv_result is not zero.