### PR TITLE
verilator: use -O0 in OPT_SLOW

### DIFF
--- a/verilator.mk
+++ b/verilator.mk
@@ -141,7 +141,7 @@ EMU_COMPILE_FILTER =
 build_emu_local: $(EMU_MK)
 	@echo -e "\n[c++] Compiling C++ files..." >> $(TIMELOG)
 	@date -R | tee -a $(TIMELOG)
-	$(TIME_CMD) $(MAKE) -s VM_PARALLEL_BUILDS=1 OPT_FAST="-O3" -C $(<D) -f $(<F) $(EMU_COMPILE_FILTER)
+	$(TIME_CMD) $(MAKE) -s VM_PARALLEL_BUILDS=1 OPT_FAST="-O3" OPT_SLOW="-O0" -C $(<D) -f $(<F) $(EMU_COMPILE_FILTER)
 
 $(EMU): $(EMU_MK) $(EMU_DEPS) $(EMU_HEADERS)
 ifeq ($(REMOTE),localhost)


### PR DESCRIPTION
Verilator's default OPT_SLOW is empty, which defaults to -O2 in nix environment.
This PR explicitly set OPT_SLOW to -O0, which will reduce total CPU time when compiling C++ to binary.

A typical cli args compiling XiangShan in nix is as follows:
```
-fPIC
-Wformat
-Wformat-security
-Werror=format-security
-fstack-protector-strong
--param
ssp-buffer-size=4
-O2
-U_FORTIFY_SOURCE
-fwrapv
-target
x86_64-unknown-linux-gnu
-I.
-MMD
-I/nix/store/8ig1aks3glkph3y165gzlgiwsxnagx8w-verilator-5.022/share/verilator/include
-I/nix/store/8ig1aks3glkph3y165gzlgiwsxnagx8w-verilator-5.022/share/verilator/include/vltstd
-DVM_COVERAGE=0
-DVM_SC=0
-DVM_TRACE=1
-DVM_TRACE_FST=1
-DVM_TRACE_VCD=0
-faligned-new
-fbracket-depth=4096
-fcf-protection=none
-Qunused-arguments
-Wno-bool-operation
-Wno-c++11-narrowing
-Wno-constant-logical-operand
-Wno-non-pod-varargs
-Wno-parentheses-equality
-Wno-shadow
-Wno-sign-compare
-Wno-tautological-bitwise-compare
-Wno-tautological-compare
-Wno-uninitialized
-Wno-unused-but-set-parameter
-Wno-unused-but-set-variable
-Wno-unused-parameter
-Wno-unused-variable
-I/nfs/home/manyang/project/XiangShan-3/difftest/src/test/csrc/common
-I/nfs/home/manyang/project/XiangShan-3/difftest/config
-DNOOP_HOME=\"/nfs/home/manyang/project/XiangShan-3\"
-I/nfs/home/manyang/project/XiangShan-3/build/generated-src
-I/nfs/home/manyang/project/XiangShan-3/difftest/src/test/csrc/plugin/include
-I/nfs/home/manyang/project/XiangShan-3/difftest/src/test/csrc/difftest
-I/nfs/home/manyang/project/XiangShan-3/build
-DENABLE_CHISEL_DB
-I/nfs/home/manyang/project/XiangShan-3/build
-DENABLE_CONSTANTIN
-I/nfs/home/manyang/project/XiangShan-3/difftest/src/test/csrc/plugin/spikedasm
-I/nfs/home/manyang/project/XiangShan-3/difftest/src/test/csrc/verilator
-DVERILATOR
-DNUM_CORES=1
--std=c++17
-DVERILATOR_4_210
-DENABLE_FST
-DEMU_THREAD=16
-include-pch
VSimTop__pch.h.slow.gch
-c
-o
VSimTop___024root__DepSet_hd5918264__3603__Slow.o
VSimTop___024root__DepSet_hd5918264__3603__Slow.cpp
-U_FORTIFY_SOURCE
-D_FORTIFY_SOURCE=2
-B/nix/store/apab5i73dqa09wx0q27b6fbhd1r18ihl-glibc-2.39-31/lib/
-idirafter
/nix/store/s3pvsv4as7mc8i2nwnk2hnsyi2qdj4bq-glibc-2.39-31-dev/include
-B/nix/store/9hgsinpfgyvsd92v0wlvmxv9wnaal68r-gcc-13.2.0/lib/gcc/x86_64-unknown-linux-gnu/13.2.0
--gcc-toolchain=/nix/store/9hgsinpfgyvsd92v0wlvmxv9wnaal68r-gcc-13.2.0
-B/nix/store/yz65gc7zz2jnnfhkch7szy9qzbd5w1bx-clang-17.0.6-lib/lib
-resource-dir=/nix/store/gvca63q7jgclvnc6fc5339vb6mry3xdn-clang-wrapper-17.0.6/resource-root
-B/nix/store/gvca63q7jgclvnc6fc5339vb6mry3xdn-clang-wrapper-17.0.6/bin/
-frandom-seed=9yr4ym76dw
...

```
This results in several "Slow" cpp consuming around 20-30 minutes, while being unnecessary.

Related document:
> OPT_FAST specifies optimization options for those parts of the model on the fast path. This is mostly code that is executed every cycle. OPT_SLOW applies to slow-path code, which rarely executes, often only once at the beginning or end of the simulation.
> Files controlled by OPT_SLOW have little effect on performance, and therefore OPT_SLOW is empty by default (equivalent to “-O0”) for improved compilation speed. In common use cases, there should be little benefit in changing OPT_SLOW.
> https://veripool.org/guide/latest/simulating.html#benchmarking-optimization
