### PR TITLE
SquashQueue: queue unsquash event and check against stamp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -382,28 +382,6 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
-      - name: Verilator Build with VCS Top (with GlobalEnable Squash SquashQueue Replay Batch InternalStep NonBlock PerfCnt)
-        run: |
-            cd $GITHUB_WORKSPACE/../xs-env
-            source ./env.sh
-            cd $GITHUB_WORKSPACE/../xs-env/NutShell
-            source ./env.sh
-            make clean
-            make simv MILL_ARGS="--difftest-config ESQRBINP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
-            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
-            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
-
-      - name: Verilator Build with VCS Top (with GlobalEnable Squash SquashQueue SquashFlush Replay Batch InternalStep NonBlock PerfCnt)
-        run: |
-            cd $GITHUB_WORKSPACE/../xs-env
-            source ./env.sh
-            cd $GITHUB_WORKSPACE/../xs-env/NutShell
-            source ./env.sh
-            make clean
-            make simv MILL_ARGS="--difftest-config ESQFRBINP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
-            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
-            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
-
       - name: Verilator Build with VCS Top (with workload-list)
         run : |
             cd $GITHUB_WORKSPACE/../xs-env

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -30,8 +30,6 @@ case class GatewayConfig(
   style: String = "dpic",
   hasGlobalEnable: Boolean = false,
   isSquash: Boolean = false,
-  hasSquashQueue: Boolean = false,
-  hasSquashFlush: Boolean = false,
   hasReplay: Boolean = false,
   replaySize: Int = 1024,
   hasDutZone: Boolean = false,
@@ -58,7 +56,7 @@ case class GatewayConfig(
     macros += s"CONFIG_DIFFTEST_ZONESIZE $dutZoneSize"
     macros += s"CONFIG_DIFFTEST_BUFLEN $dutBufLen"
     if (isBatch) macros ++= Seq("CONFIG_DIFFTEST_BATCH", s"CONFIG_DIFFTEST_BATCH_SIZE ${batchSize}")
-    if (isSquash) macros += "CONFIG_DIFFTEST_SQUASH"
+    if (isSquash) macros ++= Seq("CONFIG_DIFFTEST_SQUASH", s"CONFIG_DIFFTEST_SQUASH_STAMPSIZE 4096") // Stamp Width 12
     if (hasReplay) macros ++= Seq("CONFIG_DIFFTEST_REPLAY", s"CONFIG_DIFFTEST_REPLAY_SIZE ${replaySize}")
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
@@ -73,7 +71,7 @@ case class GatewayConfig(
     macros.toSeq
   }
   def check(): Unit = {
-    if (hasReplay || hasSquashQueue) require(isSquash)
+    if (hasReplay) require(isSquash)
     if (hasInternalStep) require(isBatch)
   }
 }
@@ -104,8 +102,6 @@ object Gateway {
     cfg.foreach {
       case 'E' => config = config.copy(hasGlobalEnable = true)
       case 'S' => config = config.copy(isSquash = true)
-      case 'Q' => config = config.copy(hasSquashQueue = true)
-      case 'F' => config = config.copy(hasSquashFlush = true)
       case 'R' => config = config.copy(hasReplay = true)
       case 'Z' => config = config.copy(hasDutZone = true)
       case 'B' => config = config.copy(isBatch = true)

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -310,8 +310,16 @@ protected:
   uint64_t track_instr = 0;
 #endif
 
+#ifdef CONFIG_DIFFTEST_SQUASH
+  int commit_stamp = 0;
+#ifdef CONFIG_DIFFTEST_LOADEVENT
+  std::queue<DifftestLoadEvent> load_event_queue;
+  void load_event_record();
+#endif // CONFIG_DIFFTEST_LOADEVENT
+#endif // CONFIG_DIFFTEST_SQUASH
+
 #ifdef CONFIG_DIFFTEST_STOREEVENT
-  std::queue<store_event_t> store_event_queue;
+  std::queue<DifftestStoreEvent> store_event_queue;
   void store_event_record();
 #endif
   void update_last_commit() {


### PR DESCRIPTION
Some unsquash event, such as LoadEvent and StoreEvent, will seriously hinder squash of related diffstate. We submit such event independently and queue them in software side with SquashStamp.

There queued event will be checked when num_commit meets stamp, resuming check order of different squashed event.