### PR TITLE
ram: fix zstd load on readFromZstd

### DIFF
--- a/src/test/csrc/common/compress.cpp
+++ b/src/test/csrc/common/compress.cpp
@@ -200,7 +200,7 @@ long readFromZstd(void *ptr, const char *file_name, long buf_size, uint8_t load_
 
   lseek(fd, 0, SEEK_SET);
 
-  long *temp_page = (long *)mallo(chunk_size);
+  long *temp_page = (long *)malloc(chunk_size);
   compress_file_buffer = (uint8_t *)malloc(file_size);
   assert(compress_file_buffer);
 

--- a/src/test/csrc/common/compress.cpp
+++ b/src/test/csrc/common/compress.cpp
@@ -200,7 +200,7 @@ long readFromZstd(void *ptr, const char *file_name, long buf_size, uint8_t load_
 
   lseek(fd, 0, SEEK_SET);
 
-  long *temp_page = (long *)malloc(chunk_size);
+  long *temp_page = (long *)malloc(chunk_size * sizeof(long));
   compress_file_buffer = (uint8_t *)malloc(file_size);
   assert(compress_file_buffer);
 


### PR DESCRIPTION
This will fix cases that may cause errors in other function segments because the new array is too large