### PR TITLE
fix(config): allow 8GB memory as default for unknown CPUs

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -1,5 +1,5 @@
 /***************************************************************************************
-* Copyright (c) 2020-2023 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
 * Copyright (c) 2020-2021 Peng Cheng Laboratory
 *
 * DiffTest is licensed under Mulan PSL v2.
@@ -36,10 +36,10 @@
 // -----------------------------------------------------------------------
 
 // emulated memory size (Byte)
-#if defined(CPU_NUTSHELL) || defined(CPU_ROCKET_CHIP)
+#if defined(CPU_XIANGSHAN)
+#define DEFAULT_EMU_RAM_SIZE 0x7ff80000000UL // from 0x8000_0000 to 0x800_0000_0000, (8192-2)GB memory
+#else
 #define DEFAULT_EMU_RAM_SIZE (8 * 1024 * 1024 * 1024UL) // 8 GB
-#elif defined(CPU_XIANGSHAN)
-#define DEFAULT_EMU_RAM_SIZE 0x7ff80000000UL // from 0x8000_0000 to 0x800_0000_0000, (8192-2)G memory
 #endif
 
 // physical memory base address


### PR DESCRIPTION
To fix #464 