### PR TITLE
difftest: support dual warmup on all platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -404,4 +404,4 @@ jobs:
             echo "./ready-to-run/microbench.bin 10000" > list.txt
             echo "./ready-to-run/linux.bin 20000" >> list.txt
             make simv VCS=verilator WORKLOAD_SWITCH=1 -j2
-            ./build/simv +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so +workload-list=./list.txt
+            ./build/simv +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so +workload-list=./list.txt +warmup-instr=10000

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1171,7 +1171,7 @@ void Difftest::display_stats() {
   auto trap = get_trap_event();
   uint64_t instrCnt = trap->instrCnt;
   uint64_t cycleCnt = trap->cycleCnt;
-  double ipc = (double)instrCnt / cycleCnt;
+  double ipc = (double)(instrCnt - warmup_instrs) / (cycleCnt - warmup_cycle);
   eprintf(ANSI_COLOR_MAGENTA "Core-%d instrCnt = %'" PRIu64 ", cycleCnt = %'" PRIu64 ", IPC = %lf\n" ANSI_COLOR_RESET,
           this->id, instrCnt, cycleCnt, ipc);
 }

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -273,6 +273,11 @@ public:
     state->dump_commit_trace = enable;
   }
 
+  void set_warmup_info(uint64_t cycle, uint64_t instr) {
+    warmup_cycle = cycle;
+    warmup_instrs = instr;
+  }
+
 protected:
   DiffTrace *difftrace = nullptr;
 
@@ -297,6 +302,8 @@ protected:
 
   int id;
 
+  uint64_t warmup_cycle = 0;
+  uint64_t warmup_instrs = 0;
   bool progress = false;
   uint64_t ticks = 0;
   uint64_t last_commit = 0;

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -722,8 +722,12 @@ int Emulator::tick() {
     auto trap = difftest[i]->get_trap_event();
     if (trap->instrCnt >= args.warmup_instr) {
       Info("Warmup finished. The performance counters will be dumped and then reset.\n");
+#if defined(NUM_CORES == 1)
       dut_ptr->difftest_perfCtrl_clean = 1;
       dut_ptr->difftest_perfCtrl_dump = 1;
+#else
+      set_warmup_info(trap->cycleCnt, warmup_instrs);
+#endif
       args.warmup_instr = -1;
     }
     if (trap->cycleCnt % args.stat_cycles == args.stat_cycles - 1) {

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -726,7 +726,7 @@ int Emulator::tick() {
       dut_ptr->difftest_perfCtrl_clean = 1;
       dut_ptr->difftest_perfCtrl_dump = 1;
 #else
-      set_warmup_info(trap->cycleCnt, warmup_instrs);
+      difftest[i]->set_warmup_info(trap->cycleCnt, warmup_instrs);
 #endif
       args.warmup_instr = -1;
     }

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -26,6 +26,7 @@ import "DPI-C" function void set_no_diff();
 import "DPI-C" function byte simv_init();
 import "DPI-C" function void set_max_instrs(longint mc);
 import "DPI-C" function void set_overwrite_nbytes(longint len);
+import "DPI-C" function void set_warmup_instrs(longint instrs);
 `ifdef WITH_DRAMSIM3
 import "DPI-C" function void simv_tick();
 `endif // WITH_DRAMSIM3
@@ -71,6 +72,7 @@ string wave_type;
 string diff_ref_so;
 string workload_list;
 longint overwrite_nbytes;
+longint warmup_instr;
 
 `ifdef ENABLE_WORKLOAD_SWITCH
 wire workload_switch;
@@ -140,6 +142,10 @@ initial begin
   if ($test$plusargs("gcpt-restore")) begin
     $value$plusargs("gcpt-restore=%s", gcpt_bin_file);
     set_gcpt_bin(gcpt_bin_file);
+  end
+  // warmup instr
+  if ($test$plusargs("warmup-instr")) begin
+    $value$plusargs("warmup-instr=%d", warmup_instr);
   end
   // diff-test golden model: nemu-so
   if ($test$plusargs("diff")) begin


### PR DESCRIPTION
Clearing all performance counters with difftest_perfCtrl_clean can lead to incorrect performance statistics on multiple cores, because the number of instruction commits varies from core to core
Now, the information of the completion of warmup under multi-core is counted into the difftest framework, which supports several platforms currently used