### PR TITLE
Batch: pack Batch param to facilitate migration between DPIC/PCIe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,7 +240,7 @@ jobs:
             make difftest_verilog PROFILE=../build/generated-src/difftest_profile.json NUMCORES=1 CONFIG=EL MFC=1
             make emu WITH_CHISELDB=0 WITH_CONSTANTIN=0 IOTRACE_ZSTD=1 -j2
             ./build/emu -b 0 -e 0 -i ../ready-to-run/microbench.bin --diff ../ready-to-run/riscv64-nemu-interpreter-so --iotrace-name ../iotrace
-    
+
   test-difftest-fuzzing:
     # This test runs on ubuntu-20.04 for two reasons:
     # (1) riscv-arch-test can be built with riscv-linux-gnu toolchain 9.4.0,
@@ -389,14 +389,14 @@ jobs:
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 
-      - name: Verilator Build with VCS Top (with DutZone GlobalEnable Squash Replay Batch PerfCnt)
+      - name: Verilator Build with VCS Top (with GlobalEnable Squash Replay Batch PerfCnt)
         run: |
             cd $GITHUB_WORKSPACE/../xs-env
             source ./env.sh
             cd $GITHUB_WORKSPACE/../xs-env/NutShell
             source ./env.sh
             make clean
-            make simv MILL_ARGS="--difftest-config ZESRBP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            make simv MILL_ARGS="--difftest-config ESRBP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +no-diff +max-cycles=100000
             ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so
 

--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -186,7 +186,7 @@ class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig, 
     }
   }
 
-  val BatchFinish = WireInit(0.U.asTypeOf(new BatchInfo))
+  val BatchFinish = Wire(new BatchInfo)
   BatchFinish.id := (Batch.getTemplate.length + 1).U
   BatchFinish.num := state_step_cnt
   val out = IO(Output(new BatchOutput(chiselTypeOf(state_data), chiselTypeOf(state_info), config)))

--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -41,8 +41,8 @@ class BatchIO(dataType: UInt, infoType: UInt) extends Bundle {
   val info = infoType
 }
 
-class BatchOutput(data: UInt, info: UInt, config: GatewayConfig) extends Bundle {
-  val io = new BatchIO(chiselTypeOf(data), chiselTypeOf(info))
+class BatchOutput(dataType: UInt, infoType: UInt, config: GatewayConfig) extends Bundle {
+  val io = new BatchIO(dataType, infoType)
   val enable = Bool()
   val step = UInt(config.stepWidth.W)
 }
@@ -131,9 +131,7 @@ class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig, 
   }
 
   val BatchInterval = WireInit(0.U.asTypeOf(new BatchInfo))
-  val BatchFinish = WireInit(0.U.asTypeOf(new BatchInfo))
   BatchInterval.id := Batch.getTemplate.length.U
-  BatchFinish.id := (Batch.getTemplate.length + 1).U
   val step_data = dataCollect_vec.last
   val step_info = Cat(infoCollect_vec.last, BatchInterval.asUInt)
   val step_data_len = dataLenCollect_vec.last
@@ -188,7 +186,10 @@ class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig, 
     }
   }
 
