### PR TITLE
Batch: pack DPIC with hybird parallel and pipeline

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -192,6 +192,8 @@ class BatchEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig, param: 
   val state_info = RegInit(0.U(param.MaxInfoBitLen.W))
   val state_info_len = RegInit(0.U(param.MaxInfoByteWidth.W))
   val state_step_cnt = RegInit(0.U(config.stepWidth.W))
+  require(state_data.getWidth >= step_data.getWidth)
+  require(state_info.getWidth >= step_info.getWidth)
 
   val delayed_enable = Delayer(global_enable, inCollect.length)
   val data_exceed = state_data_len +& step_data_len > param.MaxDataByteLen.U

--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -21,6 +21,21 @@ import difftest._
 import difftest.gateway.GatewayConfig
 import difftest.common.DifftestPerf
 
+import scala.collection.mutable.ListBuffer
+
+case class BatchParam(config: GatewayConfig, templateLen: Int) {
+  val infoWidth = (new BatchInfo).getWidth
+
+  val MaxDataByteLen = config.batchArgByteLen._1
+  val MaxDataByteWidth = log2Ceil(MaxDataByteLen)
+  val MaxDataBitLen = MaxDataByteLen * 8
+
+  // Append BatchInterval and BatchFinish Info
+  val MaxInfoByteLen = config.batchArgByteLen._2
+  val MaxInfoByteWidth = log2Ceil(MaxInfoByteLen)
+  val MaxInfoBitLen = MaxInfoByteLen * 8
+}
+
 class BatchIO(dataType: UInt, infoType: UInt) extends Bundle {
   val data = dataType
   val info = infoType
@@ -34,28 +49,48 @@ class BatchOutput(data: UInt, info: UInt, config: GatewayConfig) extends Bundle 
 
 class BatchInfo extends Bundle {
   val id = UInt(8.W)
+  val num = UInt(8.W)
 }
 
 object Batch {
-  def apply(template: Seq[DifftestBundle], bundles: MixedVec[DifftestBundle], config: GatewayConfig): BatchOutput = {
-    val module = Module(new BatchEndpoint(template, chiselTypeOf(bundles).toSeq, config))
+  private val template = ListBuffer.empty[DifftestBundle]
+
+  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): BatchOutput = {
+    template ++= chiselTypeOf(bundles).distinctBy(_.desiredCppName)
+    val param = BatchParam(config, template.length)
+    val module = Module(new BatchEndpoint(chiselTypeOf(bundles).toSeq, config, param))
     module.in := bundles
     module.out
   }
 
-  def getTemplate(bundles: MixedVec[DifftestBundle]): Seq[DifftestBundle] = {
-    chiselTypeOf(bundles).groupBy(_.desiredModuleName).values.map(_.head).toSeq
-  }
-}
+  def getTemplate: Seq[DifftestBundle] = template.toSeq
 
-class BatchEndpoint(template: Seq[DifftestBundle], bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
-  val in = IO(Input(MixedVec(bundles)))
+  def getBundleID(bundleType: DifftestBundle): Int = {
+    template.indexWhere(_.desiredCppName == bundleType.desiredCppName)
+  }
+
+  def getAlignWidth(bundleType: DifftestBundle): Int = {
+    def byteAlignWidth(data: Data) = (data.getWidth + 7) / 8 * 8
+    bundleType.elements.toSeq.reverse
+      .filterNot(bundleType.isFlatten && _._1 == "valid")
+      .map { case (_, data) =>
+        data match {
+          case vec: Vec[_] => vec.map(byteAlignWidth(_)).sum
+          case _           => byteAlignWidth(data)
+        }
+      }
+      .sum
+  }
+  def getAlignWidth(bundles: Seq[DifftestBundle]): Int = {
+    bundles.map(i => getAlignWidth(i)).sum
+  }
 
   def bundleAlign(bundle: DifftestBundle): UInt = {
     def byteAlign(data: Data): UInt = {
       val width: Int = (data.getWidth + 7) / 8 * 8
       data.asTypeOf(UInt(width.W))
     }
+
     MixedVecInit(
       bundle.elements.toSeq.reverse
         .filterNot(bundle.isFlatten && _._1 == "valid")
@@ -67,73 +102,104 @@ class BatchEndpoint(template: Seq[DifftestBundle], bundles: Seq[DifftestBundle],
         }
     ).asUInt
   }
+}
 
-  def getBundleID(name: String): Int = {
-    template.zipWithIndex.filter(_._1.desiredModuleName == name).head._2
+class BatchEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig, param: BatchParam) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+
+  def updateFilter = (x: DifftestBundle) => x.bits.needUpdate.isDefined
+  def vecAlignWidth = (vec: Seq[DifftestBundle]) => Batch.getAlignWidth(vec.head) * vec.length
+
+  // Process bundles without needUpdate Option as Base in parallel
+  val inBase = in.filterNot(updateFilter).groupBy(_.desiredCppName).values.toSeq.map(_.toSeq)
+  val inBase_w = inBase.map(vecAlignWidth)
+  val dataBase_vec = WireInit(0.U.asTypeOf(MixedVec(inBase_w.map(i => UInt(i.W)).toSeq)))
+  val infoBase_vec = WireInit(0.U.asTypeOf(Vec(inBase.length, UInt(param.infoWidth.W))))
+  val dataLenBase_vec = WireInit(0.U.asTypeOf(Vec(inBase.length, UInt(param.MaxDataByteWidth.W))))
+  inBase.zipWithIndex.foreach { case (in, idx) =>
+    val base = Module(new BatchBase(chiselTypeOf(in.head), in.length, param))
+    base.data_in := in
+    dataBase_vec(idx) := base.data_out
+    infoBase_vec(idx) := base.info_out
+    dataLenBase_vec(idx) := base.data_len_out
   }
+  val dataBase = dataBase_vec.asUInt
+  val infoBase = infoBase_vec.asUInt
+  val dataLenBase = dataLenBase_vec.foldLeft(0.U)(_ + _)
+  val infoLenBase = (inBase.length * param.infoWidth / 8).U
 
-  val aligned_data = MixedVecInit(in.map(i => bundleAlign(i)).toSeq)
-
+  // Collect bundles with needUpdate Option in Pipeline
   val global_enable = WireInit(true.B)
   if (config.hasGlobalEnable) {
     global_enable := VecInit(in.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
   }
-
-  val bundleNum = in.length
-  val delayed_enable = Delayer(global_enable, bundleNum)
-  val delayed_data = MixedVecInit(aligned_data.zipWithIndex.map { case (data, i) => Delayer(data, i) }.toSeq)
-  val delayed_valid = VecInit(in.zipWithIndex.map { case (gen, i) =>
-    Delayer(gen.bits.getValid & global_enable, i)
-  }.toSeq)
-
-  val MaxDataByteLen = config.batchArgByteLen._1
-  val MaxDataByteWidth = log2Ceil(MaxDataByteLen)
-  val MaxDataBitLen = MaxDataByteLen * 8
-  val infoWidth = (new BatchInfo).getWidth
-  // Append BatchInterval and BatchFinish Info
-  val MaxInfoByteLen = math.min((config.batchSize * (bundleNum + 1) + 1) * (infoWidth / 8), config.batchArgByteLen._2)
-  val MaxInfoByteWidth = log2Ceil(MaxInfoByteLen)
-  val MaxInfoBitLen = MaxInfoByteLen * 8
-
-  val data_vec = Reg(MixedVec((1 to bundleNum).map(i => UInt(aligned_data.map(_.getWidth).take(i).sum.W))))
-  val info_vec = Reg(MixedVec((1 to bundleNum).map(i => UInt((i * infoWidth).W))))
-  val data_len_vec = Reg(Vec(bundleNum, UInt(MaxDataByteWidth.W)))
-  val info_len_vec = Reg(Vec(bundleNum, UInt(MaxInfoByteWidth.W)))
-
-  for (idx <- 0 until bundleNum) {
-    val data_len = (aligned_data(idx).getWidth / 8).U
-    val info = Wire(new BatchInfo)
-    info.id := getBundleID(in(idx).desiredModuleName).U
-    if (idx == 0) {
-      data_vec(idx) := Mux(delayed_valid(idx), delayed_data(idx), 0.U)
-      info_vec(idx) := Mux(delayed_valid(idx), info.asUInt, 0.U)
-      data_len_vec(idx) := Mux(delayed_valid(idx), data_len, 0.U)
-      info_len_vec(idx) := Mux(delayed_valid(idx), (infoWidth / 8).U, 0.U)
-    } else {
-      data_vec(idx) := Mux(delayed_valid(idx), Cat(data_vec(idx - 1), delayed_data(idx)), data_vec(idx - 1))
-      info_vec(idx) := Mux(delayed_valid(idx), Cat(info_vec(idx - 1), info.asUInt), info_vec(idx - 1))
-      data_len_vec(idx) := Mux(delayed_valid(idx), data_len_vec(idx - 1) + data_len, data_len_vec(idx - 1))
-      info_len_vec(idx) := Mux(delayed_valid(idx), info_len_vec(idx - 1) + (infoWidth / 8).U, info_len_vec(idx - 1))
-    }
+  val inCollect =
+    in.filter(updateFilter).groupBy(_.desiredCppName).values.toSeq.map(_.toSeq).sortBy(vecAlignWidth).reverse
+  val inCollect_w = inCollect.map(vecAlignWidth)
+  val dataCollect_vec = WireInit(
+    0.U.asTypeOf(
+      MixedVec(
+        (0 to inCollect.length).map { i =>
+          val width = if (i == 0) dataBase.getWidth else dataBase.getWidth + inCollect_w.take(i).sum
+          UInt(width.W)
+        }
+      )
+    )
+  )
+  val infoCollect_vec = WireInit(
+    0.U.asTypeOf(
+      MixedVec(
+        (0 to inCollect.length).map(i => UInt((infoBase.getWidth + i * param.infoWidth).W))
+      )
+    )
+  )
+  val dataLenCollect_vec = WireInit(0.U.asTypeOf(Vec(inCollect.length + 1, UInt(param.MaxDataByteWidth.W))))
+  val infoLenCollect_vec = WireInit(0.U.asTypeOf(Vec(inCollect.length + 1, UInt(param.MaxInfoByteWidth.W))))
+  dataCollect_vec(0) := dataBase
+  infoCollect_vec(0) := infoBase
+  dataLenCollect_vec(0) := dataLenBase
+  infoLenCollect_vec(0) := infoLenBase
+  inCollect.zipWithIndex.foreach { case (in, idx) =>
+    val collector = Module(
+      new BatchCollector(
+        chiselTypeOf(in.head),
+        in.length,
+        dataCollect_vec(idx).getWidth,
+        infoCollect_vec(idx).getWidth,
+        param,
+        idx,
+      )
+    )
+    collector.data_in := in
+    collector.enable := global_enable
+    collector.data_base := dataCollect_vec(idx)
+    collector.info_base := infoCollect_vec(idx)
+    collector.data_len_base := dataLenCollect_vec(idx)
+    collector.info_len_base := infoLenCollect_vec(idx)
+    dataCollect_vec(idx + 1) := collector.data_out
+    infoCollect_vec(idx + 1) := collector.info_out
+    dataLenCollect_vec(idx + 1) := collector.data_len_out
+    infoLenCollect_vec(idx + 1) := collector.info_len_out
   }
 
-  val BatchInterval = Wire(new BatchInfo)
-  val BatchFinish = Wire(new BatchInfo)
-  BatchInterval.id := template.length.U
-  BatchFinish.id := (template.length + 1).U
-  val step_data = WireInit(data_vec(bundleNum - 1))
-  val step_info = Cat(info_vec(bundleNum - 1), BatchInterval.asUInt)
-  val step_data_len = data_len_vec(bundleNum - 1)
-  val step_info_len = info_len_vec(bundleNum - 1) + (infoWidth / 8).U
+  val BatchInterval = WireInit(0.U.asTypeOf(new BatchInfo))
+  val BatchFinish = WireInit(0.U.asTypeOf(new BatchInfo))
+  BatchInterval.id := Batch.getTemplate.length.U
+  BatchFinish.id := (Batch.getTemplate.length + 1).U
+  val step_data = dataCollect_vec.last
+  val step_info = Cat(infoCollect_vec.last, BatchInterval.asUInt)
+  val step_data_len = dataLenCollect_vec.last
+  val step_info_len = infoLenCollect_vec.last + (param.infoWidth / 8).U
 
-  val state_data = RegInit(0.U(MaxDataBitLen.W))
-  val state_data_len = RegInit(0.U(MaxDataByteWidth.W))
-  val state_info = RegInit(0.U(MaxInfoBitLen.W))
-  val state_info_len = RegInit(0.U(MaxInfoByteWidth.W))
-  val state_step_cnt = RegInit(0.U(log2Ceil(config.batchSize + 1).W))
+  val state_data = RegInit(0.U(param.MaxDataBitLen.W))
+  val state_data_len = RegInit(0.U(param.MaxDataByteWidth.W))
+  val state_info = RegInit(0.U(param.MaxInfoBitLen.W))
+  val state_info_len = RegInit(0.U(param.MaxInfoByteWidth.W))
+  val state_step_cnt = RegInit(0.U(config.stepWidth.W))
 
-  val data_exceed = state_data_len +& step_data_len > MaxDataByteLen.U
-  val info_exceed = state_info_len +& step_info_len + (infoWidth / 8).U > MaxInfoByteLen.U
+  val delayed_enable = Delayer(global_enable, inCollect.length)
+  val data_exceed = state_data_len +& step_data_len > param.MaxDataByteLen.U
+  val info_exceed = state_info_len +& step_info_len + (param.infoWidth / 8).U > param.MaxInfoByteLen.U
   val step_exceed = state_step_cnt === config.batchSize.U
   if (config.hasBuiltInPerf) {
     DifftestPerf("BatchExceed_data", data_exceed.asUInt)
@@ -163,4 +229,85 @@ class BatchEndpoint(template: Seq[DifftestBundle], bundles: Seq[DifftestBundle],
   out.io.info := state_info | BatchFinish.asUInt << (state_info_len << 3)
   out.enable := should_tick
   out.step := Mux(out.enable, state_step_cnt, 0.U)
+}
+
+// Align Bundles without Valid Option as Batch base
+class BatchBase(bundleType: DifftestBundle, length: Int, param: BatchParam) extends Module {
+  val dataOut_w = Batch.getAlignWidth(bundleType) * length
+
+  val data_in = IO(Input(Vec(length, bundleType)))
+
+  val data_out = IO(Output(UInt(dataOut_w.W)))
+  val info_out = IO(Output(UInt(param.infoWidth.W)))
+  val data_len_out = IO(Output(UInt(param.MaxDataByteWidth.W)))
+
+  data_out := VecInit(data_in.map(i => Batch.bundleAlign(i))).asUInt
+  val info = Wire(new BatchInfo)
+  info.id := Batch.getBundleID(bundleType).U
+  info.num := length.U
+  info_out := info.asUInt
+  data_len_out := (data_out.getWidth / 8).U
+}
+
+// Collect Bundles with Valid by pipeline, same Class will be processed in parallel
+class BatchCollector(
+  bundleType: DifftestBundle,
+  length: Int,
+  dataBase_w: Int,
+  infoBase_w: Int,
+  param: BatchParam,
+  delay: Int,
+) extends Module {
+  val alignWidth = Batch.getAlignWidth(bundleType)
+  val dataOut_w = dataBase_w + alignWidth * length
+  val infoOut_w = infoBase_w + param.infoWidth
+
+  val data_in = IO(Input(Vec(length, bundleType)))
+  val enable = IO(Input(Bool()))
+
+  val data_base = IO(Input(UInt(dataBase_w.W)))
+  val info_base = IO(Input(UInt(infoBase_w.W)))
+  val data_len_base = IO(Input(UInt(param.MaxDataByteWidth.W)))
+  val info_len_base = IO(Input(UInt(param.MaxInfoByteWidth.W)))
+
+  val data_out = IO(Output(UInt(dataOut_w.W)))
+  val info_out = IO(Output(UInt(infoOut_w.W)))
+  val data_len_out = IO(Output(UInt(param.MaxDataByteWidth.W)))
+  val info_len_out = IO(Output(UInt(param.MaxInfoByteWidth.W)))
+
+  val data_state = RegInit(0.U(dataOut_w.W))
+  val info_state = RegInit(0.U(infoOut_w.W))
+  val data_len_state = RegInit(0.U(param.MaxDataByteWidth.W))
+  val info_len_state = RegInit(0.U(param.MaxInfoByteWidth.W))
+
+  val align_data = VecInit(data_in.map(i => Batch.bundleAlign(i)).toSeq)
+  val delay_data = VecInit(align_data.map(i => Delayer(i, delay)).toSeq)
+  val delay_valid = VecInit(data_in.map(i => Delayer(i.bits.needUpdate.get && enable, delay)).toSeq)
+
+  val valid_num = PopCount(delay_valid)
+  val info = Wire(new BatchInfo)
+  info.id := Batch.getBundleID(bundleType).U
+  info.num := valid_num
+  val data_site = WireInit(0.U((alignWidth * length).W))
+  data_site := VecInit(delay_data.zipWithIndex.map { case (d, idx) =>
+    val offset = if (idx == 0) 0.U else PopCount(delay_valid.take(idx)) * align_data.head.getWidth.U
+    (d << offset).asUInt
+  }.toSeq).reduce(_ | _)
+
+  when(delay_valid.asUInt.orR) {
+    data_state := Cat(data_base, data_site)
+    info_state := Cat(info_base, info.asUInt)
+    data_len_state := data_len_base + valid_num * (alignWidth / 8).U
+    info_len_state := info_len_base + (param.infoWidth / 8).U
+  }.otherwise {
+    data_state := data_base
+    info_state := info_base
+    data_len_state := data_len_base
+    info_len_state := info_len_base
+  }
+
+  data_out := data_state
+  info_out := info_state
+  data_len_out := data_len_state
+  info_len_out := info_len_state
 }

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -44,7 +44,7 @@ case class GatewayConfig(
   def dutBufLen: Int = if (isBatch) batchSize else 1
   def maxStep: Int = if (isBatch) batchSize else 1
   def stepWidth: Int = log2Ceil(maxStep + 1)
-  def batchArgByteLen: (Int, Int) = if (isNonBlock) (3904, 90) else (7800, 190)
+  def batchArgByteLen: (Int, Int) = if (isNonBlock) (3900, 92) else (7800, 192)
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
   def needEndpoint: Boolean = hasGlobalEnable || hasDutZone || isBatch || isSquash
@@ -177,8 +177,7 @@ class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) exten
   val control = Wire(new GatewaySinkControl(config))
 
   if (config.isBatch) {
-    val template = Batch.getTemplate(squashed)
-    val batch = Batch(template, squashed, config)
+    val batch = Batch(squashed, config)
     if (config.hasInternalStep) {
       control.step.get := batch.step
     } else {
@@ -190,7 +189,7 @@ class GatewayEndpoint(signals: Seq[DifftestBundle], config: GatewayConfig) exten
       control.dut_zone.get := zoneControl.get.dut_zone
     }
 
-    GatewaySink.batch(template, control, batch.io, config)
+    GatewaySink.batch(Batch.getTemplate, control, batch.io, config)
   } else {
     val squashed_enable = WireInit(true.B)
     if (config.hasGlobalEnable) {


### PR DESCRIPTION
Previous we give each bundle a different delay to collect valid value by Pipeline.

This change process bundles of same class in parallel, because offset is easy to count, and it will reduce stages in pipeline to reduces regs.

We also sort bundles by width, giving larger bundle less delay for less reg. And add `num` to info, which will reduce info costs with multiple bundle of same class.