### PR TITLE
LoadEvent: replace fuType with isAtomic and isLoad

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -226,7 +226,8 @@ class StoreEvent extends DifftestBaseBundle with HasValid {
 class LoadEvent extends DifftestBaseBundle with HasValid {
   val paddr = UInt(64.W)
   val opType = UInt(8.W)
-  val fuType = UInt(8.W)
+  val isAtomic = Bool()
+  val isLoad = Bool() // Todo: support vector load
 }
 
 class AtomicEvent extends DifftestBaseBundle with HasValid {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -505,7 +505,7 @@ int Difftest::do_instr_commit(int i) {
   // Handle load instruction carefully for SMP
   if (NUM_CORES > 1) {
 #ifdef CONFIG_DIFFTEST_LOADEVENT
-    if (dut->load[i].fuType == 0xC || dut->load[i].fuType == 0xF) {
+    if (dut->load[i].isLoad || dut->load[i].isAtomic) {
       proxy->sync();
       bool reg_cmp_fail =
           !dut->commit[i].vecwen && *proxy->arch_reg(dut->commit[i].wdest, dut->commit[i].fpwen) != get_commit_data(i);
@@ -514,7 +514,7 @@ int Difftest::do_instr_commit(int i) {
         // printf("---    ltype: 0x%x paddr: 0x%lx wen: 0x%x wdst: 0x%x wdata: 0x%lx pc: 0x%lx\n", dut->load[i].opType, dut->load[i].paddr, dut->commit[i].wen, dut->commit[i].wdest, get_commit_data(i), dut->commit[i].pc);
         uint64_t golden;
         int len = 0;
-        if (dut->load[i].fuType == 0xC) {
+        if (dut->load[i].isLoad) {
           switch (dut->load[i].opType) {
             case 0: len = 1; break;
             case 1: len = 2; break;
@@ -525,7 +525,7 @@ int Difftest::do_instr_commit(int i) {
             case 6: len = 4; break;
             default: Info("Unknown fuOpType: 0x%x\n", dut->load[i].opType);
           }
-        } else { // dut->load[i].fuType == 0xF
+        } else if (dut->load[i].isAtomic) {
           if (dut->load[i].opType % 2 == 0) {
             len = 4;
           } else { // dut->load[i].opType % 2 == 1
@@ -533,7 +533,7 @@ int Difftest::do_instr_commit(int i) {
           }
         }
         read_goldenmem(dut->load[i].paddr, &golden, len);
-        if (dut->load[i].fuType == 0xC) {
+        if (dut->load[i].isLoad) {
           switch (dut->load[i].opType) {
             case 0: golden = (int64_t)(int8_t)golden; break;
             case 1: golden = (int64_t)(int16_t)golden; break;
@@ -549,7 +549,7 @@ int Difftest::do_instr_commit(int i) {
             }
             proxy->sync(true);
           }
-        } else if (dut->load[i].fuType == 0xF) { //  atomic instr carefully handled
+        } else if (dut->load[i].isAtomic) { //  atomic instr carefully handled
           proxy->ref_memcpy(dut->load[i].paddr, &golden, len, DUT_TO_REF);
           if (realWen) {
             if (!dut->commit[i].vecwen) {


### PR DESCRIPTION
New LoadEvent bundle fit XiangShan since commt [0c00289](https://github.com/OpenXiangShan/XiangShan/commit/0c002899437318e70e22fef7cb1df29f0fa8ca68)

As XiangShan change the encoding of fuType, two more decoupled singal isAtomic and isLoad is added to distinguash different load event, replacing the whole fuType