-  val out = IO(Output(new BatchOutput(state_data, state_info, config)))
+  val BatchFinish = WireInit(0.U.asTypeOf(new BatchInfo))
+  BatchFinish.id := (Batch.getTemplate.length + 1).U
+  BatchFinish.num := state_step_cnt
+  val out = IO(Output(new BatchOutput(chiselTypeOf(state_data), chiselTypeOf(state_info), config)))
   out.io.data := state_data
   out.io.info := state_info | BatchFinish.asUInt << (state_info_len << 3)
   out.enable := should_tick

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -78,7 +78,7 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
   def dpicFuncProto: String =
     s"""
        |extern "C" void $dpicFuncName (
-       |  ${dpicFuncArgs.flatten.map(arg => getDPICArgString(arg._1, arg._2, true)).mkString(",\n  ")}
+       |  ${dpicFuncArgs.flatten.map(arg => getDPICArgString(arg._1, arg._2, true, !config.isFPGA)).mkString(",\n  ")}
        |)""".stripMargin
   def getPacketDecl(gen: DifftestBundle, prefix: String, config: GatewayConfig): String = {
     val dut_zone = if (config.hasDutZone) "dut_zone" else "0"

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -64,7 +64,12 @@ case class GatewayConfig(
     macros += s"CONFIG_DIFFTEST_${style.toUpperCase}"
     macros += s"CONFIG_DIFFTEST_ZONESIZE $dutZoneSize"
     macros += s"CONFIG_DIFFTEST_BUFLEN $dutBufLen"
-    if (isBatch) macros ++= Seq("CONFIG_DIFFTEST_BATCH", s"CONFIG_DIFFTEST_BATCH_SIZE ${batchSize}")
+    if (isBatch)
+      macros ++= Seq(
+        "CONFIG_DIFFTEST_BATCH",
+        s"CONFIG_DIFFTEST_BATCH_SIZE ${batchSize}",
+        s"CONFIG_DIFFTEST_BATCH_BYTELEN ${batchArgByteLen._1 + batchArgByteLen._2}",
+      )
     if (isSquash) macros ++= Seq("CONFIG_DIFFTEST_SQUASH", s"CONFIG_DIFFTEST_SQUASH_STAMPSIZE 4096") // Stamp Width 12
     if (hasReplay) macros ++= Seq("CONFIG_DIFFTEST_REPLAY", s"CONFIG_DIFFTEST_REPLAY_SIZE ${replaySize}")
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -46,6 +46,7 @@ case class GatewayConfig(
   traceLoad: Boolean = false,
   hierarchicalWiring: Boolean = false,
   exitOnAssertions: Boolean = false,
+  isFPGA: Boolean = false,
 ) {
   def dutZoneSize: Int = if (hasDutZone) 2 else 1
   def dutZoneWidth: Int = log2Ceil(dutZoneSize)
@@ -133,6 +134,7 @@ object Gateway {
       case 'L' => config = config.copy(traceLoad = true)
       case 'H' => config = config.copy(hierarchicalWiring = true)
       case 'X' => config = config.copy(exitOnAssertions = true)
+      case 'F' => config = config.copy(isFPGA = true)
       case x   => println(s"Unknown Gateway Config $x")
     }
     config.check()

--- a/src/test/csrc/common/perf.cpp
+++ b/src/test/csrc/common/perf.cpp
@@ -44,8 +44,11 @@ void difftest_perfcnt_finish(uint64_t cycleCnt) {
   diffstate_perfcnt_finish(perf_run_msec);
   printf(">>> Other Difftest Func\n");
   const char *func_name[DIFFTEST_PERF_NUM] = {
-    "simv_nstep", "difftest_ram_read", "difftest_ram_write", "flash_read", "sd_set_addr", "sd_read",
-    "jtag_tick",  "put_pixel",         "vmem_sync",          "pte_helper", "amo_helper",
+#ifndef CONFIG_DIFFTEST_INTERNAL_STEP
+    "simv_nstep",
+#endif // CONFIG_DIFFTEST_INTERNAL_STEP
+    "difftest_ram_read", "difftest_ram_write", "flash_read", "sd_set_addr", "sd_read",
+    "jtag_tick",         "put_pixel",          "vmem_sync",  "pte_helper",  "amo_helper",
   };
   for (int i = 0; i < DIFFTEST_PERF_NUM; i++) {
     difftest_perfcnt_print(func_name[i], difftest_calls[i], difftest_bytes[i], perf_run_msec);

--- a/src/test/csrc/common/perf.h
+++ b/src/test/csrc/common/perf.h
@@ -27,7 +27,9 @@ static inline void difftest_perfcnt_print(const char *name, long long calls, lon
 void difftest_perfcnt_init();
 void difftest_perfcnt_finish(uint64_t cycleCnt);
 enum DIFFTEST_PERF {
+#ifndef CONFIG_DIFFTEST_INTERNAL_STEP
   perf_simv_nstep,
+#endif // CONFIG_DIFFTEST_INTERNAL_STEP
   perf_difftest_ram_read,
   perf_difftest_ram_write,
   perf_flash_read,


### PR DESCRIPTION
To facilitate Batch migration between DPIC and PCIe, we pack Batch param to an aligned array, and parse it inside software.

In transmission, we only need to pass single hardware data, as svBitVecVal[] or uint8_t[], and then view it as generated struct in software.

Note we put step inside BatchInfo and call simv_nstep inside, Step will be also exposed to Top all the time for Verilator and Timeout Check.