### PR TITLE
Squash: use Queue to buffer unsquashed Bundle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -362,6 +362,17 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
+      - name: Verilator Build with VCS Top (with GlobalEnable Squash SquashQueue Replay Batch InternalStep NonBlock PerfCnt)
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make simv MILL_ARGS="--difftest-config ESQRBINP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
+
       - name: Verilator Build with VCS Top (with workload-list)
         run : |
             cd $GITHUB_WORKSPACE/../xs-env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,6 +373,17 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
+      - name: Verilator Build with VCS Top (with GlobalEnable Squash SquashQueue SquashFlush Replay Batch InternalStep NonBlock PerfCnt)
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make simv MILL_ARGS="--difftest-config ESQFRBINP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
+
       - name: Verilator Build with VCS Top (with workload-list)
         run : |
             cd $GITHUB_WORKSPACE/../xs-env

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -117,6 +117,8 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   val squashQueueSize: Int = 0
   // Some Bundle may have squashQueueDelay, requires them submitted after related bundle
   val squashQueueDelay: Int = 0
+  // return a Seq indicating ones affected by this bundle, which should be flushed by new-coming this bundle
+  val squashFlush: Seq[String] = Seq()
 }
 
 class DiffArchEvent extends ArchEvent with DifftestBundle {
@@ -211,6 +213,8 @@ class DiffVecCSRState extends VecCSRState with DifftestBundle {
 class DiffSbufferEvent extends SbufferEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "sbuffer"
   override val squashGroup: Seq[String] = Seq("GOLDENMEM")
+  override val squashFlush: Seq[String] = Seq("load", "l1tlb", "l2tlb", "refill")
+  override val squashQueueSize: Int = 8
 }
 
 class DiffStoreEvent extends StoreEvent with DifftestBundle with DifftestWithIndex {

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -112,6 +112,11 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   val squashGroup: Seq[String] = Seq("REF")
   // returns a squashed, right-value Bundle. Default: overriding `base` with `this`
   def squash(base: DifftestBundle): DifftestBundle = this
+  // return Size indicating the size of queue. Defualt: 0
+  // When hasSquashQueue is true and queueSize non-zero, bundle will not be squashed, but buffered and sumbited together.
+  val squashQueueSize: Int = 0
+  // Some Bundle may have squashQueueDelay, requires them submitted after related bundle
+  val squashQueueDelay: Int = 0
 }
 
 class DiffArchEvent extends ArchEvent with DifftestBundle {
@@ -210,6 +215,9 @@ class DiffSbufferEvent extends SbufferEvent with DifftestBundle with DifftestWit
 
 class DiffStoreEvent extends StoreEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "store"
+  // To avoid overflow, queueSize should be less than REF
+  override val squashQueueSize: Int = 64
+  override val squashQueueDelay: Int = 1
 }
 
 class DiffLoadEvent extends LoadEvent with DifftestBundle with DifftestWithIndex {

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -30,6 +30,7 @@ case class GatewayConfig(
   style: String = "dpic",
   hasGlobalEnable: Boolean = false,
   isSquash: Boolean = false,
+  hasSquashQueue: Boolean = false,
   hasReplay: Boolean = false,
   replaySize: Int = 256,
   hasDutZone: Boolean = false,
@@ -71,7 +72,7 @@ case class GatewayConfig(
     macros.toSeq
   }
   def check(): Unit = {
-    if (hasReplay) require(isSquash)
+    if (hasReplay || hasSquashQueue) require(isSquash)
     if (hasInternalStep) require(isBatch)
   }
 }
@@ -102,6 +103,7 @@ object Gateway {
     cfg.foreach {
       case 'E' => config = config.copy(hasGlobalEnable = true)
       case 'S' => config = config.copy(isSquash = true)
+      case 'Q' => config = config.copy(hasSquashQueue = true)
       case 'R' => config = config.copy(hasReplay = true)
       case 'Z' => config = config.copy(hasDutZone = true)
       case 'B' => config = config.copy(isBatch = true)

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -31,6 +31,7 @@ case class GatewayConfig(
   hasGlobalEnable: Boolean = false,
   isSquash: Boolean = false,
   hasSquashQueue: Boolean = false,
+  hasSquashFlush: Boolean = false,
   hasReplay: Boolean = false,
   replaySize: Int = 256,
   hasDutZone: Boolean = false,
@@ -104,6 +105,7 @@ object Gateway {
       case 'E' => config = config.copy(hasGlobalEnable = true)
       case 'S' => config = config.copy(isSquash = true)
       case 'Q' => config = config.copy(hasSquashQueue = true)
+      case 'F' => config = config.copy(hasSquashFlush = true)
       case 'R' => config = config.copy(hasReplay = true)
       case 'Z' => config = config.copy(hasDutZone = true)
       case 'B' => config = config.copy(isBatch = true)

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -105,8 +105,10 @@ class Squasher(bundleType: DifftestBundle, length: Int, config: GatewayConfig) e
   val want_tick = IO(Output(Bool()))
   val should_tick = IO(Input(Bool()))
 
-  val state = RegInit(0.U.asTypeOf(Vec(length, bundleType)))
-  val out = IO(Output(Vec(length, bundleType)))
+  val hasQueue = config.hasSquashQueue && bundleType.squashQueueSize != 0
+  val vecLen = if (hasQueue) bundleType.squashQueueSize else length
+  val state = RegInit(0.U.asTypeOf(Vec(vecLen, bundleType)))
+  val out = IO(Output(Vec(vecLen, bundleType)))
 
   // Mark the initial commit events as non-squashable for initial state synchronization.
   val tick_first_commit = Option.when(bundleType.desiredCppName == "commit") {
@@ -118,24 +120,46 @@ class Squasher(bundleType: DifftestBundle, length: Int, config: GatewayConfig) e
     isInitialEvent && hasValidCommitEvent
   }
 
-  // If one of the bundles cannot be squashed, the others are not squashed as well.
-  val supportsSquashVec = VecInit(in.zip(state).map { case (i, s) => i.supportsSquash(s) }.toSeq)
-  val supportsSquash = supportsSquashVec.asUInt.andR
-
-  // If one of the bundles cannot be the new base, the others are not as well.
-  val supportsSquashBaseVec = VecInit(state.map(_.supportsSquashBase).toSeq)
-  val supportsSquashBase = supportsSquashBaseVec.asUInt.andR
-
-  want_tick := !supportsSquash || !supportsSquashBase || tick_first_commit.getOrElse(false.B)
-  for (((i, d), s) <- in.zip(do_squash).zip(state)) {
-    when(should_tick) {
-      s := i
-    }.elsewhen(d) {
-      s := i.squash(s)
+  if (hasQueue) {
+    // Bundle will not be squashed, but buffered and submit together.
+    val ptr = RegInit(0.U(log2Ceil(vecLen + 1).W))
+    val offset = PopCount(do_squash)
+    dontTouch(offset)
+    val queue_exceed = ptr +& offset > vecLen.U
+    want_tick := queue_exceed || tick_first_commit.getOrElse(false.B)
+    ptr := Mux(should_tick, offset, ptr + offset)
+    in.zip(do_squash).zipWithIndex.foreach { case ((i, d), idx) =>
+      val postEnq = if (idx != 0) PopCount(do_squash.take(idx)) else 0.U
+      when(should_tick && d) {
+        state(postEnq) := i
+      }.elsewhen(d) {
+        state(ptr + postEnq) := i
+      }
     }
-  }
+    state.zip(out).zipWithIndex.foreach { case ((s, o), idx) =>
+      o := Delayer(Mux(should_tick && ptr > idx.U, s, 0.U.asTypeOf(o)), bundleType.squashQueueDelay)
+      o.asInstanceOf[DifftestWithIndex].index := idx.U
+    }
+  } else {
+    // If one of the bundles cannot be squashed, the others are not squashed as well.
+    val supportsSquashVec = VecInit(in.zip(state).map { case (i, s) => i.supportsSquash(s) }.toSeq)
+    val supportsSquash = supportsSquashVec.asUInt.andR
 
-  out := Mux(should_tick, state, 0.U.asTypeOf(out))
+    // If one of the bundles cannot be the new base, the others are not as well.
+    val supportsSquashBaseVec = VecInit(state.map(_.supportsSquashBase).toSeq)
+    val supportsSquashBase = supportsSquashBaseVec.asUInt.andR
+
+    want_tick := !supportsSquash || !supportsSquashBase || tick_first_commit.getOrElse(false.B)
+
+    for (((i, d), s) <- in.zip(do_squash).zip(state)) {
+      when(should_tick) {
+        s := i
+      }.elsewhen(d) {
+        s := i.squash(s)
+      }
+    }
+    out := Mux(should_tick, state, 0.U.asTypeOf(out))
+  }
 }
 
 class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleInline {

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -49,6 +49,12 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
     }
   }
 
+  // Sometimes, the bundle may be flushed by new-coming others that affect what it checks
+  val do_flush = VecInit(in.map { i =>
+    in.collect { case b if b.squashFlush.contains(i.desiredCppName) => b.bits.needUpdate.getOrElse(true.B) }
+      .foldLeft(false.B)(_ || _)
+  }.toSeq)
+
   val control = Module(new SquashControl(config))
   control.clock := clock
   control.reset := reset
@@ -73,10 +79,12 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
   })
 
   val s_out_vec = uniqBundles.zip(want_tick_vec).map { case (u, wt) =>
-    val (s_in, s_do) = in.zip(do_squash).filter(_._1.desiredCppName == u.desiredCppName).unzip
+    val (s_in, s_do) = in.zip(do_squash.zip(do_flush)).filter(_._1.desiredCppName == u.desiredCppName).unzip
+    val (s_do_s, s_do_f) = s_do.unzip
     val squasher = Module(new Squasher(chiselTypeOf(s_in.head), s_in.length, config))
     squasher.in.zip(s_in).foreach { case (i, s_i) => i := s_i }
-    squasher.do_squash.zip(s_do).foreach { case (d, s_d) => d := s_d }
+    squasher.do_squash.zip(s_do_s).foreach { case (d, s_d) => d := s_d }
+    squasher.do_flush.zip(s_do_f).foreach { case (d, s_d) => d := s_d }
     wt := squasher.want_tick
     val group_tick =
       group_name_vec
@@ -102,6 +110,7 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
 class Squasher(bundleType: DifftestBundle, length: Int, config: GatewayConfig) extends Module {
   val in = IO(Input(Vec(length, bundleType)))
   val do_squash = IO(Input(Vec(length, Bool())))
+  val do_flush = IO(Input(Vec(length, Bool())))
   val want_tick = IO(Output(Bool()))
   val should_tick = IO(Input(Bool()))
 
@@ -124,7 +133,6 @@ class Squasher(bundleType: DifftestBundle, length: Int, config: GatewayConfig) e
     // Bundle will not be squashed, but buffered and submit together.
     val ptr = RegInit(0.U(log2Ceil(vecLen + 1).W))
     val offset = PopCount(do_squash)
-    dontTouch(offset)
     val queue_exceed = ptr +& offset > vecLen.U
     want_tick := queue_exceed || tick_first_commit.getOrElse(false.B)
     ptr := Mux(should_tick, offset, ptr + offset)
@@ -151,11 +159,13 @@ class Squasher(bundleType: DifftestBundle, length: Int, config: GatewayConfig) e
 
     want_tick := !supportsSquash || !supportsSquashBase || tick_first_commit.getOrElse(false.B)
 
-    for (((i, d), s) <- in.zip(do_squash).zip(state)) {
+    for ((((i, ds), df), s) <- in.zip(do_squash).zip(do_flush).zip(state)) {
       when(should_tick) {
         s := i
-      }.elsewhen(d) {
+      }.elsewhen(ds) {
         s := i.squash(s)
+      }.elsewhen(df) {
+        s := 0.U.asTypeOf(s)
       }
     }
     out := Mux(should_tick, state, 0.U.asTypeOf(out))


### PR DESCRIPTION
Now we use Queue to buffer StoreEvent, avoid too many squash tick
caused by it. This bundle will only compare store actions betweens
DUT and REF, no other bundles depends on it, which enable us to buffer
it.

Another bundle causing many ticks is Sbuffer, for it will update
GoldenMem, and other bundle related will affected by it. Now we still
cannot buffer and submitted such bundle together.