### PR TITLE
fix: workload switch

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -177,6 +177,11 @@ void difftest_deferred_result(uint8_t result) {
   svSetScope(deferredResultScope);
   set_deferred_result(result);
 }
+
+extern "C" void clean_deferred_result() {
+  set_deferred_result(SIMV_RUN);
+}
+
 #endif // CONFIG_DIFFTEST_DEFERRED_RESULT
 
 #ifdef WITH_DRAMSIM3

--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -9,9 +9,8 @@ module DeferredControl(
 `endif // CONFIG_DIFFTEST_INTERNAL_STEP
   output reg [7:0] simv_result
 );
-
 import "DPI-C" context function void set_deferred_result_scope();
-
+import "DPI-C" context function void clean_deferred_result();
 initial begin
   set_deferred_result_scope();
   simv_result = 8'b0;
@@ -19,7 +18,7 @@ end
 
 export "DPI-C" function set_deferred_result;
 function void set_deferred_result(byte result);
-  simv_result = result;
+  simv_result <= result;
 endfunction
 
 `ifdef PALLADIUM
@@ -37,9 +36,9 @@ initial $ixc_ctrl("gfifo", "simv_nstep");
 
 always @(posedge clock) begin
   if (reset) begin
-    simv_result <= 8'b0;
+    clean_deferred_result();
   end
-  else if (step != 0) begin
+  else if (step != 0 && simv_result == 8'b0) begin
     simv_nstep(step);
   end
 end


### PR DESCRIPTION
fix: This ensures that the workload switch will not get stuck and will not be triggered repeatedly after the NonBlock is enabled