### PR TITLE
difftest: buffer wb_int until instr commit for multiple DUT buffer

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -175,8 +175,7 @@ class DiffDebugMode extends DebugModeCSRState with DifftestBundle {
 class DiffIntWriteback(numRegs: Int = 32) extends DataWriteback(numRegs) with DifftestBundle {
   override val desiredCppName: String = "wb_int"
   override protected val needFlatten: Boolean = true
-  // TODO: We have a special and temporary fix for int writeback in Squash.scala
-  // It is only required for MMIO data synchronization for single-core co-sim
+  // It is required for MMIO/Load(only for multi-core) data synchronization, and commit instr trace record
   override def supportsSquashBase: Bool = true.B
 }
 

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -263,11 +263,8 @@ class Preprocess(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Mo
   out := in
 
   if (config.hasDutZone || config.isSquash || config.isBatch) {
-    // Special fix for int writeback. Work for single-core only
+    // Special fix for int writeback.
     if (in.exists(_.desiredCppName == "wb_int")) {
-      if (config.isSquash || config.isBatch) {
-        require(numCores == 1, "only single-core is supported yet")
-      }
       val writebacks = in.filter(_.desiredCppName == "wb_int").map(_.asInstanceOf[DiffIntWriteback])
       val numPhyRegs = writebacks.head.numElements
       val wb_int = Reg(Vec(numCores, Vec(numPhyRegs, UInt(64.W))))
@@ -277,18 +274,23 @@ class Preprocess(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Mo
         }
       }
 
+      val wb_out = out.filter(_.desiredCppName == "wb_int").map(_.asInstanceOf[DiffIntWriteback])
       val commits = in.filter(_.desiredCppName == "commit").map(_.asInstanceOf[DiffInstrCommit])
-      val num_skip = PopCount(commits.map(c => c.valid && c.skip))
-      assert(num_skip <= 1.U, p"num_skip $num_skip is larger than one. Squash not supported yet")
-      val wb_for_skip = out.filter(_.desiredCppName == "wb_int").head.asInstanceOf[DiffIntWriteback]
-      for (c <- commits) {
-        when(c.valid && c.skip) {
-          wb_for_skip.valid := true.B
-          wb_for_skip.address := c.wpdest
-          wb_for_skip.data := wb_int(c.coreid)(c.wpdest)
-          for (wb <- writebacks) {
-            when(wb.valid && wb.address === c.wpdest) {
-              wb_for_skip.data := wb.data
+      // We use physical IntReg WriteBack for compare when load and MMIO, and record commit instr trace
+      // As there are multiple DUT buffer in software side, wb_int transferred and used may not in the same buffer
+      // So we buffer wb_int until instrCommit
+      require(wb_out.length >= commits.length, "WriteBack port length should be larger than InstrCommit")
+      wb_out.foreach { wb => wb.valid := false.B }
+      for ((c, wb) <- commits.zip(wb_out.take(commits.length))) {
+        when(c.valid) {
+          wb.coreid := c.coreid
+          wb.valid := true.B
+          wb.address := c.wpdest
+          wb.data := wb_int(c.coreid)(c.wpdest)
+          // Consider wb_int valid in same cycle
+          for (wb_in <- writebacks) {
+            when(wb_in.valid && wb_in.address === c.wpdest && wb_in.coreid === c.coreid) {
+              wb.data := wb_in.data
             }
           }
         }


### PR DESCRIPTION
In difftest cpp code, wb_int will only be synced as get_commit_data when commit with skip(MMIO) or Load, and record to commit instr trace. Since there are multiple DUT buffer in software side, and wb_int transferred and used not in the same buffer, so we buffer valid wb_int until instr commit.

This change will fix related bug when enable complete difftest with multicore.