### PR TITLE
Difftest: check timeout for both commit and step

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -280,28 +280,31 @@ protected:
   DiffTrace<DiffTestState> *difftrace = nullptr;
 
 #ifdef CONFIG_DIFFTEST_BATCH
-  const uint64_t commit_storage = CONFIG_DIFFTEST_BATCH_SIZE;
+  static const uint64_t commit_storage = CONFIG_DIFFTEST_BATCH_SIZE;
 #else
-  const uint64_t commit_storage = 1;
+  static const uint64_t commit_storage = 1;
 #endif // CONFIG_DIFFTEST_BATCH
 #ifdef CONFIG_DIFFTEST_SQUASH
-  const uint64_t timeout_scale = 256;
+  static const uint64_t timeout_scale = 256;
 #else
-  const uint64_t timeout_scale = 1;
+  static const uint64_t timeout_scale = 1;
 #endif // CONFIG_DIFFTEST_SQUASH
 #if defined(CPU_NUTSHELL) || defined(CPU_ROCKET_CHIP)
-  const uint64_t firstCommit_limit = 1000 * commit_storage;
-  const uint64_t stuck_limit = 500 * timeout_scale * commit_storage;
+  static const uint64_t first_commit_limit = 1000;
 #elif defined(CPU_XIANGSHAN)
-  const uint64_t firstCommit_limit = 15000 * commit_storage;
-  const uint64_t stuck_limit = 15000 * timeout_scale * commit_storage;
+  static const uint64_t first_commit_limit = 15000;
 #endif
+  static const uint64_t stuck_commit_limit = first_commit_limit * timeout_scale;
+
+public:
+  static const uint64_t stuck_limit = stuck_commit_limit * commit_storage;
+
+protected:
   const uint64_t delay_wb_limit = 80;
 
   int id;
 
   bool progress = false;
-  uint64_t ticks = 0;
   uint64_t last_commit = 0;
 
   // For compare the first instr pc of a commit group
@@ -328,7 +331,7 @@ protected:
   void store_event_record();
 #endif
   void update_last_commit() {
-    last_commit = ticks;
+    last_commit = get_trap_event()->cycleCnt;
   }
   int check_timeout();
   void do_first_instr_commit();

--- a/src/test/csrc/plugin/runahead/runahead.cpp
+++ b/src/test/csrc/plugin/runahead/runahead.cpp
@@ -263,6 +263,7 @@ int Runahead::memdep_check(int i, RunaheadResponseQuery *ref_mem_query_result) {
 #endif
 
 int Runahead::step() { // override step() method
+  static uint64_t ticks = 0;
   ticks++;
   if (dut_ptr->event.interrupt) {
     assert(0); //TODO

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -82,6 +82,14 @@ extern "C" void set_max_instrs(uint64_t mc) {
   max_instrs = mc;
 }
 
+extern "C" uint64_t get_stuck_limit() {
+#ifdef CONFIG_NO_DIFFTEST
+  return 0;
+#else
+  return Difftest::stuck_limit;
+#endif // CONFIG_NO_DIFFTEST
+}
+
 #ifndef CONFIG_NO_DIFFTEST
 extern const char *difftest_ref_so;
 extern "C" void set_diff_ref_so(char *s) {

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -803,6 +803,17 @@ int Emulator::tick() {
     step = dut_ptr->difftest_step;
   }
 
+  static uint64_t stuck_timer = 0;
+  if (step) {
+    stuck_timer = 0;
+  } else {
+    stuck_timer++;
+    if (stuck_timer >= Difftest::stuck_limit) {
+      Info("No difftest check for more than %lu cycles, maybe get stuck.", Difftest::stuck_limit);
+      return STATE_ABORT;
+    }
+  }
+
   if (args.trace_name && !args.trace_is_read) {
     difftest_trace_write(step);
   }


### PR DESCRIPTION
Since difftest step function may not be called every cycle, we use cycleCnt recorded in trapEvent instead of ticks, to check timeout for Instr commits.

However, commit timeout will only be checked when difftest checks, which is triggered by difftest_step. We also check if step is 0 for more than stuck_limit for both vcs and emu.