### PR TITLE
Squash: tick squashed state independently between Groups

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -105,6 +105,11 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   // returns a Seq indicating the squash dependencies. Default: empty
   // Only when one of the dependencies is valid, this bundle is squashed.
   val squashDependency: Seq[String] = Seq()
+  // returns a seq of Group name of this bundle, Default: REF
+  // Only bundles with same GroupName will affect others' squash state.
+  // Some bundle will have several GroupName, such as LoadEvent
+  // Optional GroupName: REF / GOLDENMEM
+  val squashGroup: Seq[String] = Seq("REF")
   // returns a squashed, right-value Bundle. Default: overriding `base` with `this`
   def squash(base: DifftestBundle): DifftestBundle = this
 }
@@ -200,6 +205,7 @@ class DiffVecCSRState extends VecCSRState with DifftestBundle {
 
 class DiffSbufferEvent extends SbufferEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "sbuffer"
+  override val squashGroup: Seq[String] = Seq("GOLDENMEM")
 }
 
 class DiffStoreEvent extends StoreEvent with DifftestBundle with DifftestWithIndex {
@@ -208,28 +214,33 @@ class DiffStoreEvent extends StoreEvent with DifftestBundle with DifftestWithInd
 
 class DiffLoadEvent extends LoadEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "load"
+  override val squashGroup: Seq[String] = Seq("REF", "GOLDENMEM")
   // TODO: currently we assume it can be dropped
   override def supportsSquashBase: Bool = true.B
 }
 
 class DiffAtomicEvent extends AtomicEvent with DifftestBundle {
   override val desiredCppName: String = "atomic"
+  override val squashGroup: Seq[String] = Seq("GOLDENMEM")
 }
 
 class DiffL1TLBEvent extends L1TLBEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "l1tlb"
+  override val squashGroup: Seq[String] = Seq("GOLDENMEM")
   // TODO: currently we assume it can be dropped
   override def supportsSquashBase: Bool = true.B
 }
 
 class DiffL2TLBEvent extends L2TLBEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "l2tlb"
+  override val squashGroup: Seq[String] = Seq("GOLDENMEM")
   // TODO: currently we assume it can be dropped
   override def supportsSquashBase: Bool = true.B
 }
 
 class DiffRefillEvent extends RefillEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "refill"
+  override val squashGroup: Seq[String] = Seq("GOLDENMEM")
   // TODO: currently we assume it can be dropped
   override def supportsSquashBase: Bool = true.B
 }
