### PR TITLE
TrapEvent: enlarge width of trapcode to 32

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -100,7 +100,7 @@ class TrapEvent extends DifftestBaseBundle {
   val instrCnt = UInt(64.W)
   val hasWFI = Bool()
 
-  val code = UInt(3.W)
+  val code = UInt(32.W)
   val pc = UInt(64.W)
 
   override def needUpdate: Option[Bool] = Some(hasTrap || hasWFI)


### PR DESCRIPTION
At somewhere like AM, the return value of the main function is also used as the trap value ([trm.c](https://github.com/OpenXiangShan/nexus-am/blob/28c275b0ea38a341e6ce158d631bb41109863dd2/am/src/noop/isa/riscv/trm.c#L34)). However, currently, our trap value is only 3-bit-wide, which may lead to the situation where returning a non-zero value in the main function but difftest still HIT GOOD TRAP.

In fact, some of our users have encountered this issue while using AM to write test cases, and they hope that we can expand the width of the trap value. I believe this requirement is reasonable as it can help to use different return values to determine the accurate location and the specific reason of an abnormal exit.

Regarding the potential performance impact caused by expanding the bit width of the trap value, I have consulted @klin02 and he believe it has almost no impact on pldm.

As for the compatibility impact, chisel will automatically zero-extend the right values of UInt types. For return values larger than 7, we may think them as "reserved", and difftest framework also reports unknown trap reason for those trapcode currently (on [verilator](https://github.com/OpenXiangShan/difftest/blob/master/src/test/csrc/verilator/emu.cpp#L985) and [vcs](https://github.com/OpenXiangShan/difftest/blob/master/src/test/csrc/vcs/vcs_main.cpp#L204)).