### PR TITLE
emu: update the stack size only for legacy Verilator

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -169,9 +169,6 @@ extern unsigned long EMU_FLASH_SIZE;
 // set WITH_IPC=1 when make to enable drawing ipc curve in verilator simulation
 // #define ENABLE_IPC
 
-// stack size for emu
-#define EMU_STACK_SIZE (32 * 1024 * 1024)
-
 // whether to maintain goldenmem
 #if NUM_CORES>1
 #define DEBUG_GOLDENMEM


### PR DESCRIPTION
Verilator v5.026 comes with an automated stack resizer (see https://github.com/verilator/verilator/pull/5104) for various verilated models. The stack size will be set implicitly in the constructor of the verilated design based on an estimated stack size requirement.

Thus, we comment out the `setrlimit` lines for newer version of Verilator. They will use the estimated stack size instead of the predetermined constant value.