### PR TITLE
verilator.mk: define `VERILATOR_LEGACY` for version less than 5

### DIFF
--- a/verilator.mk
+++ b/verilator.mk
@@ -46,6 +46,8 @@ endif
 VERILATOR_5_000 := $(shell expr `$(VERILATOR_VER_CMD)` \>= 5000 2> /dev/null)
 ifeq ($(VERILATOR_5_000),1)
 VEXTRA_FLAGS += --no-timing +define+VERILATOR_5
+else
+VEXTRA_FLAGS += +define+VERILATOR_LEGACY
 endif
 VERILATOR_5_024 := $(shell expr `$(VERILATOR_VER_CMD)` \>= 5024 2> /dev/null)
 ifeq ($(VERILATOR_5_024),1)


### PR DESCRIPTION
This is mainly for `ClockGate.v`. Previously, it is written as:

``` v
module ClockGate (
  input  wire TE,
  input  wire E,
  input  wire CK,
  output wire Q
);

  wire clk_en;
  reg  clk_en_reg;

  assign clk_en = E | TE;

`ifdef VCS
  // code A
  always @(CK or clk_en) begin
    if (CK == 1'b0)
      clk_en_reg <= clk_en;
  end
`else
`ifdef VERILATOR_5
  // code A
  always @(CK or clk_en) begin
    if (CK == 1'b0)
      clk_en_reg <= clk_en;
  end
`else
  // code B
 always @(posedge CK) 
   begin
     clk_en_reg = clk_en;
   end
`endif // VERILATOR_5
`endif // VCS

  assign Q = CK & clk_en_reg;

endmodule
```

Actually, only verilator 4 should use code B. All other tested platforms like verilator 5, vcs and vivado should use code A. It is better to write ClockGate as:

``` v
module ClockGate (
  input  wire TE,
  input  wire E,
  input  wire CK,
  output wire Q
);

  wire clk_en;
  reg  clk_en_reg;

  assign clk_en = E | TE;

`ifndef VERILATOR_LEGACY
  // code A
  always @(CK or clk_en) begin
    if (CK == 1'b0)
      clk_en_reg <= clk_en;
  end
`else
  // code B
 always @(posedge CK) 
   begin
     clk_en_reg = clk_en;
   end
`endif // VERILATOR_LEGACY

  assign Q = CK & clk_en_reg;

endmodule
```