### PR TITLE
top: add the exit output to exit the simulation

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -378,7 +378,7 @@ object DifftestModule {
 
     Option.when(createTopIO) {
       if (enabled) {
-        createTopIOs(gateway.step.getOrElse(0.U))
+        createTopIOs(gateway.exit, gateway.step)
       } else {
         WireInit(0.U.asTypeOf(new DifftestTopIO))
       }
@@ -389,10 +389,11 @@ object DifftestModule {
     finish(cpu, true).get
   }
 
-  def createTopIOs(step: UInt): DifftestTopIO = {
+  def createTopIOs(exit: Option[UInt], step: Option[UInt]): DifftestTopIO = {
     val difftest = IO(new DifftestTopIO)
 
-    difftest.step := step
+    difftest.exit := exit.getOrElse(0.U)
+    difftest.step := step.getOrElse(0.U)
 
     val timer = RegInit(0.U(64.W)).suggestName("timer")
     timer := timer + 1.U
@@ -550,6 +551,7 @@ object Delayer {
 
 // Difftest emulator top. Will be created by DifftestModule.finish
 class DifftestTopIO extends Bundle {
+  val exit = Output(UInt(64.W))
   val step = Output(UInt(64.W))
   val perfCtrl = new PerfCtrlIO
   val logCtrl = new LogCtrlIO

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -82,6 +82,7 @@ case class GatewayResult(
   vMacros: Seq[String] = Seq(),
   instances: Seq[DifftestBundle] = Seq(),
   structPacked: Option[Boolean] = None,
+  exit: Option[UInt] = None,
   step: Option[UInt] = None,
 ) {
   def +(that: GatewayResult): GatewayResult = {
@@ -90,6 +91,7 @@ case class GatewayResult(
       vMacros = vMacros ++ that.vMacros,
       instances = instances ++ that.instances,
       structPacked = if (structPacked.isDefined) structPacked else that.structPacked,
+      exit = if (exit.isDefined) exit else that.exit,
       step = if (step.isDefined) step else that.step,
     )
   }

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -723,6 +723,16 @@ int Emulator::tick() {
     trapCode = STATE_SIG;
   }
 
+  // exit signal: non-zero exit exits the simulation. exit all 1's indicates good.
+  if (dut_ptr->difftest_exit) {
+    if (dut_ptr->difftest_exit == -1UL) {
+      trapCode = STATE_SIM_EXIT;
+    } else {
+      Info("The simulation aborted via the top-level exit of 0x%lx.\n", dut_ptr->difftest_exit);
+      trapCode = STATE_ABORT;
+    }
+  }
+
   if (trapCode != STATE_RUNNING) {
     return trapCode;
   }

--- a/src/test/vsrc/vcs/DifftestEndpoint.v
+++ b/src/test/vsrc/vcs/DifftestEndpoint.v
@@ -34,6 +34,7 @@ module DifftestEndpoint(
   input  wire [ 7:0] difftest_uart_out_ch,
   output wire        difftest_uart_in_valid,
   output wire [ 7:0] difftest_uart_in_ch,
+  input  wire [63:0] difftest_exit,
   input  wire [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] difftest_step
 );
 
@@ -196,6 +197,16 @@ always @(posedge clock) begin
     if (max_cycles > 0 && n_cycles >= max_cycles) begin
       $display("EXCEEDED MAX CYCLE: %d", max_cycles);
       $finish();
+    end
+
+    // exit signal: all 1's for normal exit; others are error
+    if (difftest_exit == 64'hffff_ffff_ffff_ffff) begin
+      $display("The simulation exits normally");
+      $finish();
+    end
+    else if (difftest_exit != 0) begin
+      $display("The simulation aborts: error code 0x%x", difftest_exit);
+      $fatal;
     end
 
 `ifndef TB_NO_DPIC

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -42,6 +42,7 @@ wire        difftest_uart_out_valid;
 wire [ 7:0] difftest_uart_out_ch;
 wire        difftest_uart_in_valid;
 wire [ 7:0] difftest_uart_in_ch;
+wire [63:0] difftest_exit;
 wire [`CONFIG_DIFFTEST_STEPWIDTH - 1:0] difftest_step;
 
 string wave_type;
@@ -122,6 +123,7 @@ SimTop sim(
   .difftest_uart_out_ch(difftest_uart_out_ch),
   .difftest_uart_in_valid(difftest_uart_in_valid),
   .difftest_uart_in_ch(difftest_uart_in_ch),
+  .difftest_exit(difftest_exit),
   .difftest_step(difftest_step)
 );
 
@@ -140,6 +142,7 @@ DifftestEndpoint difftest(
   .difftest_uart_out_ch(difftest_uart_out_ch),
   .difftest_uart_in_valid(difftest_uart_in_valid),
   .difftest_uart_in_ch(difftest_uart_in_ch),
+  .difftest_exit(difftest_exit),
   .difftest_step(difftest_step)
 );
 


### PR DESCRIPTION
This commit adds the exit output to the top-level IO of difftest. When it is a non-zero value, the simulation should exit. When all bits are ones, the simulation exits normally. Otherwise, it indicates there are some errors in the circuit.