### PR TITLE
vcs: difftest checks on negedge

### DIFF
--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -35,7 +35,7 @@ initial $ixc_ctrl("gfifo", "simv_nstep");
 `endif // PALLADIUM
 `endif // CONFIG_DIFFTEST_NONBLOCK
 
-always @(posedge clock) begin
+  always @(negedge clock) begin
   if (reset) begin
     simv_result <= 8'b0;
   end

--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -35,7 +35,7 @@ initial $ixc_ctrl("gfifo", "simv_nstep");
 `endif // PALLADIUM
 `endif // CONFIG_DIFFTEST_NONBLOCK
 
-  always @(negedge clock) begin
+always @(negedge clock) begin
   if (reset) begin
     simv_result <= 8'b0;
   end

--- a/src/test/vsrc/vcs/DifftestEndpoint.v
+++ b/src/test/vsrc/vcs/DifftestEndpoint.v
@@ -185,7 +185,7 @@ assign difftest_perfCtrl_dump = 0;
 `endif // TB_NO_DPIC
 
 reg [63:0] n_cycles;
-always @(posedge clock) begin
+  always @(negedge clock) begin
   if (reset) begin
     n_cycles <= 64'h0;
   end

--- a/src/test/vsrc/vcs/DifftestEndpoint.v
+++ b/src/test/vsrc/vcs/DifftestEndpoint.v
@@ -185,7 +185,7 @@ assign difftest_perfCtrl_dump = 0;
 `endif // TB_NO_DPIC
 
 reg [63:0] n_cycles;
-  always @(negedge clock) begin
+always @(negedge clock) begin
   if (reset) begin
     n_cycles <= 64'h0;
   end


### PR DESCRIPTION
Difftest is essentially a producer-consumer framework, where various DPI-C functions in SimTop.v act as producers, and functions like simv_nstep serve as consumers. Currently, in the difftest framework based on vcs / tb_top, both producers and consumers operate on the rising edge, leading to a race and hazard issue, namely: before all the DPI-C functions of the producer have executed, the consumer starts comparing with incomplete content, thereby triggering errors. This issue has already occurred in vcs.

As shown in the figure below, when the commit in the ROB is enabled, the mstatus in the CSR also changes synchronously.

<img width="439" alt="1718164613448" src="https://github.com/OpenXiangShan/difftest/assets/46089480/9a9634f7-72ad-4d43-960c-35dc09792c70">

However, judging from the printed content (printf in the DPI-C functions in ROB commit and CSR), the actual execution order is: the commit DPI-C function in the ROB -> the difftest comparison process (comparison fails, the producer function of the CSR has not yet been executed) -> (the DPI-C function of the CSR may be executed at this time).

<img width="389" alt="1718166222378" src="https://github.com/OpenXiangShan/difftest/assets/46089480/64a5bbcb-e004-491b-a9aa-4cd412b766e3">

<img width="626" alt="1718166247548" src="https://github.com/OpenXiangShan/difftest/assets/46089480/c96d368b-64fd-4922-a051-37f707c1988a">

It appears that a simple solution is for the producer to produce on the rising edge, while the consumer consumes on the falling edge.

Feel free to discuss whether this solution is reasonable, whether the modifications in the PR are complete, and whether there are better solutions.