### PR TITLE
Trace: support dump and load trace of difftest IOs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,6 +212,20 @@ jobs:
             make emu MILL_ARGS="--difftest-config ESB" -j2
             ./build/emu -b 0 -e 0 -i ./ready-to-run/microbench.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so
 
+      - name: Difftest with JsonProfile and DiffTestIOTrace
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make emu MILL_ARGS="--difftest-config ET" -j2
+            ./build/emu -b 0 -e 0 -i ./ready-to-run/microbench.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so --iotrace-name iotrace
+            cd difftest && export NOOP_HOME=$(pwd)
+            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=EL
+            make emu RTL_SUFFIX=v WITH_CHISELDB=0 WITH_CONSTANTIN=0 -j2
+            ./build/emu -b 0 -e 0 -i ../ready-to-run/microbench.bin --diff ../ready-to-run/riscv64-nemu-interpreter-so --iotrace-name ../iotrace
+
   test-difftest-fuzzing:
     # This test runs on ubuntu-20.04 for two reasons:
     # (1) riscv-arch-test can be built with riscv-linux-gnu toolchain 9.4.0,
@@ -393,3 +407,17 @@ jobs:
             echo "./ready-to-run/linux.bin 20000" >> list.txt
             make simv VCS=verilator WORKLOAD_SWITCH=1 -j2
             ./build/simv +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so +workload-list=./list.txt
+
+      - name: Verilator Build with VCS Top (with JsonProfile and DiffTestIOTrace)
+        run : |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make simv MILL_ARGS="--difftest-config ZET" VCS=verilator -j2
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so +iotrace-name=iotrace
+            cd difftest && export NOOP_HOME=$(pwd)
+            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=ZEL
+            make simv VCS=verilator RTL_SUFFIX=v WITH_CHISELDB=0 WITH_CONSTANTIN=0
+            ./build/simv +workload=../ready-to-run/microbench.bin +e=0 +diff=../ready-to-run/riscv64-nemu-interpreter-so +iotrace-name=../iotrace

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -24,6 +24,7 @@ import difftest.dpic.DPIC
 import difftest.squash.Squash
 import difftest.batch.{Batch, BatchIO}
 import difftest.replay.Replay
+import difftest.trace.Trace
 import difftest.util.VerificationExtractor
 import difftest.validate.Validate
 
