### PR TITLE
vcs: remove bracket of $fatal

### DIFF
--- a/scripts/palladium/argConfigs.qel
+++ b/scripts/palladium/argConfigs.qel
@@ -1,5 +1,6 @@
 * $test$plusargs TB_IMPORT
 * $value$plusargs TB_IMPORT
 * $finish TB_IMPORT
+* $fatal TB_IMPORT
 * $random TB_IMPORT
 * $fwrite GFIFO

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -99,7 +99,7 @@ initial begin
 `endif
     else begin
       $display("unknown wave file format, want [vpd, fsdb] but:%s\n", wave_type);
-      $fatal();
+      $fatal;
     end
   end
 `endif
@@ -156,7 +156,7 @@ initial begin
   end
   else begin
     $display("workload switch is enabled but the workload list is not set");
-    $fatal();
+    $fatal;
   end
 `endif // ENABLE_WORKLOAD_SWITCH
 `endif // TB_NO_DPIC
@@ -286,13 +286,13 @@ always @(posedge clock) begin
         end
         else begin
           $display("DIFFTEST INIT FAILED");
-          $fatal();
+          $fatal;
         end
       end
     end
     else if (simv_result == `SIMV_FAIL) begin
       $display("DIFFTEST FAILED at cycle %d", n_cycles);
-      $fatal();
+      $fatal;
     end
     else if (simv_result == `SIMV_DONE) begin
       $display("DIFFTEST WORKLOAD DONE at cycle %d", n_cycles);


### PR DESCRIPTION
Palladium disallow empty argument for $fatal(). We remove bracket and declare it as TB_IMPORT