### PR TITLE
vcs: exit with $fatal for errors

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -91,6 +91,7 @@ extern "C" void set_workload_list(char *s) {
   printf("set workload list %s \n", workload_list);
 }
 
+bool switch_workload_completed = false;
 int switch_workload() {
   static FILE *fp = fopen(workload_list, "r");
   if (fp) {
@@ -101,6 +102,7 @@ int switch_workload() {
       set_max_instrs(num);
     } else if (feof(fp)) {
       printf("Workload list is completed\n");
+      switch_workload_completed = true;
       fclose(fp);
       return 1;
     } else {
@@ -113,6 +115,10 @@ int switch_workload() {
     return 1;
   }
   return 0;
+}
+
+extern "C" bool workload_list_completed() {
+  return switch_workload_completed;
 }
 
 extern "C" void set_no_diff() {

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -98,7 +98,7 @@ initial begin
 `endif
     else begin
       $display("unknown wave file format, want [vpd, fsdb] but:%s\n", wave_type);
-      $finish();
+      $fatal();
     end
   end
 `endif
@@ -155,7 +155,7 @@ initial begin
   end
   else begin
     $display("workload switch is enabled but the workload list is not set");
-    $finish();
+    $fatal();
   end
 `endif // ENABLE_WORKLOAD_SWITCH
 `endif // TB_NO_DPIC
@@ -280,12 +280,12 @@ always @(posedge clock) begin
     if (!n_cycles) begin
       if (simv_init()) begin
         $display("DIFFTEST INIT FAILED");
-        $finish();
+        $fatal();
       end
     end
     else if (simv_result == `SIMV_FAIL) begin
       $display("DIFFTEST FAILED at cycle %d", n_cycles);
-      $finish();
+      $fatal();
     end
     else if (simv_result == `SIMV_DONE) begin
       $display("DIFFTEST WORKLOAD DONE at cycle %d", n_cycles);

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -31,6 +31,7 @@ import "DPI-C" function void simv_tick();
 `ifdef ENABLE_WORKLOAD_SWITCH
 import "DPI-C" function void set_workload_list(string path);
 `endif // ENABLE_WORKLOAD_SWITCH
+import "DPI-C" function byte workload_list_completed();
 `ifndef CONFIG_DIFFTEST_DEFERRED_RESULT
 import "DPI-C" function byte simv_nstep(byte step);
 `endif // CONFIG_DIFFTEST_DEFERRED_RESULT
@@ -279,8 +280,14 @@ always @(posedge clock) begin
     // difftest
     if (!n_cycles) begin
       if (simv_init()) begin
-        $display("DIFFTEST INIT FAILED");
-        $fatal();
+        if (workload_list_completed()) begin
+          $display("DIFFTEST WORKLOAD LIST DONE at cycle %d", n_cycles);
+          $finish();
+        end
+        else begin
+          $display("DIFFTEST INIT FAILED");
+          $fatal();
+        end
       end
     end
     else if (simv_result == `SIMV_FAIL) begin


### PR DESCRIPTION
When the simulation exits abnormally, we should let the user know there're failures.