### PR TITLE
Difftest: always pass step to tb_top

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -292,7 +292,6 @@ private class DummyDPICWrapper(gen: Valid[DifftestBundle], config: GatewayConfig
   dpic.clock := clock
   dpic.enable := io.valid && control.enable
   if (config.hasDutZone) dpic.dut_zone.get := control.dut_zone.get
-  if (config.hasInternalStep) dpic.step.get := control.step.get
   dpic.io := io.bits
 }
 


### PR DESCRIPTION
Privious when InternalStep is defined, we pass difftest_step to Batch DPIC instead of tb_top, thus putting transmission and comparision together.

This change pass step to tb_top all the time, which can indicate Difftest check triggered.