### PR TITLE
vcs: add set_overwrite_nbytes of gcpt.bin

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -61,6 +61,10 @@ extern "C" void set_flash_bin(char *s) {
   strcpy(flash_bin_file, s);
 }
 
+extern "C" void set_overwrite_nbytes(uint64_t len) {
+  overwrite_nbytes = len;
+}
+
 extern "C" void set_gcpt_bin(char *s) {
   gcpt_restore_bin = (char *)malloc(256);
   strcpy(gcpt_restore_bin, s);

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -25,6 +25,7 @@ import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
 import "DPI-C" function byte simv_init();
 import "DPI-C" function void set_max_instrs(longint mc);
+import "DPI-C" function void set_overwrite_nbytes(longint len);
 `ifdef WITH_DRAMSIM3
 import "DPI-C" function void simv_tick();
 `endif // WITH_DRAMSIM3
@@ -69,6 +70,7 @@ string gcpt_bin_file;
 string wave_type;
 string diff_ref_so;
 string workload_list;
+longint overwrite_nbytes;
 
 `ifdef ENABLE_WORKLOAD_SWITCH
 wire workload_switch;
@@ -128,6 +130,11 @@ initial begin
   if ($test$plusargs("flash")) begin
     $value$plusargs("flash=%s", flash_bin_file);
     set_flash_bin(flash_bin_file);
+  end
+  // size of the gcpt used
+  if ($test$plusargs("overwrite_nbytes")) begin
+    $value$plusargs("overwrite_nbytes=%d", overwrite_nbytes);
+    set_overwrite_nbytes(overwrite_nbytes);
   end
   // overwrite gcpt on ram: bin file
   if ($test$plusargs("gcpt-restore")) begin


### PR DESCRIPTION
Since we have different sizes of gcpt that need to be replaced in order to recover different core numbers or instruction sets with new checkpoints, we need to add this feature in order to support different sizes of gcpt