### PR TITLE
difftest: force load unsquash for multicore, reset after use

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -578,6 +578,8 @@ int Difftest::do_instr_commit(int i) {
 #endif
         }
       }
+      dut->load[i].isLoad = 0;
+      dut->load[i].isAtomic = 0;
     }
 #endif // CONFIG_DIFFTEST_LOADEVENT
   }


### PR DESCRIPTION
Load is related to reg writeback for goldenMem and regfile compare. Previous we ignore load for singleCore for better squash rate. But currently load is unsquash, because different core relys on load to pass reg data from other cores. We use load data to change REF model regfile.

And we also reset isLoad and isAtomic after use. These signals act as if-cond, and outdated ones will result in wrong reg copy.