### PR TITLE
misc: add argument --dramsim3-ini to set dramsim3 config file

### DIFF
--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -289,10 +289,6 @@ MmapMemory::MmapMemory(const char *image, uint64_t n_bytes) : SimMemory(n_bytes)
     img_size = reader->read_all(ram, memory_size);
     delete reader;
   }
-
-#ifdef WITH_DRAMSIM3
-  dramsim3_init();
-#endif
 }
 
 MmapMemory::~MmapMemory() {
@@ -446,13 +442,24 @@ void overwrite_ram(const char *gcpt_restore, uint64_t overwrite_nbytes) {
 }
 
 #ifdef WITH_DRAMSIM3
-void dramsim3_init() {
+void dramsim3_init(const char *config_file) {
 #if !defined(DRAMSIM3_CONFIG) || !defined(DRAMSIM3_OUTDIR)
 #error DRAMSIM3_CONFIG or DRAMSIM3_OUTDIR is not defined
 #endif
 
+  config_file = (config_file == nullptr) ? DRAMSIM3_CONFIG : config_file;
+
   assert(dram == NULL);
-  dram = new ComplexCoDRAMsim3(DRAMSIM3_CONFIG, DRAMSIM3_OUTDIR);
+  // check config_file is valid
+  std::ifstream ifs(config_file);
+  if (!ifs) {
+    std::cerr << "Cannot open DRAMSIM3 config file: " << config_file << std::endl;
+    exit(1);
+  }
+  ifs.close();
+
+  std::cout << "DRAMSIM3 config: " << config_file << std::endl;
+  dram = new ComplexCoDRAMsim3(config_file, DRAMSIM3_OUTDIR);
   // dram = new SimpleCoDRAMsim3(90);
 }
 

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -218,7 +218,7 @@ void overwrite_ram(const char *gcpt_restore, uint64_t overwrite_nbytes);
 
 #ifdef WITH_DRAMSIM3
 
-void dramsim3_init();
+void dramsim3_init(const char *config_file);
 void dramsim3_step();
 void dramsim3_finish();
 

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -157,6 +157,9 @@ extern "C" uint8_t simv_init() {
   common_init("simv");
 
   init_ram(bin_file, DEFAULT_EMU_RAM_SIZE);
+#ifdef WITH_DRAMSIM3
+  dramsim3_init(nullptr);
+#endif
   if (gcpt_restore_bin != NULL) {
     overwrite_ram(gcpt_restore_bin, overwrite_nbytes);
   }

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -313,12 +313,6 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
   return args;
 }
 
-#include <functional>
-std::function<double()> get_sc_time_stamp = []() -> double { return 0; };
-double sc_time_stamp() {
-  return get_sc_time_stamp();
-}
-
 Emulator::Emulator(int argc, const char *argv[])
     : dut_ptr(new VSimTop), cycles(0), trapCode(STATE_RUNNING), elapsed_time(uptime()) {
 
@@ -334,9 +328,6 @@ Emulator::Emulator(int argc, const char *argv[])
     printf("[warning] cannot set stack size. Large designs may cause SIGSEGV.\n");
   }
 #endif
-
-  // junk, link for verilator
-  get_sc_time_stamp = [this]() -> double { return get_cycles(); };
 
   args = parse_args(argc, argv);
 #ifdef ENABLE_CONSTANTIN

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -106,6 +106,9 @@ static inline void print_help(const char *file) {
   printf("      --diff=PATH            set the path of REF for differential testing\n");
   printf("      --enable-jtag          enable remote bitbang server\n");
   printf("      --remote-jtag-port     specify remote bitbang port\n");
+#ifdef WITH_DRAMSIM3
+  printf("      --dramsim3-ini         specify the ini file for DRAMSim3\n");
+#endif
 #if VM_COVERAGE == 1
   printf("      --dump-coverage        enable coverage dump\n");
 #endif // VM_COVERAGE
@@ -153,6 +156,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
     { "overwrite-nbytes",  1, NULL,  0  },
     { "remote-jtag-port",  1, NULL,  0  },
     { "iotrace-name",      1, NULL,  0  },
+    { "dramsim3-ini",      1, NULL,  0  },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "fork-interval",     1, NULL, 'X' },
@@ -241,6 +245,15 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
             printf("[WARN] iotrace is not enabled at compile time, ignore --iotrace-name");
 #endif // CONFIG_DIFFTEST_IOTRACE
             continue;
+          case 25:
+#ifdef WITH_DRAMSIM3
+            args.dramsim3_ini = optarg;
+            continue;
+#else
+            printf("Dramsim3 is not enabled, but --dramsim3-ini is specified\n");
+            exit(1);
+            break;
+#endif
         }
         // fall through
       default: print_help(argv[0]); exit(0);
@@ -387,6 +400,9 @@ Emulator::Emulator(int argc, const char *argv[])
       simMemory = new MmapMemoryWithFootprints(args.image, ram_size, args.footprints_name);
     } else {
       init_ram(args.image, ram_size);
+#ifdef WITH_DRAMSIM3
+      dramsim3_init(args.dramsim3_ini);
+#endif
     }
   }
 

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -46,6 +46,7 @@ struct EmuArgs {
   uint64_t stat_cycles = -1;
   uint64_t log_begin = 0, log_end = -1;
   uint64_t overwrite_nbytes = 0xe00;
+  const char *dramsim3_ini = nullptr;
 #ifdef DEBUG_REFILL
   uint64_t track_instr = 0;
 #endif


### PR DESCRIPTION
add argument --dramsim3-ini to pass the dramsim3 config file, no need to modify makefile and recompile