### PR TITLE
iotrace: add iotrace dump and load zstd compress support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,6 +227,20 @@ jobs:
             make emu WITH_CHISELDB=0 WITH_CONSTANTIN=0 -j2
             ./build/emu -b 0 -e 0 -i ../ready-to-run/microbench.bin --diff ../ready-to-run/riscv64-nemu-interpreter-so --iotrace-name ../iotrace
 
+      - name: Difftest with JsonProfile and DiffTestIOTrace-ZSTD
+        run: |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make emu MILL_ARGS="--difftest-config ET" IOTRACE_ZSTD=1 -j2
+            ./build/emu -b 0 -e 0 -i ./ready-to-run/microbench.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so --iotrace-name iotrace
+            cd difftest && export NOOP_HOME=$(pwd)
+            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=EL
+            make emu RTL_SUFFIX=v WITH_CHISELDB=0 WITH_CONSTANTIN=0 IOTRACE_ZSTD=1 -j2
+            ./build/emu -b 0 -e 0 -i ../ready-to-run/microbench.bin --diff ../ready-to-run/riscv64-nemu-interpreter-so --iotrace-name ../iotrace
+    
   test-difftest-fuzzing:
     # This test runs on ubuntu-20.04 for two reasons:
     # (1) riscv-arch-test can be built with riscv-linux-gnu toolchain 9.4.0,
@@ -421,4 +435,18 @@ jobs:
             cd difftest && export NOOP_HOME=$(pwd)
             make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=ZEL MFC=1
             make simv VCS=verilator WITH_CHISELDB=0 WITH_CONSTANTIN=0
+            ./build/simv +workload=../ready-to-run/microbench.bin +e=0 +diff=../ready-to-run/riscv64-nemu-interpreter-so +iotrace-name=../iotrace
+
+      - name: Verilator Build with VCS Top (with JsonProfile and DiffTestIOTrace-ZSTD)
+        run : |
+            cd $GITHUB_WORKSPACE/../xs-env
+            source ./env.sh
+            cd $GITHUB_WORKSPACE/../xs-env/NutShell
+            source ./env.sh
+            make clean
+            make simv MILL_ARGS="--difftest-config ZET" VCS=verilator IOTRACE_ZSTD=1 -j2
+            ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so +iotrace-name=iotrace
+            cd difftest && export NOOP_HOME=$(pwd)
+            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=ZEL
+            make simv VCS=verilator RTL_SUFFIX=v WITH_CHISELDB=0 WITH_CONSTANTIN=0 IOTRACE_ZSTD=1
             ./build/simv +workload=../ready-to-run/microbench.bin +e=0 +diff=../ready-to-run/riscv64-nemu-interpreter-so +iotrace-name=../iotrace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,8 +237,8 @@ jobs:
             make emu MILL_ARGS="--difftest-config ET" IOTRACE_ZSTD=1 -j2
             ./build/emu -b 0 -e 0 -i ./ready-to-run/microbench.bin --diff ./ready-to-run/riscv64-nemu-interpreter-so --iotrace-name iotrace
             cd difftest && export NOOP_HOME=$(pwd)
-            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=EL
-            make emu RTL_SUFFIX=v WITH_CHISELDB=0 WITH_CONSTANTIN=0 IOTRACE_ZSTD=1 -j2
+            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=EL MFC=1
+            make emu WITH_CHISELDB=0 WITH_CONSTANTIN=0 IOTRACE_ZSTD=1 -j2
             ./build/emu -b 0 -e 0 -i ../ready-to-run/microbench.bin --diff ../ready-to-run/riscv64-nemu-interpreter-so --iotrace-name ../iotrace
     
   test-difftest-fuzzing:
@@ -447,6 +447,6 @@ jobs:
             make simv MILL_ARGS="--difftest-config ZET" VCS=verilator IOTRACE_ZSTD=1 -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so +iotrace-name=iotrace
             cd difftest && export NOOP_HOME=$(pwd)
