### PR TITLE
emu: fix cycle conflict in full-wave dumping

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -612,7 +612,7 @@ inline void Emulator::single_cycle() {
     bool in_range = (args.log_begin <= cycle) && (cycle <= args.log_end);
     if (in_range || force_dump_wave) {
       if (args.enable_waveform_full) {
-        tfp->dump(2 * args.reset_cycles + 2 * cycle);
+        tfp->dump(2 * args.reset_cycles + 2 * cycles);
       } else {
         tfp->dump(cycle);
       }
@@ -649,7 +649,7 @@ inline void Emulator::single_cycle() {
 #endif
     bool in_range = (args.log_begin <= cycle) && (cycle <= args.log_end);
     if (in_range || force_dump_wave) {
-      tfp->dump(2 * args.reset_cycles + 1 + 2 * cycle);
+      tfp->dump(2 * args.reset_cycles + 1 + 2 * cycles);
     }
   }
 #endif


### PR DESCRIPTION
Three cycles of vcd dumping confliction after reset with **```--dump-wave-full```** in current implementation.