### PR TITLE
difftest: move check of LoadEvent to do_load_check

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -322,6 +322,7 @@ protected:
   void do_interrupt();
   void do_exception();
   int do_instr_commit(int index);
+  void do_load_check(int index);
   int do_store_check();
   int do_refill_check(int cacheid);
   int do_irefill_check();


### PR DESCRIPTION
Previously we bind load_check with InstrCommit. For Squash and acceleration, we move Load check to a single Function.