### PR TITLE
difftest: Enable difftest without optional DifftestTopIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ val difftest = DifftestModule.finish("Demo")
 difftest.uart <> mmio.io.uart
 ```
 
+Alternatively, you can skip the optional UART connections by using an overloaded version
+of `DifftestModule.finish(cpu: String, createTopIO: Boolean)` with the 2nd parameter
+`createTopIO` set to `false`. This overloaded version can be used in non-module context
+(e.g. in App class) as following.
+
+```scala
+object Main extends App {
+  // ...
+  DifftestModule.finish("Demo", false)
+}
+```
+
 4. Generate verilog files for simulation.
 
 5. `make emu` and start simulating & debugging!

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -342,7 +342,7 @@ object DifftestModule {
     difftest
   }
 
-  def finish(cpu: String): DifftestTopIO = {
+  def finish(cpu: String, createTopIO: Boolean): Option[DifftestTopIO] = {
     val gateway = Gateway.collect()
     cppMacros ++= gateway.cppMacros
     vMacros ++= gateway.vMacros
@@ -351,11 +351,17 @@ object DifftestModule {
     generateCppHeader(cpu, gateway.structPacked.getOrElse(false))
     generateVeriogHeader()
 
-    if (enabled) {
-      createTopIOs(gateway.step.getOrElse(0.U))
-    } else {
-      WireInit(0.U.asTypeOf(new DifftestTopIO))
+    Option.when(createTopIO) {
+      if (enabled) {
+        createTopIOs(gateway.step.getOrElse(0.U))
+      } else {
+        WireInit(0.U.asTypeOf(new DifftestTopIO))
+      }
     }
+  }
+
+  def finish(cpu: String): DifftestTopIO = {
+    finish(cpu, true).get
   }
 
   def createTopIOs(step: UInt): DifftestTopIO = {


### PR DESCRIPTION
Enable difftest without optional DifftestTopIO by add extra parameter `createTopIO: Boolean = true` to `DifftestModule.finish()`.
Chisel design can set this parameter to `false` to skip the creation of DifftestTopIO and use it in non-module context.