### PR TITLE
common: fix the assertion control logic

### DIFF
--- a/src/test/csrc/common/common.cpp
+++ b/src/test/csrc/common/common.cpp
@@ -62,7 +62,7 @@ uint32_t uptime(void) {
 
 static char mybuf[BUFSIZ];
 
-void common_init(const char *program_name) {
+void common_init_without_assertion(const char *program_name) {
   // set emu_path
   emu_path = program_name;
 
@@ -83,8 +83,17 @@ void common_init(const char *program_name) {
 
   gettimeofday(&boot, NULL);
 
-  assert_count = 0;
+  assert_count = -1;
   signal_num = 0;
+}
+
+void common_enable_assert() {
+  assert_count = 0;
+}
+
+void common_init(const char *program_name) {
+  common_init_without_assertion(program_name);
+  common_enable_assert();
 }
 
 void common_finish() {

--- a/src/test/csrc/common/common.h
+++ b/src/test/csrc/common/common.h
@@ -88,7 +88,14 @@ extern bool sim_verbose;
 
 #define TODO() panic("please implement me")
 
+// Initialize common functions, such as buffering, assertions, siganl handlers.
 void common_init(const char *program_name);
+
+// Some designs may raise assertions during the reset stage.
+// Use common_init_without_assertion with common_enable_assert to manually control assertions.
+void common_init_without_assertion(const char *program_name);
+void common_enable_assert();
+
 void common_finish();
 
 uint32_t uptime(void);

--- a/src/test/csrc/common/main.cpp
+++ b/src/test/csrc/common/main.cpp
@@ -34,10 +34,15 @@ int sim_main(int argc, const char *argv[]) {
 #else
 int main(int argc, const char *argv[]) {
 #endif // FUZZER_LIB
-  common_init(argv[0]);
+  common_init_without_assertion(argv[0]);
+
+  // initialize the design-under-test (DUT)
+  auto emu = new DUT_MODEL(argc, argv);
+
+  // allow assertions only after DUT resets
+  common_enable_assert();
 
   // main simulation loop
-  auto emu = new DUT_MODEL(argc, argv);
   while (!emu->is_finished()) {
     emu->tick();
   }


### PR DESCRIPTION
This commit fixes the assertion control logic by introducing a init function without setting assertion_count to 0. The user may manually call common_enable_assert to enable assertions.

Previously we are checking whether the assertions are allowed by negative assert_count values. However, this variable is incorrectly set to zero during common_init.