### PR TITLE
spike-dasm: performance improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,21 @@ To use DiffTest, please include all necessary modules and top-level IOs in your 
 It's worth noting the Chisel Bundles may have arguments with default values.
 Please set the correct parameters for the interfaces.
 
-# References
+## Plugins
+
+There are several plugins to improvement the RTL-simulation and debugging process.
+
+### spike-dasm: a disassembly engine for RISC-V instructions
+
+When the simulation aborts, DiffTest gives a report on the current architectural states and a list of recently commited instructions.
+To simplify the debugging process, we may want the disassembly of the executed instructions.
+DiffTest is currently using the `spike-dasm` command provided by the [riscv-isa-sim](https://github.com/riscv-software-src/riscv-isa-sim) project for RISC-V instruction disassembly.
+To use this plugin, you are required to build it from source and install the tool to somewhere in your `PATH`.
+DiffTest will automatically detect its existence by searching the `PATH`.
+Please refer to [the original README](https://github.com/riscv-software-src/riscv-isa-sim?tab=readme-ov-file#build-steps) for detailed installation instructions.
+Feel free to change the `--prefix=` argument to where you have access to, such as `~/.cache`, so that you won't need the `sudo` privilege for the installation.
+
+## References
 
 * Theories of DiffTest / DiffTest 的基本原理
   * [一生一芯计划讲义](https://ysyx.oscc.cc/slides/2205/12.html)

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -189,13 +189,8 @@ private:
     }
   }
   void display_commit_count(int i);
-  void display_commit_instr(int i) {
-    extern int test_spike();
-    int spike_invalid = test_spike();
-    display_commit_instr(retire_inst_pointer, spike_invalid);
-    fflush(stdout);
-  }
-  void display_commit_instr(int i, bool spike_invalid);
+  void display_commit_instr(int i);
+  void display_commit_instr(int i, bool use_spike);
 };
 
 class Difftest {

--- a/src/test/csrc/plugin/spikedasm/spikedasm.h
+++ b/src/test/csrc/plugin/spikedasm/spikedasm.h
@@ -14,6 +14,7 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-extern char *dasm_result;
-int test_spike();
-void spike_dasm(char *result, char *input);
+#include <cstdint>
+
+bool spike_valid();
+const char *spike_dasm(uint64_t inst);


### PR DESCRIPTION
We remove unnecessary extra logic to dasm the instruction string. The execution speed is improved by 1.78X.

We also add redirection for stderr when checking the existence of spike-dasm. This should avoid the not-found warning when running the simulation.

After this change, the user may not be aware of the spike-dasm plugin for disassembly the instruction. Therefore, we update the README as well.