### PR TITLE
verilator: be quiet for stats

### DIFF
--- a/verilator.mk
+++ b/verilator.mk
@@ -53,6 +53,10 @@ VERILATOR_5_000 := $(shell expr `$(VERILATOR_VER_CMD)` \>= 5000)
 ifeq ($(VERILATOR_5_000),1)
 VEXTRA_FLAGS += --no-timing +define+VERILATOR_5
 endif
+VERILATOR_5_024 := $(shell expr `$(VERILATOR_VER_CMD)` \>= 5024)
+ifeq ($(VERILATOR_5_024),1)
+VEXTRA_FLAGS += --quiet-stats
+endif
 
 # Verilator trace support
 EMU_TRACE ?=


### PR DESCRIPTION
Verilator v5.024 introduces stats reports for both verilation and simulation. These reports are never expected to be useful for normal users but brings annoying prints. We are disabling them by default.

For advanced users, they should remove the `--quiet-stats` option manually in the Makefile.

See https://github.com/verilator/verilator/issues/4909 and https://github.com/verilator/verilator/pull/5018.