### PR TITLE
difftest: automatically set the overwrite-size of new gpct

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -44,7 +44,6 @@ static bool enable_difftest = true;
 static uint64_t max_instrs = 0;
 static char *workload_list = NULL;
 static uint32_t overwrite_nbytes = 0xe00;
-static bool overwrite_auto = false;
 struct core_end_info_t {
   bool core_trap[NUM_CORES];
   double core_cpi[NUM_CORES];
@@ -81,7 +80,6 @@ extern "C" void set_overwrite_autoset() {
   }
   // Get the lower four bytes
   fseek(fp, 4, SEEK_SET);
-  uint32_t data = 0;
   fread(&overwrite_nbytes, sizeof(uint32_t), 1, fp);
   fclose(fp);
 }

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -81,15 +81,15 @@ extern "C" void set_gcpt_bin(char *s) {
   if (overwrite_auto) {
     FILE *fp = fopen(gcpt_restore_bin, "rb");
     fseek(fp, 4, SEEK_SET);
-    if (fread(&overwrite_nbytes, sizeof(uint32_t), 1, fp) != 1) {
-      fclose(fp);
-      printf("auto read gcpt overwrite size fiald, need manual set_overwrite_nbytes\n");
+    uint32_t data = 0;
+    if (fread(&data, sizeof(uint32_t), 1, fp) == 1) {
+      if (data > 1024 * 1024) {
+        printf("the workload you are using may not support overwrite automatically\n");
+      } else {
+        overwrite_nbytes = data;
+      }
     }
     fclose(fp);
-    if (overwrite_nbytes > 1024 * 1024) {
-      printf("the workload you are using may not support overwrite automatically\n");
-    }
-    printf("gcpt auto overwrite size :%x\n", overwrite_nbytes);
   }
 }
 

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -410,12 +410,11 @@ Emulator::Emulator(int argc, const char *argv[])
   }
 
   if (args.gcpt_restore) {
-        if (args.overwrite_nbytes_autoset) {
-            FILE *fp = fopen(gcpt_restore_bin, "rb");
-            fseek(fp, 4, SEEK_SET);
-            fread(&args.overwrite_nbytes, sizeof(uint32_t), 1, fp);
-            fclose(fp);
-         
+    if (args.overwrite_nbytes_autoset) {
+      FILE *fp = fopen(args.gcpt_restore, "rb");
+      fseek(fp, 4, SEEK_SET);
+      fread(&args.overwrite_nbytes, sizeof(uint32_t), 1, fp);
+      fclose(fp);
     }
     overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);
   }

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -86,6 +86,7 @@ static inline void print_help(const char *file) {
 #endif
   printf("  -X, --fork-interval=NUM    LightSSS snapshot interval (in seconds)\n");
   printf("      --overwrite-nbytes=N   set valid bytes, but less than 0xf00, default: 0xe00\n");
+  printf("      --overwrite-auto       overwrite size is automatically set of the new gcpt\n");
   printf("      --force-dump-result    force dump performance counter result in the end\n");
   printf("      --load-snapshot=PATH   load snapshot from PATH\n");
   printf("      --no-snapshot          disable saving snapshots\n");
@@ -157,6 +158,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
     { "remote-jtag-port",  1, NULL,  0  },
     { "iotrace-name",      1, NULL,  0  },
     { "dramsim3-ini",      1, NULL,  0  },
+    { "overwrite-auto",    1, NULL,  0  },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "fork-interval",     1, NULL, 'X' },
@@ -254,6 +256,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
             exit(1);
             break;
 #endif
+          case 26: args.overwrite_nbytes_autoset = true; continue;
         }
         // fall through
       default: print_help(argv[0]); exit(0);
@@ -407,6 +410,13 @@ Emulator::Emulator(int argc, const char *argv[])
   }
 
   if (args.gcpt_restore) {
+        if (args.overwrite_nbytes_autoset) {
+            FILE *fp = fopen(gcpt_restore_bin, "rb");
+            fseek(fp, 4, SEEK_SET);
+            fread(&args.overwrite_nbytes, sizeof(uint32_t), 1, fp);
+            fclose(fp);
+         
+    }
     overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);
   }
 

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -80,6 +80,7 @@ struct EmuArgs {
   bool trace_is_read = true;
   bool dump_coverage = false;
   bool image_as_footprints = false;
+  bool overwrite_nbytes_autoset = false;
 };
 
 class Emulator final : public DUT {

--- a/src/test/vsrc/vcs/DifftestEndpoint.v
+++ b/src/test/vsrc/vcs/DifftestEndpoint.v
@@ -49,6 +49,7 @@ import "DPI-C" function byte simv_init();
 import "DPI-C" function void set_max_instrs(longint mc);
 import "DPI-C" function longint get_stuck_limit();
 import "DPI-C" function void set_overwrite_nbytes(longint len);
+import "DPI-C" function void set_overwrite_autoset();
 `ifdef WITH_DRAMSIM3
 import "DPI-C" function void simv_tick();
 `endif // WITH_DRAMSIM3
@@ -114,6 +115,10 @@ initial begin
   if ($test$plusargs("overwrite_nbytes")) begin
     $value$plusargs("overwrite_nbytes=%d", overwrite_nbytes);
     set_overwrite_nbytes(overwrite_nbytes);
+  end
+  // auto set gcpt used size
+  if ($test$plusargs("overwrite_autoset")) begin
+    set_overwrite_autoset();
   end
   // overwrite gcpt on ram: bin file
   if ($test$plusargs("gcpt-restore")) begin


### PR DESCRIPTION
New versions of gcpt allow you to set oversize automatically. if you don't specify size manually, gcpt will look for an oversize flag，on vcs/palldium  using --set_overwrite_autoset enable auto set oversize，on emu using --overwrite-auto