### PR TITLE
lightsss: parent manually kills child that not the oldest when wake up

### DIFF
--- a/src/test/csrc/common/lightsss.h
+++ b/src/test/csrc/common/lightsss.h
@@ -18,6 +18,7 @@
 #define __LIGHTSSS_H
 
 #include "common.h"
+#include <deque>
 #include <list>
 #include <signal.h>
 #include <sys/ipc.h>
@@ -49,14 +50,14 @@ public:
 
 const int FORK_OK = 0;
 const int FORK_ERROR = 1;
-const int WAIT_LAST = 2;
-const int WAIT_EXIT = 3;
+const int FORK_CHILD = 2;
 
 class LightSSS {
   pid_t pid = -1;
   int slotCnt = 0;
   int waitProcess = 0;
-  std::list<pid_t> pidSlot = {};
+  // front() is the newest. back() is the oldest.
+  std::deque<pid_t> pidSlot = {};
   ForkShareMemory forkshm;
 
 public:

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -861,8 +861,7 @@ int Emulator::tick() {
       lasttime_snapshot = timer;
       switch (lightsss->do_fork()) {
         case FORK_ERROR: return -1;
-        case WAIT_EXIT: exit(0);
-        case WAIT_LAST: fork_child_init();
+        case FORK_CHILD: fork_child_init();
         default: break;
       }
     }


### PR DESCRIPTION
Current Problem:
1. Non-oldest child process call exit(0) to kill itself. And the parent child doesn't waitpid it.
2. The non-oldest child gets stucked, and exit(0) is failed to over.
3. There 'whole' program can not stop correctly or there will be a zombie process.

Solution: 
The parent manually kills the non-oldest child processes in wake-up just like it does in do-fork.