### PR TITLE
stack: large the size

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -170,7 +170,7 @@ extern unsigned long EMU_FLASH_SIZE;
 // #define ENABLE_IPC
 
 // stack size for emu
-#define EMU_STACK_SIZE (16 * 1024 * 1024)
+#define EMU_STACK_SIZE (32 * 1024 * 1024)
 
 // whether to maintain goldenmem
 #if NUM_CORES>1


### PR DESCRIPTION
MultiCore test in XiangShan will failed with origin small stack size. So there larges the stack size.