### PR TITLE
verilator.mk: Add support for PGO

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,16 @@ jobs:
             source ./env.sh
             ./build/emu -b 0 -e 0 --no-diff -C 10000
 
+      - name: Basic Difftest with PGO build
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make -C ./difftest clean_obj
+            make emu PGO_WORKLOAD=`realpath ready-to-run/microbench.bin` LLVM_PROFDATA=llvm-profdata PGO_EMU_ARGS="--diff `realpath ./ready-to-run/riscv64-nemu-interpreter-so` 2>/dev/null" -j2
+            ./build/emu -b 0 -e 0 -i ./ready-to-run/microbench.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
+
       - name: Difftest with Snapshot
         run: |
             cd $GITHUB_WORKSPACE/../xs-env


### PR DESCRIPTION
This commit add PGO_CFLAGS and PGO_LDFLAGS when calling verilator to generate Makefile. And add script to build PGO for both GCC and LLVM.

The following is the usage of PGO:

```shell
make emu MFC=1 EMU_THREADS=16 NUM_CORES=1 PGO_WORKLOAD=`realpath ready-to-run/coremark-2-iteration.bin` LLVM_PROFDATA=llvm-profdata -j `nproc`
```

Note: The LLVM_PROFDATA is hard to detect if multiple versions of LLVM are installed. An example is that on Debian, we can install different versions of LLVM and use a version with suffixes like `clang++-18`. The LLVM_PROFDATA should be set to the correct version like `llvm-profdata-18` in this case.

If the compiler of verilator is GCC, we should not use LLVM_PROFDATA:

```shell
make emu MFC=1 EMU_THREADS=16 NUM_CORES=1 PGO_WORKLOAD=`realpath ready-to-run/coremark-2-iteration.bin` -j `nproc`
```