### PR TITLE
Delayer: optionally use Mem to reduce gates

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -280,8 +280,9 @@ class BatchCollector(
   val info_len_state = RegInit(0.U(param.MaxInfoByteWidth.W))
 
   val align_data = VecInit(data_in.map(i => Batch.bundleAlign(i)).toSeq)
-  val delay_data = VecInit(align_data.map(i => Delayer(i, delay)).toSeq)
-  val delay_valid = VecInit(data_in.map(i => Delayer(i.bits.needUpdate.get && enable, delay)).toSeq)
+  val valid_vec = VecInit(data_in.map(i => i.bits.needUpdate.get && enable))
+  val delay_data = Delayer(align_data.asUInt, delay, useMem = true).asTypeOf(align_data)
+  val delay_valid = Delayer(valid_vec.asUInt, delay, useMem = true).asTypeOf(valid_vec)
 
   val valid_num = PopCount(delay_valid)
   val info = Wire(new BatchInfo)

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -17,6 +17,7 @@
 package difftest
 
 import chisel3._
+import chisel3.util._
 import difftest.common.DifftestWiring
 import difftest.gateway.Gateway
 
@@ -472,9 +473,11 @@ object DifftestModule {
 }
 
 private class Delayer[T <: Data](gen: T, n_cycles: Int) extends Module {
-  val i = IO(Input(gen.cloneType))
-  val o = IO(Output(gen.cloneType))
+  val i = IO(Input(chiselTypeOf(gen)))
+  val o = IO(Output(chiselTypeOf(gen)))
+}
 
+private class DelayReg[T <: Data](gen: T, n_cycles: Int) extends Delayer(gen, n_cycles) {
   var r = WireInit(i)
   for (_ <- 0 until n_cycles) {
     r = RegNext(r, 0.U.asTypeOf(gen))
@@ -482,10 +485,27 @@ private class Delayer[T <: Data](gen: T, n_cycles: Int) extends Module {
   o := r
 }
 
+private class DelayMem[T <: Data](gen: T, n_cycles: Int) extends Delayer(gen, n_cycles) {
+  val mem = Mem(n_cycles, chiselTypeOf(gen))
+  val ptr = RegInit(0.U(log2Ceil(n_cycles).W))
+  val init_flag = RegInit(false.B)
+  mem(ptr) := i
+  ptr := ptr + 1.U
+  when(ptr === (n_cycles - 1).U) {
+    init_flag := true.B
+    ptr := 0.U
+  }
+  o := Mux(init_flag, mem(ptr), 0.U.asTypeOf(gen))
+}
+
 object Delayer {
-  def apply[T <: Data](gen: T, n_cycles: Int): T = {
+  def apply[T <: Data](gen: T, n_cycles: Int, useMem: Boolean = false): T = {
     if (n_cycles > 0) {
-      val delayer = Module(new Delayer(gen, n_cycles))
+      val delayer = if (useMem) {
+        Module(new DelayMem(gen, n_cycles))
+      } else {
+        Module(new DelayReg(gen, n_cycles))
+      }
       delayer.i := gen
       delayer.o
     } else {


### PR DESCRIPTION
We use delayer to delay signal for several cycles. Now we can use Reg or Mem to implement it. In some case like Palladium, Mem will be treated as RAM, it will save more gates than register.