### PR TITLE
Make: add support for compiling difftest as a lib.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ endif
 include verilator.mk
 include vcs.mk
 include palladium.mk
+include libso.mk
 
 clean: vcs-clean pldm-clean
 	rm -rf $(BUILD_DIR)

--- a/libso.mk
+++ b/libso.mk
@@ -1,0 +1,18 @@
+LIBDIFFTEST_SO    	 = $(BUILD_DIR)/libdifftest.so
+CC_OBJ_DIR	 	 = $(abspath $(BUILD_DIR)/cc_obj)
+
+PLDM_CSRC_DIR 	 = $(abspath ./src/test/csrc/vcs)
+PLDM_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(PLDM_CSRC_DIR) -name "*.cpp")
+PLDM_CXXFLAGS 	 = -m64 -c -fPIC -g -std=c++11
+PLDM_CXXFLAGS 	+= $(subst \\\",\", $(SIM_CXXFLAGS)) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
+
+ifeq ($(WITH_DRAMSIM3),1)
+LD_LIB  	 = -L $(DRAMSIM3_HOME)/ -ldramsim3 -Wl,-rpath-link=$(DRAMSIM3_HOME)/libdramsim3.so
+endif
+
+$(CC_OBJ_DIR):
+	mkdir -p $(CC_OBJ_DIR)
+difftest-so-pldm: $(CC_OBJ_DIR)
+	cd $(CC_OBJ_DIR) 					&& \
+	$(CC) $(PLDM_CXXFLAGS) $(PLDM_CXXFILES)			&& \
+	$(CC) -o $(LIBDIFFTEST_SO) -m64 -shared *.o $(LD_LIB)

--- a/libso.mk
+++ b/libso.mk
@@ -1,5 +1,5 @@
-LIBDIFFTEST_SO    	 = $(BUILD_DIR)/libdifftest.so
-CC_OBJ_DIR	 	 = $(abspath $(BUILD_DIR)/cc_obj)
+LIBDIFFTEST_SO   = $(BUILD_DIR)/libdifftest.so
+CC_OBJ_DIR	 = $(abspath $(BUILD_DIR)/cc_obj)
 
 LIB_CSRC_DIR 	 = $(abspath ./src/test/csrc/vcs)
 LIB_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(LIB_CSRC_DIR) -name "*.cpp")
@@ -12,6 +12,7 @@ endif
 
 $(CC_OBJ_DIR):
 	mkdir -p $(CC_OBJ_DIR)
+
 difftest-so: $(CC_OBJ_DIR)
 	cd $(CC_OBJ_DIR) 					&& \
 	$(CC) $(LIB_CXXFLAGS) $(LIB_CXXFILES)			&& \

--- a/libso.mk
+++ b/libso.mk
@@ -1,10 +1,10 @@
 LIBDIFFTEST_SO    	 = $(BUILD_DIR)/libdifftest.so
 CC_OBJ_DIR	 	 = $(abspath $(BUILD_DIR)/cc_obj)
 
-PLDM_CSRC_DIR 	 = $(abspath ./src/test/csrc/vcs)
-PLDM_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(PLDM_CSRC_DIR) -name "*.cpp")
-PLDM_CXXFLAGS 	 = -m64 -c -fPIC -g -std=c++11
-PLDM_CXXFLAGS 	+= $(subst \\\",\", $(SIM_CXXFLAGS)) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
+LIB_CSRC_DIR 	 = $(abspath ./src/test/csrc/vcs)
+LIB_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(LIB_CSRC_DIR) -name "*.cpp")
+LIB_CXXFLAGS 	 = -m64 -c -fPIC -g -std=c++11
+LIB_CXXFLAGS 	+= $(subst \\\",\", $(SIM_CXXFLAGS)) -I$(LIB_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
 
 ifeq ($(WITH_DRAMSIM3),1)
 LD_LIB  	 = -L $(DRAMSIM3_HOME)/ -ldramsim3 -Wl,-rpath-link=$(DRAMSIM3_HOME)/libdramsim3.so
@@ -12,7 +12,7 @@ endif
 
 $(CC_OBJ_DIR):
 	mkdir -p $(CC_OBJ_DIR)
-difftest-so-pldm: $(CC_OBJ_DIR)
+difftest-so: $(CC_OBJ_DIR)
 	cd $(CC_OBJ_DIR) 					&& \
-	$(CC) $(PLDM_CXXFLAGS) $(PLDM_CXXFILES)			&& \
+	$(CC) $(LIB_CXXFLAGS) $(LIB_CXXFILES)			&& \
 	$(CC) -o $(LIBDIFFTEST_SO) -m64 -shared *.o $(LD_LIB)


### PR DESCRIPTION
This commit adds support for using difftest as a lib to simulate with XS.
For now, it works both on VCS and Palladium.
use "make difftest-so" to generate libdifftest.so and link it when compiling your design. 