### PR TITLE
Avoid warning messages when ccache does not exist

### DIFF
--- a/verilator.mk
+++ b/verilator.mk
@@ -37,7 +37,7 @@ EMU = $(BUILD_DIR)/fuzzer
 endif
 
 # CCACHE
-CCACHE := $(if $(shell which ccache),ccache,)
+CCACHE := $(if $(shell which ccache 2> /dev/null),ccache,)
 ifneq ($(CCACHE),)
 export OBJCACHE = ccache
 endif


### PR DESCRIPTION
verilator.mk checks the existence of ccache and use it when possible. However, on some OS platforms, such as CentOS, this checker may cause warning messages if ccache does not exist. Since this checker is always called even when the user is not building Verilator targets, the warning message seems confused for users.

We avoid this message by redirecting the stderr to /dev/null.