### PR TITLE
Perf: report Simulation speed when finish

### DIFF
--- a/src/test/csrc/common/perf.cpp
+++ b/src/test/csrc/common/perf.cpp
@@ -31,12 +31,14 @@ void difftest_perfcnt_init() {
   diffstate_perfcnt_init();
 }
 
-void difftest_perfcnt_finish() {
+void difftest_perfcnt_finish(uint64_t cycleCnt) {
   printf("==================== Difftest PerfCnt ====================\n");
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
   perf_run_msec = ts.tv_sec * 1000 + ts.tv_nsec / 1000000 - perf_run_msec;
   printf("Run time: %lld s %lld ms\n", perf_run_msec / 1000, perf_run_msec % 1000);
+  float speed = (float)cycleCnt / (float)perf_run_msec;
+  printf("Simulation speed: %.2f KHz\n", speed);
   printf("%30s %15s %17s %16s %18s\n", "DPIC_FUNC", "DPIC_CALLS", "DPIC_CALLS/s", "DPIC_BYTES", "DPIC_BYTES/s");
   printf(">>> DiffState Func\n");
   diffstate_perfcnt_finish(perf_run_msec);

--- a/src/test/csrc/common/perf.h
+++ b/src/test/csrc/common/perf.h
@@ -25,7 +25,7 @@ static inline void difftest_perfcnt_print(const char *name, long long calls, lon
   printf("%30s %15lld %15lld/s %15lldB %15lldB/s\n", name, calls, calls_mean, bytes, bytes_mean);
 }
 void difftest_perfcnt_init();
-void difftest_perfcnt_finish();
+void difftest_perfcnt_finish(uint64_t cycleCnt);
 enum DIFFTEST_PERF {
   perf_simv_nstep,
   perf_difftest_ram_read,

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -113,7 +113,8 @@ void difftest_trace_write(int step) {
 
 void difftest_finish() {
 #ifdef CONFIG_DIFFTEST_PERFCNT
-  difftest_perfcnt_finish();
+  uint64_t cycleCnt = difftest[0]->get_trap_event()->cycleCnt;
+  difftest_perfcnt_finish(cycleCnt);
 #endif // CONFIG_DIFFTEST_PERFCNT
   diffstate_buffer_free();
   for (int i = 0; i < NUM_CORES; i++) {


### PR DESCRIPTION
As test in Palladium, Speed calculate by Time and CycleCnt is very close to Palladium report. We add this platform-independent report here.