### PR TITLE
Makefile: set difftest_verilog the default target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate Verilog
         run: |
-          make difftest_verilog
+          make
 
   test-difftest-nutshell:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ RTL_SUFFIX ?= v
 SIM_TOP_V = $(RTL_DIR)/$(SIM_TOP).$(RTL_SUFFIX)
 
 # generate difftest files for non-chisel design.
+.DEFAULT_GOAL := difftest_verilog
 difftest_verilog:
 	mill -i difftest.test.runMain difftest.DifftestMain --target-dir $(RTL_DIR)
 
@@ -44,7 +45,6 @@ TIME_CMD = time -a -o $(TIMELOG)
 
 # remote machine with more cores to speedup c++ build
 REMOTE ?= localhost
-.DEFAULT_GOAL = emu
 
 # simulation
 SIM_CONFIG_DIR = $(abspath ./config)


### PR DESCRIPTION
This commit changes the default target of make to difftest_verilog.

The previous default target is emu. However, emu is for only the Verilator target, one of the three supported simulation platforms.

To make the default target clearer, we change the default target to difftest_verilog. It generates example difftest design-under-test interfaces and C++ files. Using this main target, user may connect their own design (maybe in Verilog) to difftest for simulation.