### PR TITLE
Difftest, mmu: Support Sv48 & Sv48x4 ptw check

### DIFF
--- a/src/test/csrc/common/golden.h
+++ b/src/test/csrc/common/golden.h
@@ -57,11 +57,11 @@ typedef union atpStruct {
   };
   uint64_t val;
 } Satp, Hgatp;
-#define noS2xlate      0
-#define allStage       3
-#define onlyStage1     1
-#define onlyStage2     2
-#define VPNiSHFT(i)    (12 + 9 * (i))
-#define GVPNi(addr, i) (((addr) >> (18 - 9 * (i) + 12)) & (i == 0 ? 0x7ff : 0x1ff))
-#define VPNi(vpn, i)   (((vpn) >> (18 - 9 * (i))) & 0x1ff)
+#define noS2xlate           0
+#define allStage            3
+#define onlyStage1          1
+#define onlyStage2          2
+#define VPNiSHFT(i)         (12 + 9 * (i))
+#define GVPNi(addr, i, max) (((addr) >> (9 * (i) + 12)) & ((i == 3 || (i == 2 && max == 2)) ? 0x7ff : 0x1ff))
+#define VPNi(vpn, i)        (((vpn) >> (9 * (i))) & 0x1ff)
 #endif


### PR DESCRIPTION
Also refactor page table walker level:
previous (only support Sv39):
level 0 -> 1GB page
level 1 -> 2MB page
level 2 -> 4KB page
current (support Sv39, Sv48, and future extension) Sv48 -> maxlevel = 3, Sv39 -> maxlevel = 2
level 3 -> 512GB page
level 2 -> 1GB page
level 1 -> 2MB page
level 0 -> 4KB page