### PR TITLE
emu: increase reset cycles in verilator

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -357,7 +357,7 @@ Emulator::Emulator(int argc, const char *argv[])
 #endif
 
   // init core
-  reset_ncycles(10);
+  reset_ncycles(args.reset_cycles);
 
   // init ram
   uint64_t ram_size = DEFAULT_EMU_RAM_SIZE;
@@ -603,7 +603,7 @@ inline void Emulator::single_cycle() {
     bool in_range = (args.log_begin <= cycle) && (cycle <= args.log_end);
     if (in_range || force_dump_wave) {
       if (args.enable_waveform_full) {
-        tfp->dump(20 + 2 * cycle);
+        tfp->dump(2 * args.reset_cycles + 2 * cycle);
       } else {
         tfp->dump(cycle);
       }
@@ -640,7 +640,7 @@ inline void Emulator::single_cycle() {
 #endif
     bool in_range = (args.log_begin <= cycle) && (cycle <= args.log_end);
     if (in_range || force_dump_wave) {
-      tfp->dump(21 + 2 * cycle);
+      tfp->dump(2 * args.reset_cycles + 1 + 2 * cycle);
     }
   }
 #endif

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -37,6 +37,7 @@
 #endif
 
 struct EmuArgs {
+  uint32_t reset_cycles = 50;
   uint32_t seed = 0;
   uint64_t max_cycles = -1;
   uint64_t fork_interval = 1000;


### PR DESCRIPTION
Some signals need more than 10 posedges to reach a stable state. We may increase the reset cycles to 50 posedges, which is the same as what vcs is doing.

![d76c22231ff678bee2e3070e88025ad](https://github.com/OpenXiangShan/difftest/assets/46089480/fdf506c9-2ce6-451a-8ef3-b0e14560efce)
