### PR TITLE
mem: add dramsim size config

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -36,7 +36,11 @@
 // -----------------------------------------------------------------------
 
 // emulated memory size (Byte)
+#ifdef WITH_DRAMSIM3
+#define DEFAULT_EMU_RAM_SIZE (16 * 1024 * 1024 * 1024UL) // 8 GB
+#else
 #define DEFAULT_EMU_RAM_SIZE (8 * 1024 * 1024 * 1024UL) // 8 GB
+#endif // WITH_DRAMSIM3
 
 // physical memory base address
 #define PMEM_BASE 0x80000000UL


### PR DESCRIPTION
When dramsim is enabled, the memory size should be set to the same 16GB as for rlt
https://github.com/OpenXiangShan/XiangShan/blob/4a8a734e58e2469a23b631ed5ab41474c59ec5a1/src/test/scala/top/SimTop.scala#L45