### PR TITLE
ram: add gcpt-restore option for VCS

### DIFF
--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -432,7 +432,7 @@ void LinearizedFootprintsMemory::save_linear_memory(const char *filename) {
   out_file.close();
 }
 
-void overwrite_ram(char *gcpt_restore, uint64_t overwrite_nbytes) {
+void overwrite_ram(const char *gcpt_restore, uint64_t overwrite_nbytes) {
   InputReader *reader = new FileReader(gcpt_restore);
   int overwrite_size = reader->read_all(simMemory->as_ptr(), overwrite_nbytes);
   Info("Overwrite %d bytes from file %s.\n", overwrite_size, gcpt_restore);

--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -435,7 +435,7 @@ void LinearizedFootprintsMemory::save_linear_memory(const char *filename) {
 void overwrite_ram(char *gcpt_restore, uint64_t overwrite_nbytes) {
   InputReader *reader = new FileReader(gcpt_restore);
   int overwrite_size = reader->read_all(simMemory->as_ptr(), overwrite_nbytes);
-  Info("Overwrite %d bytes from file %s.\n", overwrite_size,gcpt_restore);
+  Info("Overwrite %d bytes from file %s.\n", overwrite_size, gcpt_restore);
   delete reader;
 }
 

--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -432,6 +432,13 @@ void LinearizedFootprintsMemory::save_linear_memory(const char *filename) {
   out_file.close();
 }
 
+void overwrite_ram(char *gcpt_restore, uint64_t overwrite_nbytes) {
+  InputReader *reader = new FileReader(gcpt_restore);
+  int overwrite_size = reader->read_all(simMemory->as_ptr(), overwrite_nbytes);
+  Info("Overwrite %d bytes from file %s.\n", overwrite_size,gcpt_restore);
+  delete reader;
+}
+
 #ifdef WITH_DRAMSIM3
 void dramsim3_init() {
 #if !defined(DRAMSIM3_CONFIG) || !defined(DRAMSIM3_OUTDIR)

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -214,7 +214,7 @@ public:
 extern SimMemory *simMemory;
 // This is to initialize the common mmap RAM
 void init_ram(const char *image, uint64_t n_bytes);
-void overwrite_ram(char *gcpt_restore, uint64_t overwrite_nbytes);
+void overwrite_ram(const char *gcpt_restore, uint64_t overwrite_nbytes);
 
 #ifdef WITH_DRAMSIM3
 

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -214,6 +214,7 @@ public:
 extern SimMemory *simMemory;
 // This is to initialize the common mmap RAM
 void init_ram(const char *image, uint64_t n_bytes);
+void overwrite_ram(char *gcpt_restore, uint64_t overwrite_nbytes);
 
 #ifdef WITH_DRAMSIM3
 

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -32,9 +32,11 @@
 static bool has_reset = false;
 static char bin_file[256] = "/dev/zero";
 static char *flash_bin_file = NULL;
+static char *gcpt_bin_file = NULL;
 static bool enable_difftest = true;
 static uint64_t max_instrs = 0;
 static char *workload_list = NULL;
+static uint64_t overwrite_nbytes = 0xe00;
 
 enum {
   SIMV_RUN,
@@ -51,6 +53,11 @@ extern "C" void set_flash_bin(char *s) {
   printf("flash image:%s\n", s);
   flash_bin_file = (char *)malloc(256);
   strcpy(flash_bin_file, s);
+}
+
+extern "C" void set_gcpt_bin(char *s) {
+  gcpt_bin_file = (char *)malloc(256);
+  strcpy(gcpt_bin_file, s);
 }
 
 extern "C" void set_max_instrs(uint64_t mc) {
@@ -116,6 +123,9 @@ extern "C" uint8_t simv_init() {
   if (enable_difftest) {
     init_goldenmem();
     init_nemuproxy(DEFAULT_EMU_RAM_SIZE);
+  }
+  if (gcpt_bin_file != NULL) {
+    overwrite_ram(gcpt_bin_file, overwrite_nbytes);
   }
   return 0;
 }

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -32,7 +32,7 @@
 static bool has_reset = false;
 static char bin_file[256] = "/dev/zero";
 static char *flash_bin_file = NULL;
-static char *gcpt_bin_file = NULL;
+static char *gcpt_restore_bin = NULL;
 static bool enable_difftest = true;
 static uint64_t max_instrs = 0;
 static char *workload_list = NULL;
@@ -56,8 +56,8 @@ extern "C" void set_flash_bin(char *s) {
 }
 
 extern "C" void set_gcpt_bin(char *s) {
-  gcpt_bin_file = (char *)malloc(256);
-  strcpy(gcpt_bin_file, s);
+  gcpt_restore_bin = (char *)malloc(256);
+  strcpy(gcpt_restore_bin, s);
 }
 
 extern "C" void set_max_instrs(uint64_t mc) {
@@ -124,8 +124,8 @@ extern "C" uint8_t simv_init() {
     init_goldenmem();
     init_nemuproxy(DEFAULT_EMU_RAM_SIZE);
   }
-  if (gcpt_bin_file != NULL) {
-    overwrite_ram(gcpt_bin_file, overwrite_nbytes);
+  if (gcpt_restore_bin != NULL) {
+    overwrite_ram(gcpt_restore_bin, overwrite_nbytes);
   }
   return 0;
 }

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -382,10 +382,7 @@ Emulator::Emulator(int argc, const char *argv[])
   }
 
   if (args.gcpt_restore) {
-    char gcpt_restore[256];
-    uint64_t overwrite_nbytes = args.overwrite_nbytes;
-    strcpy(gcpt_restore, args.gcpt_restore);
-    overwrite_ram(gcpt_restore, overwrite_nbytes);
+    overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);
   }
 
 #ifdef ENABLE_CHISEL_DB

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -382,10 +382,7 @@ Emulator::Emulator(int argc, const char *argv[])
   }
 
   if (args.gcpt_restore) {
-    InputReader *reader = new FileReader(args.gcpt_restore);
-    int overwrite_size = reader->read_all(simMemory->as_ptr(), args.overwrite_nbytes);
-    Info("Overwrite %d bytes from file %s.\n", overwrite_size, args.gcpt_restore);
-    delete reader;
+    overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);
   }
 
 #ifdef ENABLE_CHISEL_DB

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -382,7 +382,10 @@ Emulator::Emulator(int argc, const char *argv[])
   }
 
   if (args.gcpt_restore) {
-    overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);
+    char gcpt_restore[256];
+    uint64_t overwrite_nbytes = args.overwrite_nbytes;
+    strcpy(gcpt_restore, args.gcpt_restore);
+    overwrite_ram(gcpt_restore, overwrite_nbytes);
   }
 
 #ifdef ENABLE_CHISEL_DB

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -20,6 +20,7 @@ module tb_top();
 `ifndef TB_NO_DPIC
 import "DPI-C" function void set_bin_file(string bin);
 import "DPI-C" function void set_flash_bin(string bin);
+import "DPI-C" function void set_gcpt_bin(string bin);
 import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
 import "DPI-C" function byte simv_init();
@@ -63,6 +64,7 @@ wire [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] difftest_step;
 
 string bin_file;
 string flash_bin_file;
+string gcpt_bin_file;
 string wave_type;
 string diff_ref_so;
 string workload_list;
@@ -125,6 +127,11 @@ initial begin
   if ($test$plusargs("flash")) begin
     $value$plusargs("flash=%s", flash_bin_file);
     set_flash_bin(flash_bin_file);
+  end
+  // overwrite gcpt on ram: bin file
+  if ($test$plusargs("gcpt")) begin
+    $value$plusargs("gcpt=%s", gcpt_bin_file);
+    set_gcpt_bin(gcpt_bin_file);
   end
   // diff-test golden model: nemu-so
   if ($test$plusargs("diff")) begin

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -129,8 +129,8 @@ initial begin
     set_flash_bin(flash_bin_file);
   end
   // overwrite gcpt on ram: bin file
-  if ($test$plusargs("gcpt")) begin
-    $value$plusargs("gcpt=%s", gcpt_bin_file);
+  if ($test$plusargs("gcpt-restore")) begin
+    $value$plusargs("gcpt-restore=%s", gcpt_bin_file);
     set_gcpt_bin(gcpt_bin_file);
   end
   // diff-test golden model: nemu-so


### PR DESCRIPTION
The mobile gcpt overlay function becomes public so that it can also be used on the vcs Paladin