### PR TITLE
Replay: seperate from Squash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
-      - name: Verilator Build with VCS Top (with DutZone GlobalEnable Squash SquashReplay Batch PerfCnt)
+      - name: Verilator Build with VCS Top (with DutZone GlobalEnable Squash Replay Batch PerfCnt)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
@@ -351,7 +351,7 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
-      - name: Verilator Build with VCS Top (with GlobalEnable Squash SquashReplay Batch InternalStep NonBlock PerfCnt)
+      - name: Verilator Build with VCS Top (with GlobalEnable Squash Replay Batch InternalStep NonBlock PerfCnt)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh

--- a/config/config.h
+++ b/config/config.h
@@ -114,9 +114,9 @@ extern unsigned long EMU_FLASH_SIZE;
 // #define DEBUG_L2TLB
 
 // whether to enable REF/GoldenMemory record origin data of memory and restore
-#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
+#ifdef CONFIG_DIFFTEST_REPLAY
 #define ENABLE_STORE_LOG
-#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
+#endif // CONFIG_DIFFTEST_REPLAY
 
 // -----------------------------------------------------------------------
 // Simulator run ahead config

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -17,7 +17,6 @@ package difftest
 
 import chisel3._
 import chisel3.util._
-import difftest.gateway.GatewayConfig
 
 sealed trait HasValid {
   val valid = Bool()
@@ -261,6 +260,8 @@ class RunaheadRedirectEvent extends DifftestBaseBundle with HasValid {
   val checkpoint_id = UInt(64.W)
 }
 
-class TraceInfo(val config: GatewayConfig) extends DifftestBaseBundle {
-  val squash_idx = Option.when(config.squashReplay)(UInt(log2Ceil(config.replaySize).W))
+class TraceInfo extends DifftestBaseBundle with HasValid {
+  val in_replay = Bool()
+  val trace_head = UInt(16.W)
+  val trace_tail = UInt(16.W)
 }

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -1,0 +1,121 @@
+/***************************************************************************************
+ * Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.replay
+
+import chisel3._
+import chisel3.experimental.ExtModule
+import chisel3.util._
+import difftest._
+import difftest.gateway.GatewayConfig
+
+object Replay {
+  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): MixedVec[DifftestBundle] = {
+    val module = Module(new ReplayEndpoint(chiselTypeOf(bundles).toSeq, config))
+    module.in := bundles
+    module.out
+  }
+}
+
+class ReplayEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+  val info = WireInit(0.U.asTypeOf(new DiffTraceInfo))
+  val appendIn = WireInit(0.U.asTypeOf(MixedVec(bundles ++ Seq(chiselTypeOf(info)))))
+  in.zipWithIndex.foreach { case (gen, idx) => appendIn(idx) := gen }
+  appendIn.last := info
+  val out = IO(Output(chiselTypeOf(appendIn)))
+
+  val control = Module(new ReplayControl(config))
+  control.clock := clock
+  control.reset := reset
+
+  val buffer = Mem(config.replaySize, chiselTypeOf(appendIn))
+  val ptr = RegInit(0.U(log2Ceil(config.replaySize).W))
+
+  // write
+  // ignore useless data when hasGlobalEnable
+  val needStore = WireInit(true.B)
+  if (config.hasGlobalEnable) {
+    needStore := VecInit(in.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+  }
+  info.valid := needStore
+  info.trace_head := ptr
+  info.trace_tail := ptr
+  when(needStore && !control.replay) {
+    buffer(ptr) := appendIn
+    ptr := ptr + 1.U
+    when(ptr === (config.replaySize - 1).U) {
+      ptr := 0.U
+    }
+  }
+
+  // read
+  val in_replay = RegInit(false.B) // indicates ptr in correct replay pos
+  when(control.replay) {
+    when(!in_replay) {
+      in_replay := true.B
+      ptr := control.replay_head // position of first corresponding replay data
+    }.otherwise {
+      ptr := ptr + 1.U
+      when(ptr === (config.replaySize - 1).U) {
+        ptr := 0.U
+      }
+    }
+  }
+  out := Mux(in_replay, buffer(ptr), appendIn)
+  out.filter(_.desiredCppName == "trace_info").foreach { gen =>
+    val info = gen.asInstanceOf[DiffTraceInfo]
+    info.in_replay := in_replay
+  }
+}
+
+class ReplayControl(config: GatewayConfig) extends ExtModule with HasExtModuleInline {
+  val clock = IO(Input(Clock()))
+  val reset = IO(Input(Reset()))
+  val replay = IO(Output(Bool()))
+  val replay_head = IO(Output(UInt(log2Ceil(config.replaySize).W)))
+
+  setInline(
+    "ReplayControl.v",
+    s"""
+       |module ReplayControl(
+       |  input clock,
+       |  input reset,
+       |  output reg replay,
+       |  output reg [${log2Ceil(config.replaySize) - 1}:0] replay_head
+       |);
+       |
+       |`ifndef SYNTHESIS
+       |`ifdef DIFFTEST
+       |import "DPI-C" context function void set_replay_scope();
+       |
+       |initial begin
+       |  set_replay_scope();
+       |  replay = 1'b0;
+       |  replay_head = ${log2Ceil(config.replaySize)}'b0;
+       |end
+       |
+       |// For the C/C++ interface
+       |export "DPI-C" task set_replay_head;
+       |task set_replay_head(int head);
+       |  replay = 1'b1;
+       |  replay_head = head;
+       |endtask
+       |`endif // DIFFTEST
+       |`endif // SYNTHESIS
+       |endmodule;
+       |""".stripMargin,
+  )
+}

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -373,20 +373,22 @@ protected:
 
   void raise_trap(int trapCode);
 
-#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
-  bool isSquash;
-  int squash_idx;
-  bool inReplay = false;
-  int replay_idx;
+#ifdef CONFIG_DIFFTEST_REPLAY
+  struct {
+    bool in_replay = false;
+    int trace_head;
+    int trace_tail;
+  } replay_status;
 
   DiffState *state_ss = NULL;
   int proxy_reg_size = 0;
   uint8_t *proxy_reg_ss = NULL;
   uint64_t squash_csr_buf[4096];
-  bool squash_check();
-  void squash_snapshot();
-  void squash_replay();
-#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
+  bool can_replay();
+  bool in_replay_range();
+  void replay_snapshot();
+  void do_replay();
+#endif // CONFIG_DIFFTEST_REPLAY
 };
 
 extern Difftest **difftest;
@@ -407,9 +409,10 @@ int init_nemuproxy(size_t);
 #ifdef CONFIG_DIFFTEST_SQUASH
 extern "C" void set_squash_scope();
 extern "C" void difftest_squash_enable(int enable);
-#ifdef CONFIG_DIFFTEST_SQUASH_REPLAY
-extern "C" void difftest_squash_replay(int idx);
-#endif // CONFIG_DIFFTEST_SQUASH_REPLAY
 #endif // CONFIG_DIFFTEST_SQUASH
+#ifdef CONFIG_DIFFTEST_REPLAY
+extern "C" void set_replay_scope();
+extern "C" void difftest_replay_head(int idx);
+#endif // CONFIG_DIFFTEST_REPLAY
 
 #endif


### PR DESCRIPTION
We seperate Replay feature for better structure. Signal in_replay will mark trace as replay or not, replayed trace will not be squashed. And we will record squashed range between trace_head and trace_tail, see squash function of DiffTraceInfo. In the future, Replay may support not only Squashed, but also Compress, etc.

This change also provides better flexibility for optimization. It will generated Cpp declaration depends on result of Gateway.