### PR TITLE
fix(l1tlb_check): correct the check for only VS stage

### DIFF
--- a/src/test/csrc/common/golden.h
+++ b/src/test/csrc/common/golden.h
@@ -62,9 +62,9 @@ typedef union atpStruct {
   uint64_t val;
 } Satp, Hgatp;
 #define noS2xlate           0
-#define allStage            3
 #define onlyStage1          1
 #define onlyStage2          2
+#define allStage            3
 #define VPNiSHFT(i)         (12 + 9 * (i))
 #define GVPNi(addr, i, max) (((addr) >> (9 * (i) + 12)) & ((i == 3 || (i == 2 && max == 2)) ? 0x7ff : 0x1ff))
 #define VPNi(vpn, i)        (((vpn) >> (9 * (i))) & 0x1ff)


### PR DESCRIPTION
As a legacy issue of supporting Sv48, the default level of do_s2xlate when mode=0 is incorrect. Also, for only VS stage case (onlyS1), it should not do_s2xlate at all. This patch fixes these problems.