### PR TITLE
feat(mem): add optional ref func `ref_memcpy_init`

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -555,7 +555,7 @@ void Difftest::do_first_instr_commit() {
     simMemory->clone_on_demand(
         [this](uint64_t offset, void *src, size_t n) {
           uint64_t dest_addr = PMEM_BASE + offset;
-          proxy->ref_memcpy(dest_addr, src, n, DUT_TO_REF);
+          proxy->mem_init(dest_addr, src, n, DUT_TO_REF);
         },
         true);
     // Use a temp variable to store the current pc of dut

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -135,15 +135,16 @@ public:
   REF_STORE_LOG(f)  \
   REF_DEBUG_MODE(f)
 
-#define REF_OPTIONAL(f)                                                       \
-  f(ref_status, difftest_status, int, )                                       \
-  f(ref_close, difftest_close, void, )                                        \
-  f(ref_set_ramsize, difftest_set_ramsize, void, size_t)                      \
-  f(ref_set_mhartid, difftest_set_mhartid, void, int)                         \
-  f(ref_put_gmaddr, difftest_put_gmaddr, void, void *)                        \
-  f(ref_skip_one, difftest_skip_one, void, bool, bool, uint32_t, uint64_t)    \
-  f(ref_guided_exec, difftest_guided_exec, void, void*)                       \
-  f(raise_nmi_intr, difftest_raise_nmi_intr, void, bool)                      \
+#define REF_OPTIONAL(f)                                                                                     \
+  f(ref_status, difftest_status, int, )                                                                     \
+  f(ref_close, difftest_close, void, )                                                                      \
+  f(ref_set_ramsize, difftest_set_ramsize, void, size_t)                                                    \
+  f(ref_set_mhartid, difftest_set_mhartid, void, int)                                                       \
+  f(ref_put_gmaddr, difftest_put_gmaddr, void, void *)                                                      \
+  f(ref_skip_one, difftest_skip_one, void, bool, bool, uint32_t, uint64_t)                                  \
+  f(ref_guided_exec, difftest_guided_exec, void, void*)                                                     \
+  f(ref_memcpy_init, difftest_memcpy_init, void, uint64_t, void*, size_t, bool)                             \
+  f(raise_nmi_intr, difftest_raise_nmi_intr, void, bool)                                                    \
   f(ref_virtual_interrupt_is_hvictl_inject, difftest_virtual_interrupt_is_hvictl_inject, void, bool)        \
   f(disambiguation_state, difftest_disambiguation_state, int, )               \
   f(ref_non_reg_interrupt_pending, difftest_non_reg_interrupt_pending, void, void*)
@@ -266,6 +267,14 @@ public:
   inline void set_illegal_mem_access(bool ignored = false) {
     config.ignore_illegal_mem_access = ignored;
     sync_config();
+  }
+
+  inline void mem_init(uint64_t dest, void *src, size_t n, bool direction) {
+    if (ref_memcpy_init) {
+      ref_memcpy_init(dest, src, n, direction);
+    } else {
+      ref_memcpy(dest, src, n, direction);
+    }
   }
 
 #ifdef ENABLE_STORE_LOG

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -1064,7 +1064,7 @@ void Emulator::snapshot_save(const char *filename) {
   stream.unbuf_write(&proxy->pc, sizeof(proxy->pc));
 
   char *buf = (char *)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
-  proxy->ref_memcpy(PMEM_BASE, buf, size, REF_TO_DUT);
+  proxy->mem_init(PMEM_BASE, buf, size, REF_TO_DUT);
   stream.unbuf_write(buf, size);
   munmap(buf, size);
 
@@ -1111,7 +1111,7 @@ void Emulator::snapshot_load(const char *filename) {
 
   char *buf = (char *)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
   stream.read(buf, size);
-  proxy->ref_memcpy(PMEM_BASE, buf, size, DUT_TO_REF);
+  proxy->mem_init(PMEM_BASE, buf, size, DUT_TO_REF);
   munmap(buf, size);
 
   uint64_t csr_buf[4096];


### PR DESCRIPTION
When initializing REF's memory, call mem_init function. If REF provides ref_memcpy_init, use it. If not, use ref_memcpy.