-            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=ZEL
-            make simv VCS=verilator RTL_SUFFIX=v WITH_CHISELDB=0 WITH_CONSTANTIN=0 IOTRACE_ZSTD=1
+            make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=ZEL MFC=1
+            make simv VCS=verilator WITH_CHISELDB=0 WITH_CONSTANTIN=0 IOTRACE_ZSTD=1
             ./build/simv +workload=../ready-to-run/microbench.bin +e=0 +diff=../ready-to-run/riscv64-nemu-interpreter-so +iotrace-name=../iotrace

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ SIM_CXXFLAGS += -DLLVM_COVER
 SIM_LDFLAGS  += -fsanitize-coverage=trace-pc-guard -fsanitize-coverage=pc-table
 endif
 
-ifdef ($(IOTRACE_ZSTD),1)
+ifeq ($(IOTRACE_ZSTD),1)
 SIM_CXXFLAGS += -DCONFIG_IOTRACE_ZSTD
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,10 @@ SIM_CXXFLAGS += -DLLVM_COVER
 SIM_LDFLAGS  += -fsanitize-coverage=trace-pc-guard -fsanitize-coverage=pc-table
 endif
 
+ifdef ($(IOTRACE_ZSTD),1)
+SIM_CXXFLAGS += -DCONFIG_IOTRACE_ZSTD
+endif
+
 # Do not allow compiler warnings
 ifeq ($(CXX_NO_WARNING),1)
 SIM_CXXFLAGS += -Werror