@@ -41,6 +42,8 @@ case class GatewayConfig(
   hasInternalStep: Boolean = false,
   isNonBlock: Boolean = false,
   hasBuiltInPerf: Boolean = false,
+  traceDump: Boolean = false,
+  traceLoad: Boolean = false,
   hierarchicalWiring: Boolean = false,
   exitOnAssertions: Boolean = false,
 ) {
@@ -52,7 +55,8 @@ case class GatewayConfig(
   def batchArgByteLen: (Int, Int) = if (isNonBlock) (3900, 92) else (7800, 192)
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
-  def needEndpoint: Boolean = hasGlobalEnable || hasDutZone || isBatch || isSquash || hierarchicalWiring
+  def needEndpoint: Boolean =
+    hasGlobalEnable || hasDutZone || isBatch || isSquash || hierarchicalWiring || traceDump || traceLoad
   def needPreprocess: Boolean = hasDutZone || isBatch || isSquash || needTraceInfo
   // Macros Generation for Cpp and Verilog
   def cppMacros: Seq[String] = {
@@ -65,6 +69,7 @@ case class GatewayConfig(
     if (hasReplay) macros ++= Seq("CONFIG_DIFFTEST_REPLAY", s"CONFIG_DIFFTEST_REPLAY_SIZE ${replaySize}")
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
+    if (traceDump || traceLoad) macros += "CONFIG_DIFFTEST_IOTRACE"
     macros.toSeq
   }
   def vMacros: Seq[String] = {
@@ -73,11 +78,14 @@ case class GatewayConfig(
     if (isNonBlock) macros += "CONFIG_DIFFTEST_NONBLOCK"
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
+    if (traceDump || traceLoad) macros += "CONFIG_DIFFTEST_IOTRACE"
     macros.toSeq
   }
   def check(): Unit = {
     if (hasReplay) require(isSquash)
     if (hasInternalStep) require(isBatch)
+    // TODO: support dump and load together
+    require(!(traceDump && traceLoad))
   }
 }
 
@@ -115,6 +123,8 @@ object Gateway {
       case 'I' => config = config.copy(hasInternalStep = true)
       case 'N' => config = config.copy(isNonBlock = true)
       case 'P' => config = config.copy(hasBuiltInPerf = true)
+      case 'T' => config = config.copy(traceDump = true)
+      case 'L' => config = config.copy(traceLoad = true)
       case 'H' => config = config.copy(hierarchicalWiring = true)
       case 'X' => config = config.copy(exitOnAssertions = true)
       case x   => println(s"Unknown Gateway Config $x")
@@ -124,13 +134,15 @@ object Gateway {
 
   def apply[T <: DifftestBundle](gen: T, delay: Int): T = {
     val bundle = WireInit(0.U.asTypeOf(gen))
-    if (config.needEndpoint) {
-      val packed = WireInit(bundle.asUInt)
-      DifftestWiring.addSource(packed, s"gateway_${instanceWithDelay.length}", config.hierarchicalWiring)
-    } else {
-      val control = WireInit(0.U.asTypeOf(new GatewaySinkControl(config)))
-      control.enable := true.B
-      GatewaySink(control, Delayer(bundle, delay).genValidBundle, config)
+    if (!config.traceLoad) {
+      if (config.needEndpoint) {
+        val packed = WireInit(bundle.asUInt)
+        DifftestWiring.addSource(packed, s"gateway_${instanceWithDelay.length}", config.hierarchicalWiring)
+      } else {
+        val control = WireInit(0.U.asTypeOf(new GatewaySinkControl(config)))
+        control.enable := true.B
+        GatewaySink(control, Delayer(bundle, delay).genValidBundle, config)
+      }
     }
     instanceWithDelay += ((gen, delay))
     bundle
@@ -145,12 +157,17 @@ object Gateway {
     }
     val instances = instanceWithDelay.map(_._1).toSeq
     val sink = if (config.needEndpoint) {
-      val packed = WireInit(0.U.asTypeOf(MixedVec(instances.map(gen => UInt(gen.getWidth.W)))))
-      for ((data, idx) <- packed.zipWithIndex) {
-        DifftestWiring.addSink(data, s"gateway_$idx", config.hierarchicalWiring)
+      val gatewayIn = if (config.traceLoad) {
+        MixedVecInit(Trace.load(instances).toSeq.map(_.asUInt))
+      } else {
+        val packed = WireInit(0.U.asTypeOf(MixedVec(instances.map(gen => UInt(gen.getWidth.W)))))
+        for ((data, idx) <- packed.zipWithIndex) {
+          DifftestWiring.addSink(data, s"gateway_$idx", config.hierarchicalWiring)
+        }
+        packed
       }
       val endpoint = Module(new GatewayEndpoint(instanceWithDelay.toSeq, config))
-      endpoint.in := packed
+      endpoint.in := gatewayIn
       GatewayResult(
         instances = endpoint.instances,
         structPacked = Some(config.isBatch),
@@ -170,6 +187,10 @@ object Gateway {
 class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(instanceWithDelay.map { case (gen, _) => UInt(gen.getWidth.W) })))
   val bundle = MixedVecInit(in.zip(instanceWithDelay).map { case (i, (gen, d)) => Delayer(i.asTypeOf(gen), d) }.toSeq)
+
+  if (config.traceDump) {
+    Trace(bundle)
+  }
 
   val preprocessed = if (config.needPreprocess) {
     WireInit(Preprocess(bundle, config))

--- a/src/main/scala/Trace.scala
+++ b/src/main/scala/Trace.scala
@@ -51,7 +51,7 @@ object Trace {
     uniqBundles.foreach { case (name, gens) =>
       difftestCpp += gens.head.toTraceDeclaration
       difftestCpp += ""
-      val suffix = if (gens.length == 1) "" else s"[$gens.length]"
+      val suffix = if (gens.length == 1) "" else s"[${gens.length}]"
       val typeName = name.replace("Difftest", "DiffTrace")
       traceDecl += f"  ${typeName}%-30s ${gens.head.desiredCppName}${suffix};"
     }

--- a/src/main/scala/Trace.scala
+++ b/src/main/scala/Trace.scala
@@ -1,0 +1,174 @@
+/***************************************************************************************
+ * Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.trace
+
+import chisel3._
+import chisel3.experimental.ExtModule
+import chisel3.util._
+import difftest._
+import difftest.DifftestModule.streamToFile
+
+import scala.collection.mutable.ListBuffer
+
+object Trace {
+  def apply(bundles: MixedVec[DifftestBundle]): Unit = {
+    val bundleType = chiselTypeOf(bundles).toSeq
+    generateCppFile(bundleType, true)
+    val module = Module(new TraceDumper(bundleType))
+    module.io := bundles
+  }
+
+  def load(bundles: Seq[DifftestBundle]): MixedVec[DifftestBundle] = {
+    generateCppFile(bundles, false)
+    val module = Module(new TraceLoader(bundles))
+    module.io
+  }
+
+  def generateCppFile(bundles: Seq[DifftestBundle], isDump: Boolean): Unit = {
+    val difftestCpp = ListBuffer.empty[String]
+    difftestCpp += "#ifndef __DIFFTEST_IOTRACE_H__"
+    difftestCpp += "#define __DIFFTEST_IOTRACE_H__"
+    difftestCpp += ""
+    difftestCpp += "#include <cstdint>"
+    difftestCpp += "#include \"svdpi.h\""
+    difftestCpp += ""
+    val uniqBundles = bundles.groupBy(_.desiredModuleName).toSeq.sortBy(_._2.head.order)
+    val traceDecl = ListBuffer.empty[String]
+    uniqBundles.foreach { case (name, gens) =>
+      difftestCpp += gens.head.toTraceDeclaration
+      difftestCpp += ""
+      val suffix = if (gens.length == 1) "" else s"[$gens.length]"
+      val typeName = name.replace("Difftest", "DiffTrace")
+      traceDecl += f"  ${typeName}%-30s ${gens.head.desiredCppName}${suffix};"
+    }
+    difftestCpp += "typedef struct __attribute__((packed)) {"
+    difftestCpp ++= traceDecl
+    difftestCpp += "} DiffTestIOTrace;"
+    difftestCpp += "extern \"C\" void set_iotrace_name(char *s);"
+    difftestCpp += "extern void difftest_iotrace_init();"
+    difftestCpp += "extern void difftest_iotrace_free();"
+    val dpicArgPrefix = if (isDump) "const" else ""
+    val dpicFuncProto =
+      s"""
+         |extern "C" void v_difftest_trace (
+         |  $dpicArgPrefix svBitVecVal io[${bundles.map(_.getByteAlignWidth(true)).sum / 32}]
+         |)""".stripMargin
+    difftestCpp += dpicFuncProto + ";"
+    difftestCpp += "#endif // __DIFFTEST_TRACE_H__"
+    difftestCpp += ""
+    streamToFile(difftestCpp, "difftest-iotrace.h")
+
+    difftestCpp.clear()
+    difftestCpp += "#include \"difftest-iotrace.h\""
+    difftestCpp += "#include \"difftrace.h\""
+    difftestCpp += "#include <cassert>"
+    val (isRead, traceFunc) = if (isDump) {
+      ("false", "append")
+    } else {
+      ("true", "read_next")
+    }
+    // set iotrace to zero before loading
+    val traceInit = if (isDump) "" else "memset(io, 0, sizeof(DiffTestIOTrace));"
+    // padding N trace to file, allow difftest to finish comparision within N cycles after loading last trace
+    val traceFinish =
+      if (isDump)
+        s"""
+           |  DiffTestIOTrace* padding = (DiffTestIOTrace*)calloc(1, sizeof(DiffTestIOTrace));
+           |  for (int i = 0; i < 100; i++) {
+           |    difftest_iotrace->append(padding);
+           |  }
+           |""".stripMargin
+      else ""
+    difftestCpp +=
+      s"""
+         |static char *iotrace_name = nullptr;
+         |DiffTrace<DiffTestIOTrace> *difftest_iotrace = nullptr;
+         |extern \"C\" void set_iotrace_name(char *s) {
+         |  printf(\"difftest iotrace: %s\\n\", s);
+         |  iotrace_name = (char *)malloc(256);
+         |  strcpy(iotrace_name, s);
+         |}
+         |void difftest_iotrace_init() {
+         |  assert(iotrace_name);
+         |  difftest_iotrace = new DiffTrace<DiffTestIOTrace>(iotrace_name, $isRead);
+         |}
+         |void difftest_iotrace_free() {
+         |$traceFinish
+         |  delete difftest_iotrace;
+         |  difftest_iotrace = nullptr;
+         |}
+         |$dpicFuncProto {
+         |  if (!difftest_iotrace) {
+         |    $traceInit
+         |    return;
+         |  }
+         |  difftest_iotrace->${traceFunc}((DiffTestIOTrace *)io);
+         |}
+         |""".stripMargin
+    streamToFile(difftestCpp, "difftest-iotrace.cpp")
+  }
+}
+
+class TraceDumper(bundles: Seq[DifftestBundle]) extends Module {
+  val io = IO(Input(MixedVec(bundles)))
+  val aligned = MixedVecInit(io.sortBy(_.order).toSeq.map(_.getByteAlign(true)))
+  val trace = Module(new DifftestTrace(aligned.getWidth, true))
+  trace.clock := clock
+  trace.io := aligned.asUInt
+  trace.enable := VecInit(io.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+}
+
+class TraceLoader(bundles: Seq[DifftestBundle]) extends Module {
+  val io = IO(Output(MixedVec(bundles)))
+  val io_sort = io.sortBy(_.order).toSeq
+  val aligned = WireInit(
+    0.U.asTypeOf(MixedVec(io_sort.map { b => UInt(b.getByteAlignWidth(true).W) }))
+  )
+  val trace = Module(new DifftestTrace(aligned.getWidth, false))
+  trace.clock := clock
+  trace.enable := !reset.asBool
+  aligned := trace.io.asTypeOf(aligned)
+  io_sort.zip(aligned).foreach { case (o, a) => o := o.reverseByteAlign(a, true) }
+}
+
+class DifftestTrace(width: Int, isDump: Boolean) extends ExtModule with HasExtModuleInline {
+  def do_flip[T <: Data](dt: T): T = if (isDump) dt else Flipped(dt)
+  val clock = IO(Input(Clock()))
+  val enable = IO(Input(Bool()))
+  val io = IO(do_flip(Input(UInt(width.W))))
+
+  val io_direction = if (isDump) "input" else "output"
+  setInline(
+    "DifftestTrace.v",
+    s"""
+       |module DifftestTrace(
+       |  input clock,
+       |  input enable,
+       |  $io_direction [${width - 1}:0] io
+       |);
+       |
+       |import "DPI-C" function void v_difftest_trace (
+       |  $io_direction bit[${width - 1}:0] io
+       |);
+       |
+       |  always @(posedge clock) begin
+       |    if (enable) v_difftest_trace(io);
+       |  end
+       |endmodule
+       |""".stripMargin,
+  )
+}

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -34,6 +34,9 @@ int difftest_init() {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_perfcnt_init();
 #endif // CONFIG_DIFFTEST_PERFCNT
+#ifdef CONFIG_DIFFTEST_IOTRACE
+  difftest_iotrace_init();
+#endif // CONFIG_DIFFTEST_IOTRACE
   diffstate_buffer_init();
   difftest = new Difftest *[NUM_CORES];
   for (int i = 0; i < NUM_CORES; i++) {
@@ -116,6 +119,9 @@ void difftest_finish() {
   uint64_t cycleCnt = difftest[0]->get_trap_event()->cycleCnt;
   difftest_perfcnt_finish(cycleCnt);
 #endif // CONFIG_DIFFTEST_PERFCNT
+#ifdef CONFIG_DIFFTEST_IOTRACE
+  difftest_iotrace_free();
+#endif // CONFIG_DIFFTEST_IOTRACE
   diffstate_buffer_free();
   for (int i = 0; i < NUM_CORES; i++) {
     delete difftest[i];

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -227,7 +227,7 @@ public:
   void display_stats();
 
   void set_trace(const char *name, bool is_read) {
-    difftrace = new DiffTrace(name, is_read);
+    difftrace = new DiffTrace<DiffTestState>(name, is_read);
   }
   void trace_read() {
     if (difftrace) {
@@ -277,7 +277,7 @@ public:
   }
 
 protected:
-  DiffTrace *difftrace = nullptr;
+  DiffTrace<DiffTestState> *difftrace = nullptr;
 
 #ifdef CONFIG_DIFFTEST_BATCH
   const uint64_t commit_storage = CONFIG_DIFFTEST_BATCH_SIZE;

--- a/src/test/csrc/difftest/difftrace.h
+++ b/src/test/csrc/difftest/difftrace.h
@@ -2,8 +2,11 @@
 #define __DIFFTRACE_H__
 
 #include "common.h"
+#ifdef CONFIG_DIFFTEST_IOTRACE
+#include "difftest-iotrace.h"
+#endif // CONFIG_DIFFTEST_IOTRACE
 
-class DiffTrace {
+template <typename T> class DiffTrace {
 public:
   char trace_name[32];
   bool is_read;
@@ -17,13 +20,13 @@ public:
       free(buffer);
     }
   }
-  bool append(const DiffTestState *trace);
-  bool read_next(DiffTestState *trace);
+  bool append(const T *trace);
+  bool read_next(T *trace);
 
 private:
   uint64_t buffer_size;
   uint64_t buffer_count = 0;
-  DiffTestState *buffer = nullptr;
+  T *buffer = nullptr;
 
   bool trace_file_next();
 };

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -111,6 +111,7 @@ static inline void print_help(const char *file) {
 #endif // VM_COVERAGE
   printf("      --load-difftrace=NAME  load from trace NAME\n");
   printf("      --dump-difftrace=NAME  dump to trace NAME\n");
+  printf("      --iotrace-name=NAME    load from/dump to iotrace NAME\n");
   printf("      --dump-footprints=NAME dump memory access footprints to NAME\n");
   printf("      --as-footprints        load the image as memory access footprints\n");
   printf("      --dump-linearized=NAME dump the linearized footprints to NAME\n");
@@ -151,6 +152,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
     { "dump-wave-full",    0, NULL,  0  },
     { "overwrite-nbytes",  1, NULL,  0  },
     { "remote-jtag-port",  1, NULL,  0  },
+    { "iotrace-name",      1, NULL,  0  },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "fork-interval",     1, NULL, 'X' },
@@ -232,6 +234,13 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
             continue;
           case 22: args.overwrite_nbytes = atoll_strict(optarg, "overwrite_nbytes"); continue;
           case 23: remote_jtag_port = atoll_strict(optarg, "remote-jtag-port"); continue;
+          case 24:
+#ifdef CONFIG_DIFFTEST_IOTRACE
+            set_iotrace_name(optarg);
+#else
+            printf("[WARN] iotrace is not enabled at compile time, ignore --iotrace-name");
+#endif // CONFIG_DIFFTEST_IOTRACE
+            continue;
         }
         // fall through
       default: print_help(argv[0]); exit(0);

--- a/src/test/vsrc/vcs/DifftestEndpoint.v
+++ b/src/test/vsrc/vcs/DifftestEndpoint.v
@@ -57,6 +57,9 @@ import "DPI-C" function byte workload_list_completed();
 `ifndef CONFIG_DIFFTEST_DEFERRED_RESULT
 import "DPI-C" function byte simv_nstep(byte step);
 `endif // CONFIG_DIFFTEST_DEFERRED_RESULT
+`ifdef CONFIG_DIFFTEST_IOTRACE
+import "DPI-C" function void set_iotrace_name(string name);
+`endif // CONFIG_DIFFTEST_IOTRACE
 `endif // TB_NO_DPIC
 
 `define SIMV_DONE     8'h1
@@ -70,6 +73,7 @@ string flash_bin_file;
 string gcpt_bin_file;
 string diff_ref_so;
 string workload_list;
+string iotrace_name;
 longint overwrite_nbytes;
 
 reg [63:0] max_instrs;
@@ -125,6 +129,13 @@ initial begin
     $value$plusargs("max-instrs=%d", max_instrs);
     set_max_instrs(max_instrs);
   end
+`ifdef CONFIG_DIFFTEST_IOTRACE
+  // set difftest iotrace directory path
+  if ($test$plusargs("iotrace-name")) begin
+    $value$plusargs("iotrace-name=%s", iotrace_name);
+    set_iotrace_name(iotrace_name);
+  end
+`endif // CONFIG_DIFFTEST_IOTRACE
 `ifdef ENABLE_WORKLOAD_SWITCH
   // set workload list
   if ($test$plusargs("workload-list")) begin


### PR DESCRIPTION
Trace module will dump trace of IOs between DUT and difftest. With trace file and json profile, we can drive difftest without DUT, which will speed up repeated simulation without DUT modification, and support difftest modification and iteration.

Note we padding 100 trace at the end of traceFile when dumping, because when enable some features for acceleration, Difftest may finish comparision within some cycles after loading trace.