### PR TITLE
vcs: check max-instrs for every cpu core

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1172,8 +1172,8 @@ void Difftest::display_stats() {
   uint64_t instrCnt = trap->instrCnt;
   uint64_t cycleCnt = trap->cycleCnt;
   double ipc = (double)instrCnt / cycleCnt;
-  eprintf(ANSI_COLOR_MAGENTA "instrCnt = %'" PRIu64 ", cycleCnt = %'" PRIu64 ", IPC = %lf\n" ANSI_COLOR_RESET, instrCnt,
-          cycleCnt, ipc);
+  eprintf(ANSI_COLOR_MAGENTA "Core-%d instrCnt = %'" PRIu64 ", cycleCnt = %'" PRIu64 ", IPC = %lf\n" ANSI_COLOR_RESET,
+          this->id, instrCnt, cycleCnt, ipc);
 }
 
 void DiffState::display_commit_count(int i) {

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -43,11 +43,11 @@ static bool enable_difftest = true;
 static uint64_t max_instrs = 0;
 static char *workload_list = NULL;
 static uint64_t overwrite_nbytes = 0xe00;
-struct CORE_END_INFO {
+struct core_end_info_t {
   bool core_trap[NUM_CORES];
   uint8_t core_trap_num;
 };
-static CORE_END_INFO core_end_info;
+static core_end_info_t core_end_info;
 
 enum {
   SIMV_RUN,
@@ -197,10 +197,10 @@ extern "C" uint8_t simv_step() {
   if (max_instrs != 0) { // 0 for no limit
     for (int i = 0; i < NUM_CORES; i++) {
       if (core_end_info.core_trap[i])
-        break;
+        continue;
       auto trap = difftest[i]->get_trap_event();
       if (max_instrs < trap->instrCnt) {
-        core_end_info.core_trap[i] = 1;
+        core_end_info.core_trap[i] = true;
         core_end_info.core_trap_num++;
         eprintf(ANSI_COLOR_GREEN "EXCEEDED CORE-%d MAX INSTR: %ld\n" ANSI_COLOR_RESET, i, max_instrs);
         difftest[i]->display_stats();
@@ -254,7 +254,7 @@ void simv_finish() {
   simMemory = nullptr;
 
   for (int i = 0; i < NUM_CORES; i++)
-    core_end_info.core_trap[i] = 0;
+    core_end_info.core_trap[i] = false;
   core_end_info.core_trap_num = 0;
 }
 

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -43,6 +43,11 @@ static bool enable_difftest = true;
 static uint64_t max_instrs = 0;
 static char *workload_list = NULL;
 static uint64_t overwrite_nbytes = 0xe00;
+struct CORE_END_INFO {
+  bool core_trap[NUM_CORES];
+  uint8_t core_trap_num;
+};
+static CORE_END_INFO core_end_info;
 
 enum {
   SIMV_RUN,
@@ -190,11 +195,18 @@ extern "C" uint8_t simv_step() {
   }
 
   if (max_instrs != 0) { // 0 for no limit
-    auto trap = difftest[0]->get_trap_event();
-    if (max_instrs < trap->instrCnt) {
-      eprintf(ANSI_COLOR_GREEN "EXCEEDED MAX INSTR: %ld\n" ANSI_COLOR_RESET, max_instrs);
-      difftest[0]->display_stats();
-      return SIMV_DONE;
+    for (int i = 0; i < NUM_CORES; i++) {
+      if (core_end_info.core_trap[i])
+        break;
+      auto trap = difftest[i]->get_trap_event();
+      if (max_instrs < trap->instrCnt) {
+        core_end_info.core_trap[i] = 1;
+        core_end_info.core_trap_num++;
+        eprintf(ANSI_COLOR_GREEN "EXCEEDED CORE-%d MAX INSTR: %ld\n" ANSI_COLOR_RESET, i, max_instrs);
+        difftest[i]->display_stats();
+        if (core_end_info.core_trap_num == NUM_CORES)
+          return SIMV_DONE;
+      }
     }
   }
 #endif // CONFIG_NO_DIFFTEST

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -252,6 +252,10 @@ void simv_finish() {
   finish_device();
   delete simMemory;
   simMemory = nullptr;
+
+  for (int i = 0; i < NUM_CORES; i++)
+    core_end_info.core_trap[i] = 0;
+  core_end_info.core_trap_num = 0;
 }
 
 static uint8_t simv_result = SIMV_RUN;


### PR DESCRIPTION
When exiting the program using max_instrs, ensure that each core runs to the corresponding number of instructions, and add the core id when printing the IPC