### PR TITLE
pc: add compare for the first instr pc of a commit group.

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -304,6 +304,11 @@ protected:
   uint64_t ticks = 0;
   uint64_t last_commit = 0;
 
+  // For compare the first instr pc of a commit group
+  bool pc_mismatch = false;
+  uint64_t dut_commit_first_pc = 0;
+  uint64_t ref_commit_first_pc = 0;
+
   uint64_t nemu_this_pc;
   DiffState *state = NULL;
 #ifdef DEBUG_REFILL


### PR DESCRIPTION
Sometimes the dut or ref will wrongly jump to a pc, and if their reg state still match in the next instructions, this will make debugging very difficult. So I add the comparison to the pc.