### PR TITLE
runahead: fixed missing <deque> include in memdep

### DIFF
--- a/src/test/csrc/plugin/runahead/memdep.h
+++ b/src/test/csrc/plugin/runahead/memdep.h
@@ -18,6 +18,7 @@
 #define MEMDEP_H
 
 #include "common.h"
+#include <deque>
 
 typedef struct MemInstInfo {
   uint64_t pc;


### PR DESCRIPTION
Missing ```#include <deque>``` in memdep.h:
* Failing in some ```gcc``` compiling scenarios