@@ -253,6 +264,7 @@ class DiffRunaheadRedirectEvent extends RunaheadRedirectEvent with DifftestBundl
 class DiffTraceInfo extends TraceInfo with DifftestBundle {
   override val desiredCppName: String = "trace_info"
 
+  override val squashGroup: Seq[String] = Seq("REF", "GOLDENMEM")
   override def supportsSquashBase: Bool = true.B
 
   override def squash(base: DifftestBundle): DifftestBundle = {

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -20,6 +20,7 @@ import chisel3.experimental.ExtModule
 import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
+import difftest.common.DifftestPerf
 
 object Squash {
   def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): MixedVec[DifftestBundle] = {
@@ -31,42 +32,13 @@ object Squash {
 
 class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
-  val out = IO(Output(MixedVec(bundles)))
-
-  val state = RegInit(0.U.asTypeOf(MixedVec(bundles)))
-
-  val in_replay =
-    in.filter(_.desiredCppName == "trace_info").map(_.asInstanceOf[DiffTraceInfo].in_replay).foldLeft(false.B)(_ || _)
-
-  // Mark the initial commit events as non-squashable for initial state synchronization.
-  val hasValidCommitEvent = VecInit(state.filter(_.desiredCppName == "commit").map(_.bits.getValid).toSeq).asUInt.orR
-  val isInitialEvent = RegInit(true.B)
-  when(isInitialEvent && hasValidCommitEvent) {
-    isInitialEvent := false.B
-  }
-  val tick_first_commit = isInitialEvent && hasValidCommitEvent
-
-  // If one of the bundles cannot be squashed, the others are not squashed as well.
-  val supportsSquashVec = VecInit(in.zip(state).map { case (i, s) => i.supportsSquash(s) }.toSeq)
-  val supportsSquash = supportsSquashVec.asUInt.andR
-
-  // If one of the bundles cannot be the new base, the others are not as well.
-  val supportsSquashBaseVec = VecInit(state.map(_.supportsSquashBase).toSeq)
-  val supportsSquashBase = supportsSquashBaseVec.asUInt.andR
-
-  val control = Module(new SquashControl(config))
-  control.clock := clock
-  control.reset := reset
-
-  // Submit the pending non-squashable events immediately.
-  val should_tick = !control.enable || !supportsSquash || !supportsSquashBase || tick_first_commit || in_replay
-  out := Mux(should_tick, state, 0.U.asTypeOf(MixedVec(bundles)))
 
   // Sometimes, the bundle may have squash dependencies.
+  // Only when one of the dependencies is valid, this bundle is squashed.
   val do_squash = WireInit(VecInit.fill(in.length)(true.B))
-  in.zip(do_squash).foreach { case (i, do_m) =>
+  in.zip(do_squash).foreach { case (i, do_s) =>
     if (i.squashDependency.nonEmpty) {
-      do_m := VecInit(
+      do_s := VecInit(
         in.filter(b => i.squashDependency.contains(b.desiredCppName))
           .map(bundle => {
             // Only if the corresponding bundle is valid, we update this bundle
@@ -77,6 +49,84 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
     }
   }
 
+  val control = Module(new SquashControl(config))
+  control.clock := clock
+  control.reset := reset
+  val in_replay =
+    in.filter(_.desiredCppName == "trace_info").map(_.asInstanceOf[DiffTraceInfo].in_replay).foldLeft(false.B)(_ || _)
+  val global_tick = !control.enable || in_replay
+
+  val uniqBundles = bundles.distinctBy(_.desiredCppName)
+  // Tick and Submit the pending non-squashable events immediately.
+  val want_tick_vec = WireInit(VecInit.fill(uniqBundles.length)(false.B))
+  // Record Tick Cause for each SquashGroup
+  val group_name_vec = uniqBundles.flatMap(_.squashGroup).distinct
+  val group_tick_vec = VecInit(group_name_vec.map { g =>
+    uniqBundles
+      .zip(want_tick_vec)
+      .filter(_._1.squashGroup.contains(g))
+      .map { case (u, wt) =>
+        if (config.hasBuiltInPerf) DifftestPerf(s"SquashTick_${g}_${u.desiredCppName}", wt)
+        wt
+      }
+      .reduce(_ || _)
+  })
+
+  val s_out_vec = uniqBundles.zip(want_tick_vec).map { case (u, wt) =>
+    val (s_in, s_do) = in.zip(do_squash).filter(_._1.desiredCppName == u.desiredCppName).unzip
+    val squasher = Module(new Squasher(s_in.map(chiselTypeOf(_)).toSeq, config))
+    squasher.in.zip(s_in).foreach { case (i, s_i) => i := s_i }
+    squasher.do_squash.zip(s_do).foreach { case (d, s_d) => d := s_d }
+    wt := squasher.want_tick
+    val group_tick =
+      group_name_vec
+        .zip(group_tick_vec)
+        .collect { case (n, gt) if u.squashGroup.contains(n) => gt }
+        .foldLeft(false.B)(_ || _)
+    squasher.should_tick := group_tick || global_tick
+    squasher.out
+  }
+  // Flatten Seq[MixedVec[DifftestBundle]] to MixedVec[DifftestBundle]
+  val out = IO(Output(MixedVec(s_out_vec.flatMap(chiselTypeOf(_)))))
+  s_out_vec.zipWithIndex.foreach { case (vec, i) =>
+    val base = if (i != 0) {
+      s_out_vec.take(i).map(_.length).sum
+    } else 0
+    vec.zipWithIndex.foreach { case (gen, idx) =>
+      out(base + idx) := gen
+    }
+  }
+}
+
+// It will help do squash for bundles with same Class, return tick and state
+class Squasher(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+  val do_squash = IO(Input(Vec(bundles.length, Bool())))
+  val out = IO(Output(MixedVec(bundles)))
+  val want_tick = IO(Output(Bool()))
+  val should_tick = IO(Input(Bool()))
+
+  val state = RegInit(0.U.asTypeOf(MixedVec(bundles)))
+
+  // If one of the bundles cannot be squashed, the others are not squashed as well.
+  val supportsSquashVec = VecInit(in.zip(state).map { case (i, s) => i.supportsSquash(s) }.toSeq)
+  val supportsSquash = supportsSquashVec.asUInt.andR
+
+  // If one of the bundles cannot be the new base, the others are not as well.
+  val supportsSquashBaseVec = VecInit(state.map(_.supportsSquashBase).toSeq)
+  val supportsSquashBase = supportsSquashBaseVec.asUInt.andR
+
+  // Mark the initial commit events as non-squashable for initial state synchronization.
+  val tick_first_commit = if (in.head.desiredCppName == "commit") {
+    val hasValidCommitEvent = VecInit(state.map(_.bits.getValid).toSeq).asUInt.orR
+    val isInitialEvent = RegInit(true.B)
+    when(isInitialEvent && hasValidCommitEvent) {
+      isInitialEvent := false.B
+    }
+    isInitialEvent && hasValidCommitEvent
+  } else WireInit(false.B)
+  want_tick := !supportsSquash || !supportsSquashBase || tick_first_commit
+
   for (((i, d), s) <- in.zip(do_squash).zip(state)) {
     when(should_tick) {
       s := i
@@ -84,6 +134,8 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
       s := i.squash(s)
     }
   }
+
+  out := Mux(should_tick, state, 0.U.asTypeOf(out))
 }
 
 class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleInline {


### PR DESCRIPTION
We seperate DiffTestBundles into REF/GoldenMem, tick of Bundle will only affected by it's Group. Default Group is REF. Note some bundle will have several Group, because it will affect both REF and GoldenMem state. Bundles allowed to be dropped will ticked incidentially when it's Group tick.

We also add built-in perf to count the tick cause of each Group.