### PR TITLE
difftest:Surrport VCS use sim-jtag

### DIFF
--- a/src/test/csrc/common/SimJTAG.cpp
+++ b/src/test/csrc/common/SimJTAG.cpp
@@ -11,7 +11,7 @@ remote_bitbang_t *jtag;
 bool enable_simjtag = false;
 uint16_t remote_jtag_port = 23334;
 
-void jtag_init() {
+extern "C" void jtag_init() {
   jtag = new remote_bitbang_t(remote_jtag_port);
 }
 

--- a/src/test/csrc/common/remote_bitbang.h
+++ b/src/test/csrc/common/remote_bitbang.h
@@ -9,7 +9,7 @@
 extern bool enable_simjtag;
 extern uint16_t remote_jtag_port;
 
-void jtag_init();
+extern "C" void jtag_init();
 
 class remote_bitbang_t {
 public:

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -34,6 +34,7 @@
 #ifdef CONFIG_DIFFTEST_PERFCNT
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
+#include "remote_bitbang.h"
 
 static bool has_reset = false;
 static char bin_file[256] = "/dev/zero";
@@ -134,6 +135,10 @@ extern "C" bool workload_list_completed() {
 extern "C" void set_no_diff() {
   printf("disable diff-test\n");
   enable_difftest = false;
+}
+
+extern "C" void set_simjtag() {
+  enable_simjtag = true;
 }
 
 extern "C" uint8_t simv_init() {

--- a/src/test/vsrc/vcs/DifftestEndpoint.v
+++ b/src/test/vsrc/vcs/DifftestEndpoint.v
@@ -44,6 +44,7 @@ import "DPI-C" function void set_flash_bin(string bin);
 import "DPI-C" function void set_gcpt_bin(string bin);
 import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
+import "DPI-C" function void set_simjtag();
 import "DPI-C" function byte simv_init();
 import "DPI-C" function void set_max_instrs(longint mc);
 import "DPI-C" function void set_overwrite_nbytes(longint len);
@@ -119,6 +120,10 @@ initial begin
   // disable diff-test
   if ($test$plusargs("no-diff")) begin
     set_no_diff();
+  end
+  // enable sim-jtag
+  if ($test$plusargs("enable-jtag")) begin
+    set_simjtag();
   end
   // set exit instrs const
   if ($test$plusargs("max-instrs")) begin


### PR DESCRIPTION
The JTAG driver is packaged within the difftest shared object (.so) file, initialized with dpic, allowing the use of simjtag in the VCS environment.