### PR TITLE
vcs: call difftest_finish also when no-diff

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -227,9 +227,9 @@ void simv_finish() {
   flash_finish();
 
 #ifndef CONFIG_NO_DIFFTEST
+  difftest_finish();
   if (enable_difftest) {
     goldenmem_finish();
-    difftest_finish();
   }
 #endif // CONFIG_NO_DIFFTEST
 


### PR DESCRIPTION
This change is corresponding to difftest_init.