### PR TITLE
Add Py Scirpt Enforce CamelCase Naming Convention in Scala Code

### DIFF
--- a/check_camel_case.py
+++ b/check_camel_case.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import re
+
+# Color constants
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+RESET = "\033[0m"
+
+def print_usage(program_name):
+    print(f"{RED}Usage: {program_name} <directory> [--fix]{RESET}")
+    sys.exit(1)
+
+def find_snake_case(file_path, fix):
+    modified_lines = []
+    with open(file_path, "r") as file:
+        for line_num, line in enumerate(file, start=1):
+            modified_line = line
+            for match in re.finditer(r"\b[a-z0-9]+_[a-z0-9]+\b", line):
+                snake_case = match.group()
+                camel_case = convert_to_camel(snake_case)
+                print(f"{RED}{file_path}:{GREEN}{line_num}:{GREEN}{match.start()+1}: {RED}{snake_case} is not in camelCase{RESET}")
+                if fix:
+                    modified_line = modified_line.replace(snake_case, camel_case)
+                    print(f"{GREEN}Fixed: {RED}{snake_case} {GREEN}-> {camel_case}{RESET}")
+            modified_lines.append(modified_line)
+    return modified_lines
+
+def convert_to_camel(snake_str):
+    parts = snake_str.split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
+
+def main():
+    if len(sys.argv) < 2:
+        print_usage(sys.argv[0])
+
+    directory = sys.argv[1]
+    fix = "--fix" in sys.argv
+
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".scala"):
+                file_path = os.path.join(root, file)
+                modified_content = find_snake_case(file_path, fix)
+                if fix:
+                    with open(file_path, "w") as file:
+                        file.writelines(modified_content)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Pull Request: Add Py Scirpt  Enforce CamelCase Naming Convention in Scala Code

### Description

This pull request introduces the `check_camel_case.py` script to the project. This script helps maintain consistent code style by automatically identifying and optionally fixing variables and functions named with underscores (snake_case) in the Scala files. Consistent use of camelCase improves readability and adheres to common Scala conventions.

### Why CamelCase?

In Scala, camelCase is the preferred naming convention for variables, functions, and methods. It enhances code clarity by visually grouping words together and avoiding potential confusion with underscores (which often have special meanings in Scala).

### Key Improvements

1. **Automated Detection:** The script efficiently scans `.scala` files within a specified directory to find instances of snake_case naming.
2. **Optional Automatic Fixing:** With the `--fix` flag, the script automatically replaces snake_case names with their camelCase equivalents, saving manual effort.
3. **Clear Reporting:** Even without fixing, the script provides detailed reports of the file, line number, and column where snake_case violations occur. This helps developers quickly locate and correct issues.

### Usage

1. **Place the Script:** The script `check_camel_case.py` is located in the root directory of the project.
2. **Run the Script:**
   * **To check for violations:**
     ```bash
     ./check_camel_case.py <directory>
     ```
     (Replace `<directory>` with the path to the directory containing your Scala code, e.g., `src`)
   * **To fix violations automatically:**
     ```bash
     ./check_camel_case.py <directory> --fix
     ```

### Example Output

```
./check_camel_case.py src --fix
src/main/scala/Batch.scala:117:10: data_in is not in camelCase
Fixed: data_in -> dataIn
src/main/scala/Batch.scala:118:31: data_out is not in camelCase
Fixed: data_out -> dataOut
src/main/scala/Batch.scala:119:31: info_out is not in camelCase
Fixed: info_out -> infoOut
```

### Additional Notes

* The script currently handles simple snake_case to camelCase conversions. More complex patterns may require manual adjustment.
* Consider incorporating this script into the CI/CD pipeline to automatically enforce camelCase naming in new code contributions.
*  I have not compiled the project and test the reformed code's functionality, we may need to chekc this.

