### PR TITLE
CommitData: preprocess data in Hardware, submit with InstrCommit

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -89,6 +89,11 @@ class InstrCommit(val numPhyRegs: Int = 32) extends DifftestBaseBundle with HasV
   }
 }
 
+// Instantiate inside DiffTest, work for get_commit_data specially
+class CommitData extends DifftestBaseBundle with HasValid {
+  val data = UInt(64.W)
+}
+
 class TrapEvent extends DifftestBaseBundle {
   val hasTrap = Bool()
   val cycleCnt = UInt(64.W)

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -151,6 +151,11 @@ class DiffInstrCommit(nPhyRegs: Int = 32) extends InstrCommit(nPhyRegs) with Dif
   }
 }
 
+class DiffCommitData extends CommitData with DifftestBundle with DifftestWithIndex {
+  override val desiredCppName: String = "commit_data"
+  override def supportsSquashBase: Bool = true.B
+}
+
 class DiffTrapEvent extends TrapEvent with DifftestBundle {
   override val desiredCppName: String = "trap"
   override def supportsSquashBase: Bool = !hasTrap && !hasWFI

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -332,6 +332,9 @@ protected:
   int do_golden_memory_update();
 
   inline uint64_t get_commit_data(int i) {
+#ifdef CONFIG_DIFFTEST_COMMITDATA
+    return dut->commit_data[i].data;
+#else
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
     if (dut->commit[i].fpwen) {
       return
@@ -358,6 +361,7 @@ protected:
 #else
         dut->regs_int.value[dut->commit[i].wdest];
 #endif // CONFIG_DIFFTEST_INTWRITEBACK
+#endif // CONFIG_DIFFTEST_COMMITDATA
   }
   inline bool has_wfi() {
     return dut->trap.hasWFI;


### PR DESCRIPTION
We use physical Register WriteBack for loadEvent and MMIO access, and record commit Data in Commit Instr Trace. As there are multiple DUT buffer in software side, WriteBacks transferred and used may not in same cycle, so we buffer corresponding wb data until instrCommit.

As writeBacks only used in get_commit_data, and comes from int/vec/fp, we preprocess commitData in hardware side, and submit along with InstrCommit. This change will fix error of fpWriteBacks, and also help simplify logic of Load Squash.