### PR TITLE
feat(store_event): add pc and robidx for store event

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -224,9 +224,11 @@ class SbufferEvent extends DifftestBaseBundle with HasValid {
 }
 
 class StoreEvent extends DifftestBaseBundle with HasValid {
-  val addr = UInt(64.W)
-  val data = UInt(64.W)
-  val mask = UInt(8.W)
+  val pc     = UInt(64.W)
+  val robidx = UInt(10.W)
+  val addr   = UInt(64.W)
+  val data   = UInt(64.W)
+  val mask   = UInt(8.W)
 }
 
 class LoadEvent extends DifftestBaseBundle with HasValid {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -666,11 +666,12 @@ int Difftest::do_store_check() {
     if (store_event.stamp != commit_stamp)
       return 0;
 #endif // CONFIG_DIFFTEST_SQUASH
+    auto pc   = store_event.pc;
     auto addr = store_event.addr;
     auto data = store_event.data;
-    auto mask = store_event.mask;
+    auto mask  = store_event.mask;
 
-    if (proxy->store_commit(&addr, &data, &mask)) {
+    if (proxy->store_commit(&addr, &data, &mask, &pc)) {
 #ifdef FUZZING
       if (in_disambiguation_state()) {
         Info("Store mismatch detected with a disambiguation state at pc = 0x%lx.\n", dut->trap.pc);
@@ -679,8 +680,9 @@ int Difftest::do_store_check() {
 #endif
       display();
       printf("Mismatch for store commits \n");
-      printf("  REF commits addr 0x%lx, data 0x%lx, mask 0x%x\n", addr, data, mask);
-      printf("  DUT commits addr 0x%lx, data 0x%lx, mask 0x%x\n", store_event.addr, store_event.data, store_event.mask);
+      printf("  REF commits addr 0x%016lx, data 0x%016lx, mask 0x%04x, pc 0x%016lx\n", addr, data, mask, pc);
+      printf("  DUT commits addr 0x%016lx, data 0x%016lx, mask 0x%04x, pc 0x%016lx, robidx 0x%x\n", 
+            store_event.addr, store_event.data, store_event.mask, store_event.pc, store_event.robidx);
 
       store_event_queue.pop();
       return 1;

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -103,7 +103,7 @@ public:
   f(ref_reg_display, difftest_display, void, )                                \
   f(update_config, update_dynamic_config, void, void*)                        \
   f(uarchstatus_sync, difftest_uarchstatus_sync, void, void*)                 \
-  f(store_commit, difftest_store_commit, int, uint64_t*, uint64_t*, uint8_t*) \
+  f(store_commit, difftest_store_commit, int, uint64_t*, uint64_t*, uint8_t*, uint64_t*) \
   f(raise_intr, difftest_raise_intr, void, uint64_t)                          \
   f(load_flash_bin, difftest_load_flash, void, void*, size_t)
 


### PR DESCRIPTION
To make the store event information more efficient, we now add pc and robidx to the store event. The changes need to be used with the new NEMU changes(https://github.com/OpenXiangShan/NEMU/commit/e3966cce05f679311b33f7f569c8116cec48cfe1).