### PR TITLE
squash: use soft queue to buffer unsquashed Diffstate

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -230,6 +230,7 @@ class DiffSbufferEvent extends SbufferEvent with DifftestBundle with DifftestWit
 
 class DiffStoreEvent extends StoreEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "store"
+  override val squashGroup: Seq[String] = Seq()
   // To avoid overflow, queueSize should be less than REF
   override val squashQueueSize: Int = 64
   override val squashQueueDelay: Int = 1

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -95,7 +95,7 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
         .zip(group_tick_vec)
         .collect { case (n, gt) if u.squashGroup.contains(n) => gt }
         .foldLeft(false.B)(_ || _)
-    squasher.should_tick := group_tick || global_tick
+    squasher.should_tick := wt || group_tick || global_tick
     squasher.out
   }
   // Flatten Seq[MixedVec[DifftestBundle]] to MixedVec[DifftestBundle]

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -317,12 +317,12 @@ int Difftest::step() {
         if (do_instr_commit(i)) {
           return 1;
         }
-        if (do_store_check()) {
-          return 1;
-        }
         dut->commit[i].valid = 0;
         num_commit += 1 + dut->commit[i].nFused;
       }
+    }
+    if (num_commit > 0 && do_store_check()) {
+      return 1;
     }
   }
 


### PR DESCRIPTION
Now there are some diffstates still can not squash, such as StoreEvent, which will affect squash of related event.

Previous we use hardware queue to buffer such event for strict order. For less gates consumed, larger queue size and easier order control, now we try to buffer such event by soft queue.

In hardware, we should continue squashing related event while submit unsquash ones. Software logic should also correspond to this, may be depends on some MACRO.

We also fix wrong process order of StoreEvent. Since all StoreEvent submitted before has been enqueued. Check should be after all InstrCommits.