### PR TITLE
Validate: recover needUpdate for TrapEvent

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -95,6 +95,8 @@ class TrapEvent extends DifftestBaseBundle {
 
   val code = UInt(32.W)
   val pc = UInt(64.W)
+
+  override def needUpdate: Option[Bool] = Some(hasTrap || hasWFI)
 }
 
 class CSRState extends DifftestBaseBundle {


### PR DESCRIPTION
TrapEvent may not raise hasTrap when any other bundle valid, so we recover needUpdate to mark there is valid TrapEvent at this cycle.

In Validate, we use getValid to mark valid for single bundle, and needUpdate to mark valid for this cycle. We will transmit trapEvent when hasTrap, or other bundles valid.