--- a/src/test/csrc/difftest/difftrace.cpp
+++ b/src/test/csrc/difftest/difftrace.cpp
@@ -2,10 +2,14 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifdef CONFIG_IOTRACE_ZSTD
+static DiffTraceZstd *trace_zstd = new DiffTraceZstd;
+#endif // CONFIG_IOTRACE_ZSTD
+
 template <typename T>
 DiffTrace<T>::DiffTrace(const char *_trace_name, bool is_read, uint64_t _buffer_size) : is_read(is_read) {
+  buffer_size = _buffer_size;
   if (!is_read) {
-    buffer_size = _buffer_size;
     buffer = (T *)calloc(buffer_size, sizeof(T));
   }
   if (strlen(trace_name) > 31) {
@@ -26,7 +30,11 @@ template <typename T> bool DiffTrace<T>::append(const T *trace) {
 }
 
 template <typename T> bool DiffTrace<T>::read_next(T *trace) {
+#ifndef CONFIG_IOTRACE_ZSTD
   if (!buffer || buffer_count == buffer_size) {
+#else
+  if (!buffer || trace_zstd->trace_load_len == buffer_count) {
+#endif // CONFIG_IOTRACE_ZSTD
     trace_file_next();
   }
   memcpy(trace, buffer + buffer_count, sizeof(T));
@@ -35,12 +43,8 @@ template <typename T> bool DiffTrace<T>::read_next(T *trace) {
   return 0;
 }
 
-template <typename T> bool DiffTrace<T>::trace_file_next() {
+template <typename T> void DiffTrace<T>::next_file_name(char *file_name) {
   static uint64_t trace_index = 0;
-  static FILE *file = nullptr;
-  if (file) {
-    fclose(file);
-  }
   char dirname[128];
   if (strchr(trace_name, '/')) {
     snprintf(dirname, 128, "%s", trace_name);
@@ -49,10 +53,36 @@ template <typename T> bool DiffTrace<T>::trace_file_next() {
     snprintf(dirname, 128, "%s/%s", noop_home, trace_name);
   }
   mkdir(dirname, 0755);
-  char filename[128];
+#ifndef CONFIG_IOTRACE_ZSTD
   const char *prefix = "bin";
-  snprintf(filename, 128, "%s/%lu.%s", dirname, trace_index, prefix);
+#else
+  const char *prefix = "zstd";
+#endif // CONFIG_IOTRACE_ZSTD
+  snprintf(file_name, 128, "%s/%lu.%s", dirname, trace_index, prefix);
+  trace_index++;
+}
+
+template <typename T> bool DiffTrace<T>::trace_file_next() {
+  char *filename = (char *)malloc(128);
+#ifdef CONFIG_IOTRACE_ZSTD
+  if (trace_zstd->need_load_new_file == true && is_read) {
+    next_file_name(filename);
+    trace_zstd->diff_zstd_next(filename, is_read);
+    trace_zstd->need_load_new_file = false;
+  } else if (!is_read) {
+    next_file_name(filename);
+    trace_zstd->diff_zstd_next(filename, is_read);
+  }
+#else
+  next_file_name(filename);
+  static FILE *file = nullptr;
+  if (file) {
+    fclose(file);
+  }
+#endif
+
   if (is_read) {
+#ifndef CONFIG_IOTRACE_ZSTD
     FILE *file = fopen(filename, "rb");
     if (!file) {
       printf("File %s not found.\n", filename);
@@ -71,19 +101,135 @@ template <typename T> bool DiffTrace<T>::trace_file_next() {
     uint64_t read_bytes = fread(buffer, sizeof(T), buffer_size, file);
     assert(read_bytes == buffer_size);
     fclose(file);
-    buffer_count = 0;
+#else
+    buffer = (T *)calloc(buffer_size, sizeof(T));
+    trace_zstd->diff_IOtrace_load((char *)buffer, sizeof(T));
+#endif // CONFIG_IOTRACE_ZSTD
   } else if (buffer_count > 0) {
     Info("Writing %lu traces to %s ...\n", buffer_count, filename);
+#ifndef CONFIG_IOTRACE_ZSTD
     FILE *file = fopen(filename, "wb");
     fwrite(buffer, sizeof(T), buffer_count, file);
     fclose(file);
-    buffer_count = 0;
+#else
+    trace_zstd->diff_IOtrace_dump((char *)buffer, sizeof(T) * buffer_count);
+#endif
   }
-  trace_index++;
+  buffer_count = 0;
   return 0;
 }
 
 template class DiffTrace<DiffTestState>;
+
+#ifdef CONFIG_IOTRACE_ZSTD
+void DiffTraceZstd::diff_zstd_next(const char *file_name, bool is_read) {
+  if (is_read) {
+    if (io_trace_file_i.is_open()) {
+      io_trace_file_i.close();
+    }
+    io_trace_file_i.open(file_name, std::ios::binary);
+    if (io_trace_file_i.is_open() == false) {
+      printf("No more trace files.End simulation\n");
+      exit(0);
+    }
+  } else {
+    if (io_trace_file_o.is_open()) {
+      io_trace_file_o.close();
+    }
+    io_trace_file_o.open(file_name, std::ios::binary);
+  }
+}
+
+void DiffTraceZstd::diff_IOtrace_dump(const char *str, uint64_t len) {
+  static const size_t cLevel = 1; // compression level
+
+  std::vector<char> outputBuffer(max_compress_size);
+  trace_cctx = ZSTD_createCCtx();
+
+  size_t compressedSize = ZSTD_compressCCtx(trace_cctx, outputBuffer.data(), outputBuffer.size(), str, len, cLevel);
+  if (ZSTD_isError(compressedSize)) {
+    std::cerr << "Zstd Compress error: " << ZSTD_getErrorName(compressedSize) << std::endl;
+    ZSTD_freeCCtx(trace_cctx);
+    return;
+  }
+
+  io_trace_file_o.write(outputBuffer.data(), compressedSize);
+  ZSTD_freeCCtx(trace_cctx);
+}
+
+bool DiffTraceZstd::diff_IOtrace_load(char *buffer, uint64_t len) {
+  int result = diff_IOtrace_ZstdDcompress();
+  if (result != 0) {
+    need_load_new_file = true;
+    return false;
+  } else {
+    uint64_t have_size = io_trace_buffer.size() / len;
+    uint64_t byte_size = have_size * len;
+    memcpy(buffer, io_trace_buffer.data(), byte_size);
+    trace_load_len = have_size;
+    // clear read data
+    io_trace_buffer.erase(io_trace_buffer.begin(), io_trace_buffer.begin() + byte_size);
+    //printf("iotrace load erase get size %ld len %ld\n", have_size, len);
+  }
+  return true;
+}
+
+int DiffTraceZstd::diff_IOtrace_ZstdDcompress() {
+  // Set up buffers
+  static const size_t inbufferSize = ZSTD_DStreamInSize(); // Use ZSTD's recommended output buffer size
+  static const size_t outbufferSize = ZSTD_DStreamOutSize();
+  static std::vector<char> inputBuffer(inbufferSize);
+  std::vector<char> outputBuffer(outbufferSize);
+
+  if (trace_dctx == NULL) {
+    trace_dctx = ZSTD_createDCtx();
+  }
+  // Read and decompress data in a loop
+  ZSTD_outBuffer output = {outputBuffer.data(), outbufferSize, 0};
+  static ZSTD_inBuffer input = {inputBuffer.data(), 0, 0};
+
+  if (input.pos == input.size) {
+    inputBuffer.resize(inbufferSize);
+    io_trace_file_i.read(inputBuffer.data(), inbufferSize);
+    input.size = io_trace_file_i.gcount();
+    input.pos = 0;
+
+    // Outputs the current file pointer location
+    std::streampos currentPos = io_trace_file_i.tellg();
+    if (currentPos == -1) {
+      std::cout << "Decompress read zstd file error" << std::endl;
+      return 2;
+    }
+  } else if (input.size == 0) {
+    ZSTD_freeDCtx(trace_dctx);
+    trace_dctx = NULL;
+    return 1;
+  } else {
+    input.size = input.size;
+    input.pos = input.pos;
+  }
+
+  // Decompress the data
+  size_t ret = ZSTD_decompressStream(trace_dctx, &output, &input);
+#ifdef IOTRACE_ZSTD_DEBUG
+  std::cout << "Current input file position: " << currentPos << std::endl;
+  if (output.pos == output.size) {
+    std::cout << "there might be some data left within internal buffers" << std::endl;
+  }
+  if (input.pos == input.size) {
+    std::cout << "once a block has been processed, more data is needed" << std::endl;
+  }
+  if (ZSTD_isError(ret)) {
+    std::cerr << "Decompression error: " << ZSTD_getErrorName(ret) << std::endl;
+    exit(0);
+  }
+#endif // IOTRACE_ZSTD_DEBUG
+  io_trace_buffer.insert(io_trace_buffer.end(), outputBuffer.begin(), outputBuffer.end());
+
+  return 0;
+}
+#endif // CONFIG_IOTRACE_ZSTD
+
 #ifdef CONFIG_DIFFTEST_IOTRACE
 template class DiffTrace<DiffTestIOTrace>;
 #endif // CONFIG_DIFFTEST_IOTRACE

--- a/src/test/csrc/difftest/difftrace.h
+++ b/src/test/csrc/difftest/difftrace.h
@@ -12,12 +12,48 @@
 #include <zstd.h>
 #endif // CONFIG_IOTRACE_ZSTD
 
+#ifdef CONFIG_IOTRACE_ZSTD
+class DiffTraceZstd {
+public:
+  int trace_load_len = 0;
+  bool need_load_new_file = true;
+
+  DiffTraceZstd(uint64_t buffer_size) {
+    trace_buffer_size = buffer_size;
+    max_compress_size = 5000 * trace_buffer_size / 10;
+    max_dcompress_size = 5000 * trace_buffer_size;
+    io_trace_buffer.reserve(max_dcompress_size);
+  };
+
+  ~DiffTraceZstd() {
+    ZSTD_freeCCtx(trace_cctx);
+  }
+
+  void diff_zstd_next(const char *file_name, bool is_read);
+
+  void diff_IOtrace_dump(const char *str, uint64_t len);
+
+  bool diff_IOtrace_load(char *buffer, uint64_t len);
+  int diff_IOtrace_ZstdDcompress();
+
+private:
+  uint64_t trace_buffer_size = 0;
+  uint64_t max_compress_size = 0; // The number of bytes in a single compression
+  uint64_t max_dcompress_size = 0;
+  std::vector<char> io_trace_buffer;
+
+  ZSTD_CCtx *trace_cctx = NULL;
+  ZSTD_DCtx *trace_dctx = NULL;
+  std::fstream io_trace_file;
+};
+#endif // CONFIG_IOTRACE_ZSTD
+
 template <typename T> class DiffTrace {
 public:
   char trace_name[32];
   bool is_read;
 #ifdef CONFIG_IOTRACE_ZSTD
-  DiffTraceZstd *trace_zstd = new DiffTraceZstd(buffer_size);
+  DiffTraceZstd *trace_zstd = NULL;
 #endif // CONFIG_IOTRACE_ZSTD
 
   DiffTrace(const char *trace_name, bool is_read, uint64_t buffer_size = 1024 * 1024);
@@ -43,39 +79,5 @@ private:
 
   bool trace_file_next();
 };
-
-#ifdef CONFIG_IOTRACE_ZSTD
-class DiffTraceZstd {
-public:
-  int trace_load_len = 0;
-  bool need_load_new_file = true;
-
-  DiffTraceZstd(uint64_t buffer_size) {
-    trace_buffer_size = buffer_size;
-    io_trace_buffer.reserve(max_dcompress_size);
-  };
-
-  ~DiffTraceZstd() {
-    ZSTD_freeCCtx(trace_cctx);
-  }
-
-  void diff_zstd_next(const char *file_name, bool is_read);
-
-  void diff_IOtrace_dump(const char *str, uint64_t len);
-
-  bool diff_IOtrace_load(char *buffer, uint64_t len);
-  int diff_IOtrace_ZstdDcompress();
-
-private:
-  uint64_t trace_buffer_size = 0;
-  const uint64_t max_compress_size = 5000 * trace_buffer_size / 10; // The number of bytes in a single compression
-  const uint64_t max_dcompress_size = 5000 * trace_buffer_size;
-  std::vector<char> io_trace_buffer;
-
-  ZSTD_CCtx *trace_cctx = NULL;
-  ZSTD_DCtx *trace_dctx = NULL;
-  std::fstream io_trace_file;
-};
-#endif // CONFIG_IOTRACE_ZSTD
 
 #endif

--- a/src/test/csrc/difftest/difftrace.h
+++ b/src/test/csrc/difftest/difftrace.h
@@ -12,13 +12,15 @@
 #include <zstd.h>
 #endif // CONFIG_IOTRACE_ZSTD
 
-const uint64_t trace_buffer_size = 1024 * 1024;
 template <typename T> class DiffTrace {
 public:
   char trace_name[32];
   bool is_read;
+#ifdef CONFIG_IOTRACE_ZSTD
+  DiffTraceZstd *trace_zstd = new DiffTraceZstd(buffer_size);
+#endif // CONFIG_IOTRACE_ZSTD
 
-  DiffTrace(const char *trace_name, bool is_read, uint64_t buffer_size = trace_buffer_size);
+  DiffTrace(const char *trace_name, bool is_read, uint64_t buffer_size = 1024 * 1024);
   ~DiffTrace() {
     if (!is_read) {
       trace_file_next();
@@ -26,6 +28,9 @@ public:
     if (buffer) {
       free(buffer);
     }
+#ifdef CONFIG_IOTRACE_ZSTD
+    delete trace_zstd;
+#endif // CONFIG_IOTRACE_ZSTD
   }
   bool append(const T *trace);
   bool read_next(T *trace);
@@ -45,7 +50,8 @@ public:
   int trace_load_len = 0;
   bool need_load_new_file = true;
 
-  DiffTraceZstd() {
+  DiffTraceZstd(uint64_t buffer_size) {
+    trace_buffer_size = buffer_size;
     io_trace_buffer.reserve(max_dcompress_size);
   };
 
@@ -61,14 +67,14 @@ public:
   int diff_IOtrace_ZstdDcompress();
 
 private:
+  uint64_t trace_buffer_size = 0;
   const uint64_t max_compress_size = 5000 * trace_buffer_size / 10; // The number of bytes in a single compression
   const uint64_t max_dcompress_size = 5000 * trace_buffer_size;
   std::vector<char> io_trace_buffer;
 
   ZSTD_CCtx *trace_cctx = NULL;
   ZSTD_DCtx *trace_dctx = NULL;
-  std::ofstream io_trace_file_o;
-  std::ifstream io_trace_file_i;
+  std::fstream io_trace_file;
 };
 #endif // CONFIG_IOTRACE_ZSTD
 

--- a/src/test/csrc/difftest/difftrace.h
+++ b/src/test/csrc/difftest/difftrace.h
@@ -5,13 +5,20 @@
 #ifdef CONFIG_DIFFTEST_IOTRACE
 #include "difftest-iotrace.h"
 #endif // CONFIG_DIFFTEST_IOTRACE
+#ifdef CONFIG_IOTRACE_ZSTD
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <zstd.h>
+#endif // CONFIG_IOTRACE_ZSTD
 
+const uint64_t trace_buffer_size = 1024 * 1024;
 template <typename T> class DiffTrace {
 public:
   char trace_name[32];
   bool is_read;
 
-  DiffTrace(const char *trace_name, bool is_read, uint64_t buffer_size = 1024 * 1024);
+  DiffTrace(const char *trace_name, bool is_read, uint64_t buffer_size = trace_buffer_size);
   ~DiffTrace() {
     if (!is_read) {
       trace_file_next();
@@ -22,6 +29,7 @@ public:
   }
   bool append(const T *trace);
   bool read_next(T *trace);
+  void next_file_name(char *file_name);
 
 private:
   uint64_t buffer_size;
@@ -30,5 +38,38 @@ private:
 
   bool trace_file_next();
 };
+
+#ifdef CONFIG_IOTRACE_ZSTD
+class DiffTraceZstd {
+public:
+  int trace_load_len = 0;
+  bool need_load_new_file = true;
+
+  DiffTraceZstd() {
+    io_trace_buffer.reserve(max_dcompress_size);
+  };
+
+  ~DiffTraceZstd() {
+    ZSTD_freeCCtx(trace_cctx);
+  }
+
+  void diff_zstd_next(const char *file_name, bool is_read);
+
+  void diff_IOtrace_dump(const char *str, uint64_t len);
+
+  bool diff_IOtrace_load(char *buffer, uint64_t len);
+  int diff_IOtrace_ZstdDcompress();
+
+private:
+  const uint64_t max_compress_size = 5000 * trace_buffer_size / 10; // The number of bytes in a single compression
+  const uint64_t max_dcompress_size = 5000 * trace_buffer_size;
+  std::vector<char> io_trace_buffer;
+
+  ZSTD_CCtx *trace_cctx = NULL;
+  ZSTD_DCtx *trace_dctx = NULL;
+  std::ofstream io_trace_file_o;
+  std::ifstream io_trace_file_i;
+};
+#endif // CONFIG_IOTRACE_ZSTD
 
 #endif


### PR DESCRIPTION
Adding the difftest trace feature enables ZSTD for streaming compression, which compresses the trace volume by about 98%, enabling printing more cycle traces to disk