### PR TITLE
Validate: append valid to DifftestBundle

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -39,13 +39,6 @@ sealed trait DifftestBaseBundle extends Bundle {
   }
 
   def needUpdate: Option[Bool] = if (hasValid) Some(getValid) else None
-  def defaultUpdate(): DifftestBaseBundle = {
-    if (hasValid) {
-      getValid := false.B
-    }
-    this
-  }
-
   def hasAddress: Boolean = this.isInstanceOf[HasAddress]
   def getNumElements: Int = {
     this match {
@@ -102,13 +95,6 @@ class TrapEvent extends DifftestBaseBundle {
 
   val code = UInt(32.W)
   val pc = UInt(64.W)
-
-  override def needUpdate: Option[Bool] = Some(hasTrap || hasWFI)
-  override def defaultUpdate(): TrapEvent = {
-    hasTrap := false.B
-    hasWFI := false.B
-    this
-  }
 }
 
 class CSRState extends DifftestBaseBundle {

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -285,15 +285,15 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
   setInline(s"$desiredName.v", moduleBody)
 }
 
-private class DummyDPICWrapper(gen: DifftestBundle, config: GatewayConfig) extends Module {
+private class DummyDPICWrapper(gen: Valid[DifftestBundle], config: GatewayConfig) extends Module {
   val control = IO(Input(new GatewaySinkControl(config)))
   val io = IO(Input(gen))
-  val dpic = Module(new DPIC(gen, config))
+  val dpic = Module(new DPIC(gen.bits, config))
   dpic.clock := clock
-  dpic.enable := io.bits.getValid && control.enable
+  dpic.enable := io.valid && control.enable
   if (config.hasDutZone) dpic.dut_zone.get := control.dut_zone.get
   if (config.hasInternalStep) dpic.step.get := control.step.get
-  dpic.io := io
+  dpic.io := io.bits
 }
 
 private class DummyDPICBatchWrapper(
@@ -314,7 +314,7 @@ private class DummyDPICBatchWrapper(
 object DPIC {
   val interfaces = ListBuffer.empty[(String, String, String)]
 
-  def apply(control: GatewaySinkControl, io: DifftestBundle, config: GatewayConfig): Unit = {
+  def apply(control: GatewaySinkControl, io: Valid[DifftestBundle], config: GatewayConfig): Unit = {
     val module = Module(new DummyDPICWrapper(chiselTypeOf(io), config))
     module.control := control
     module.io := io

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -21,9 +21,10 @@ import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
 import difftest.common.DifftestPerf
+import difftest.validate.Validate._
 
 object Squash {
-  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): MixedVec[DifftestBundle] = {
+  def apply(bundles: MixedVec[Valid[DifftestBundle]], config: GatewayConfig): MixedVec[Valid[DifftestBundle]] = {
     val squashIn = Stamp(bundles)
     val module = Module(new SquashEndpoint(chiselTypeOf(squashIn).toSeq, config))
     module.in := squashIn
@@ -32,22 +33,24 @@ object Squash {
 }
 
 object Stamp {
-  def apply(bundles: MixedVec[DifftestBundle]): MixedVec[DifftestBundle] = {
+  def apply(bundles: MixedVec[Valid[DifftestBundle]]): MixedVec[Valid[DifftestBundle]] = {
     val module = Module(new Stamper(chiselTypeOf(bundles).toSeq))
     module.in := bundles
     module.out
   }
 }
 
-class Stamper(bundles: Seq[DifftestBundle]) extends Module {
+class Stamper(bundles: Seq[Valid[DifftestBundle]]) extends Module {
   val in = IO(Input(MixedVec(bundles)))
-  val numCores = in.count(_.isUniqueIdentifier)
+  val numCores = in.count(_.bits.isUniqueIdentifier)
   val stamp = RegInit(0.U.asTypeOf(Vec(numCores, UInt(12.W)))) // StampSize corresponds to Cpp Macros
-  val commits = in.filter(_.desiredCppName == "commit").map(_.asInstanceOf[DiffInstrCommit])
+  val commits = in.filter(_.bits.desiredCppName == "commit").map(_.asInstanceOf[Valid[DiffInstrCommit]])
   val commitLen = commits.length / numCores
   val commitSum = VecInit.tabulate(numCores) { id =>
     val commitCnt =
-      commits.slice(id * commitLen, (id + 1) * commitLen).map { c => Mux(c.valid && !c.skip, 1.U + c.nFused, 0.U) }
+      commits.slice(id * commitLen, (id + 1) * commitLen).map { c =>
+        Mux(c.valid && !c.bits.skip, 1.U + c.bits.nFused, 0.U)
+      }
     VecInit.tabulate(commitLen) { idx =>
       commitCnt.take(idx + 1).reduce(_ + _)
     }
@@ -57,65 +60,52 @@ class Stamper(bundles: Seq[DifftestBundle]) extends Module {
   }
 
   // Instantiation of LoadEvent corresponds to InstrCommit
-  val commitData = in.filter(_.desiredCppName == "commit_data").map(_.asInstanceOf[DiffCommitData])
-  val loads = in.filter(_.desiredCppName == "load").map(_.asInstanceOf[DiffLoadEvent])
+  val commitData = in.filter(_.bits.desiredCppName == "commit_data").map(_.asInstanceOf[Valid[DiffCommitData]])
+  val loads = in.filter(_.bits.desiredCppName == "load").map(_.asInstanceOf[Valid[DiffLoadEvent]])
   val loadQueues = loads.zip(commits).zip(commitData).zip(commitSum.flatten).map { case (((ld, c), cd), sum) =>
-    val lq = WireInit(0.U.asTypeOf(new DiffLoadEventQueue))
+    val lq = WireInit(0.U.asTypeOf(Valid(new DiffLoadEventQueue)))
     lq.inheritFrom(ld)
-    lq.stamp := stamp(ld.coreid) + sum
-    lq.commitData := cd.data
-    lq.regWen := ((c.rfwen && c.wdest =/= 0.U) || c.fpwen) && !c.vecwen
-    lq.wdest := c.wdest
-    lq.fpwen := c.fpwen
+    lq.bits.stamp := stamp(ld.bits.coreid) + sum
+    lq.bits.commitData := cd.bits.data
+    lq.bits.regWen := ((c.bits.rfwen && c.bits.wdest =/= 0.U) || c.bits.fpwen) && !c.bits.vecwen
+    lq.bits.wdest := c.bits.wdest
+    lq.bits.fpwen := c.bits.fpwen
     lq
   }
 
-  val stores = in.filter(_.desiredCppName == "store").map(_.asInstanceOf[DiffStoreEvent])
+  val stores = in.filter(_.bits.desiredCppName == "store").map(_.asInstanceOf[Valid[DiffStoreEvent]])
   val storeQueues = stores.map { st =>
-    val sq = WireInit(0.U.asTypeOf(new DiffStoreEventQueue))
+    val sq = WireInit(0.U.asTypeOf(Valid(new DiffStoreEventQueue)))
     sq.inheritFrom(st)
-    val base = stamp(sq.coreid)
-    val inc = commitSum(sq.coreid).last
+    val base = stamp(sq.bits.coreid)
+    val inc = commitSum(sq.bits.coreid).last
     // If no instr committed in the same cycle, store event will be checked in next commit
-    sq.stamp := Mux(inc === 0.U, base + 1.U, base + inc)
+    sq.bits.stamp := Mux(inc === 0.U, base + 1.U, base + inc)
     sq
   }
 
   val withStamp = MixedVecInit(
-    (in.filterNot(b => Seq("load", "store").contains(b.desiredCppName)) ++ loadQueues ++ storeQueues).toSeq
+    (in.filterNot(b => Seq("load", "store").contains(b.bits.desiredCppName)) ++ loadQueues ++ storeQueues).toSeq
   )
   val out = IO(Output(chiselTypeOf(withStamp)))
   out := withStamp
 }
 
-class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
-  val numCores = in.count(_.isUniqueIdentifier)
-
-  // Sometimes, the bundle may have squash dependencies.
-  // Only when one of the dependencies is valid, this bundle is squashed.
-  val do_squash = VecInit(in.map(_.bits.needUpdate.getOrElse(true.B)).toSeq)
-  in.zip(do_squash).foreach { case (i, do_s) =>
-    if (i.squashDependency.nonEmpty) {
-      do_s := VecInit(
-        in.filter(b => i.squashDependency.contains(b.desiredCppName))
-          .map(bundle => {
-            // Only if the corresponding bundle is valid, we update this bundle
-            bundle.coreid === i.coreid && bundle.asInstanceOf[DifftestBaseBundle].getValid
-          })
-          .toSeq
-      ).asUInt.orR && i.bits.needUpdate.getOrElse(true.B)
-    }
-  }
+  val numCores = in.count(_.bits.isUniqueIdentifier)
 
   val control = Module(new SquashControl(config))
   control.clock := clock
   control.reset := reset
   val in_replay =
-    in.filter(_.desiredCppName == "trace_info").map(_.asInstanceOf[DiffTraceInfo].in_replay).foldLeft(false.B)(_ || _)
+    in.map(_.bits)
+      .filter(_.desiredCppName == "trace_info")
+      .map(_.asInstanceOf[DiffTraceInfo].in_replay)
+      .foldLeft(false.B)(_ || _)
   val global_tick = !control.enable || in_replay
 
-  val uniqBundles = bundles.distinctBy(_.desiredCppName)
+  val uniqBundles = bundles.map(_.bits).distinctBy(_.desiredCppName)
   // Tick and Submit the pending non-squashable events immediately.
   val want_tick_vec = WireInit(VecInit.fill(uniqBundles.length)(false.B))
   // Record Tick Cause for each SquashGroup
@@ -136,10 +126,9 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
   })
 
   val s_out_vec = uniqBundles.zip(want_tick_vec).map { case (u, wt) =>
-    val (s_in, s_do) = in.zip(do_squash).filter(_._1.desiredCppName == u.desiredCppName).unzip
+    val s_in = in.filter(_.bits.desiredCppName == u.desiredCppName)
     val squasher = Module(new Squasher(chiselTypeOf(s_in.head), s_in.length, numCores, config))
     squasher.in.zip(s_in).foreach { case (i, s_i) => i := s_i }
-    squasher.do_squash.zip(s_do).foreach { case (d, s_d) => d := s_d }
     wt := squasher.want_tick
     val group_tick =
       group_name_vec
@@ -162,9 +151,8 @@ class SquashEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
 }
 
 // It will help do squash for bundles with same Class, return tick and state
-class Squasher(bundleType: DifftestBundle, length: Int, numCores: Int, config: GatewayConfig) extends Module {
+class Squasher(bundleType: Valid[DifftestBundle], length: Int, numCores: Int, config: GatewayConfig) extends Module {
   val in = IO(Input(Vec(length, bundleType)))
-  val do_squash = IO(Input(Vec(length, Bool())))
   val want_tick = IO(Output(Bool()))
   val should_tick = IO(Input(Bool()))
 
@@ -172,10 +160,10 @@ class Squasher(bundleType: DifftestBundle, length: Int, numCores: Int, config: G
   val out = IO(Output(Vec(length, bundleType)))
 
   // Mark the initial commit events as non-squashable for initial state synchronization.
-  val tick_first_commit = Option.when(bundleType.desiredCppName == "commit") {
+  val tick_first_commit = Option.when(bundleType.bits.desiredCppName == "commit") {
     VecInit
       .tabulate(numCores) { id =>
-        val hasValidCommitEvent = VecInit(state.map(c => c.coreid === id.U && c.bits.getValid).toSeq).asUInt.orR
+        val hasValidCommitEvent = VecInit(state.map(c => c.bits.coreid === id.U && c.valid).toSeq).asUInt.orR
         val isInitialEvent = RegInit(true.B)
         when(isInitialEvent && hasValidCommitEvent) {
           isInitialEvent := false.B
@@ -196,10 +184,10 @@ class Squasher(bundleType: DifftestBundle, length: Int, numCores: Int, config: G
 
   want_tick := !supportsSquash || !supportsSquashBase || tick_first_commit.getOrElse(false.B)
 
-  for (((i, ds), s) <- in.zip(do_squash).zip(state)) {
+  for ((i, s) <- in.zip(state)) {
     when(should_tick) {
       s := i
-    }.elsewhen(ds) {
+    }.otherwise {
       s := i.squash(s)
     }
   }

--- a/src/main/scala/Validate.scala
+++ b/src/main/scala/Validate.scala
@@ -1,0 +1,74 @@
+/***************************************************************************************
+ * Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.validate
+
+import chisel3._
+import chisel3.util._
+import difftest._
+import difftest.gateway.GatewayConfig
+
+object Validate {
+  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): MixedVec[Valid[DifftestBundle]] = {
+    val module = Module(new Validator(chiselTypeOf(bundles).toSeq, config))
+    module.in := bundles
+    module.out
+  }
+
+  implicit class ValidateHelper(bundle: Valid[DifftestBundle]) {
+    def inheritFrom(parent: Valid[DifftestBundle]): Unit = {
+      bundle.valid := parent.valid
+      bundle.bits.asInstanceOf[DiffTestIsInherited].inheritFrom(parent.bits)
+    }
+    def supportsSquashBase: Bool = bundle.bits.supportsSquashBase
+    def supportsSquash(base: Valid[DifftestBundle]): Bool = bundle.bits.supportsSquash(base.bits)
+    def squash(base: Valid[DifftestBundle]): Valid[DifftestBundle] = {
+      if (!bundle.bits.bits.hasValid) {
+        WireInit(Mux(bundle.valid, bundle, base))
+      } else {
+        val gen = bundle.bits.squash(base.bits)
+        val squashed = WireInit(0.U.asTypeOf(chiselTypeOf(bundle)))
+        squashed.bits := gen
+        squashed.valid := gen.bits.getValid
+        squashed
+      }
+    }
+  }
+}
+
+class Validator(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+  val out = IO(Output(MixedVec(bundles.map(Valid(_)))))
+  val globalEnable = WireInit(true.B)
+  if (config.hasGlobalEnable) {
+    globalEnable := VecInit(in.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+  }
+  in.zip(out).foreach { case (i, o) =>
+    val valid = i.bits.getValid && globalEnable && Option
+      .when(i.updateDependency.nonEmpty)(
+        VecInit(
+          in.filter(b => i.updateDependency.contains(b.desiredCppName))
+            .map(bundle => {
+              // Only if the corresponding bundle is valid, we update this bundle
+              bundle.coreid === i.coreid && bundle.bits.getValid
+            })
+            .toSeq
+        ).asUInt.orR
+      )
+      .getOrElse(true.B)
+    o := i.genValidBundle(valid)
+  }
+}


### PR DESCRIPTION
Previous we transmit all DiffState without hasValid when some DiffState valid in same cycle. However, when Squash enabled, some State without hasValid can be validated with special condition. As Submit times of State with SquashQueue is much greater than others, validated will greatly reduce submit times of Stata without hasValid.

Previous we also use do_squash and squashDependency to filter invalid CSR value. This change rename squashDependency to updateDependency, and only validate CSR when commit and event. So we remove do_squash.

As Trapevent will also be checked for instrs Exceed, we transmit it when validated, rather than just hasTrap or hasWFI.