### PR TITLE
vcs: support track pc

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -238,6 +238,10 @@ public:
     }
   }
 
+  uint64_t track_pc{0};
+  bool enable_track_pc{false};
+  int frequency{1};
+
   // Difftest public APIs for dut: called from DPI-C functions (or testbench)
   // These functions generally do nothing but copy the information to core_state.
   inline DifftestTrapEvent *get_trap_event() {
@@ -405,6 +409,8 @@ void difftest_trace_read();
 void difftest_trace_write(int step);
 
 int init_nemuproxy(size_t);
+
+void set_diff_track_pc(uint64_t track_pc);
 
 #ifdef CONFIG_DIFFTEST_SQUASH
 extern "C" void set_squash_scope();

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -37,6 +37,7 @@ static bool enable_difftest = true;
 static uint64_t max_instrs = 0;
 static char *workload_list = NULL;
 static uint64_t overwrite_nbytes = 0xe00;
+static uint64_t track_pc = 0;
 
 enum {
   SIMV_RUN,
@@ -63,6 +64,11 @@ extern "C" void set_gcpt_bin(char *s) {
 extern "C" void set_max_instrs(uint64_t mc) {
   printf("set max instrs: %lu\n", mc);
   max_instrs = mc;
+}
+
+extern "C" void set_track_pc(uint64_t pc) {
+  printf("set track pc: %lx\n", pc);
+  track_pc = pc;
 }
 
 extern const char *difftest_ref_so;
@@ -122,6 +128,7 @@ extern "C" uint8_t simv_init() {
   init_flash(flash_bin_file);
 
   difftest_init();
+  set_diff_track_pc(track_pc);
   init_device();
   if (enable_difftest) {
     init_goldenmem();

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -25,6 +25,7 @@ import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
 import "DPI-C" function byte simv_init();
 import "DPI-C" function void set_max_instrs(longint mc);
+import "DPI-C" function void set_track_pc(longint pc);
 `ifdef WITH_DRAMSIM3
 import "DPI-C" function void simv_tick();
 `endif // WITH_DRAMSIM3
@@ -75,6 +76,8 @@ wire workload_switch;
 
 reg [63:0] max_instrs;
 reg [63:0] max_cycles;
+
+reg [63:0] track_pc;
 
 initial begin
 `ifndef WIRE_CLK
@@ -141,6 +144,11 @@ initial begin
   // disable diff-test
   if ($test$plusargs("no-diff")) begin
     set_no_diff();
+  end
+  // set track pc
+  if ($test$plusargs("track-pc")) begin
+    $value$plusargs("track-pc=%h", track_pc);
+    set_track_pc(track_pc);
   end
 `ifdef ENABLE_WORKLOAD_SWITCH
   // set exit instrs const


### PR DESCRIPTION
when the commit PC is same value as the tracking PC, print the clock cycle. 
Sometimes the result is inaccurate for branch instruction and fused instruction. 
When multiple instructions are committed in a single cycle, the commit PC is inferred from the dut->commit[0].pc at the beginning of each cycle and the number of instructions has been committed in the current cycle.