### PR TITLE
assert: add v2 to include filename information

### DIFF
--- a/src/test/csrc/common/common.cpp
+++ b/src/test/csrc/common/common.cpp
@@ -22,9 +22,18 @@ int assert_count = 0;
 int signal_num = 0;
 const char *emu_path = NULL;
 
+// Usage in SV/Verilog: xs_assert(`__LINE__);
 extern "C" void xs_assert(long long line) {
   if (assert_count >= 0) {
     printf("Assertion failed at line %lld.\n", line);
+    assert_count++;
+  }
+}
+
+// Usage in SV/Verilog: xs_assert_v2(`__FILE__, `__LINE__);
+extern "C" void xs_assert_v2(const char *filename, long long line) {
+  if (assert_count >= 0) {
+    printf("Assertion failed at %s:%lld.\n", filename, line);
     assert_count++;
   }
 }

--- a/src/test/vsrc/common/assert.v
+++ b/src/test/vsrc/common/assert.v
@@ -19,4 +19,11 @@ import "DPI-C" function void xs_assert
 (
   input  longint    line
 );
+
+import "DPI-C" function void xs_assert_v2
+(
+  input  string     filename,
+  input  longint    line
+);
+
 `endif


### PR DESCRIPTION
This commit adds the xs_assert_v2 and introduces the `filename` argument to show which file the assertion line lies. This is very useful if the design is generated using `--split-verilog`.

For backward compatibility, xs_assert is preserved.