### PR TITLE
fix(cmo): Support difftest for cbo.inval instruction

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -244,6 +244,10 @@ class AtomicEvent extends DifftestBaseBundle with HasValid {
   val out = UInt(64.W)
 }
 
+class CMOInvalEvent extends DifftestBaseBundle with HasValid {
+  val addr = UInt(64.W)
+}
+
 class L1TLBEvent extends DifftestBaseBundle with HasValid {
   val satp = UInt(64.W)
   val vpn = UInt(64.W)

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -368,6 +368,13 @@ class DiffAtomicEvent extends AtomicEvent with DifftestBundle {
   override val squashGroup: Seq[String] = Seq("GOLDENMEM")
 }
 
+class DiffCMOInvalEvent extends CMOInvalEvent with DifftestBundle {
+  override val desiredCppName: String = "cmo_inval"
+  override val squashGroup: Seq[String] = Seq("GOLDENMEM")
+  // TODO: currently we assume it can be dropped
+  override def supportsSquashBase: Bool = true.B
+}
+
 class DiffL1TLBEvent extends L1TLBEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "l1tlb"
   override val squashGroup: Seq[String] = Seq("GOLDENMEM")

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -274,6 +274,10 @@ int Difftest::step() {
   }
 #endif
 
+#ifdef CONFIG_DIFFTEST_REFILLEVENT
+  cmo_inval_event_record();
+#endif
+
   if (!has_commit) {
     return 0;
   }
@@ -725,22 +729,42 @@ int Difftest::do_refill_check(int cacheid) {
     for (int i = 0; i < 8; i++) {
       read_goldenmem(dut_refill->addr + i * 8, &buf, 8);
       if (dut_refill->data[i] != *((uint64_t *)buf)) {
-        printf("cacheid=%d,idtfr=%d,realpaddr=0x%lx: Refill test failed!\n", cacheid, dut_refill->idtfr, realpaddr);
-        printf("addr: %lx\nGold: ", dut_refill->addr);
-        for (int j = 0; j < 8; j++) {
-          read_goldenmem(dut_refill->addr + j * 8, &buf, 8);
-          printf("%016lx", *((uint64_t *)buf));
+        if (cmo_inval_event_set.find(dut_refill->addr) != cmo_inval_event_set.end()) {
+          // If the data inconsistency occurs in the cache block operated by CBO.INVAL,
+          // it is considered reasonable and the DUT data is used to update goldenMem.
+          printf("INFO: Sync GoldenMem using refill Data from DUT (Because of CBO.INVAL):\n");
+          printf("      cacheid=%d, addr: %lx\n      Gold: ", cacheid, dut_refill->addr);
+          for (int j = 0; j < 8; j++) {
+            read_goldenmem(dut_refill->addr + j * 8, &buf, 8);
+            printf("%016lx", *((uint64_t *)buf));
+          }
+          printf("\n      Core: ");
+          for (int j = 0; j < 8; j++) {
+            printf("%016lx", dut_refill->data[j]);
+          }
+          printf("\n");
+          update_goldenmem(dut_refill->addr, dut_refill->data, 0xffffffffffffffffUL, 64);
+          proxy->ref_memcpy(dut_refill->addr, dut_refill->data, 64, DUT_TO_REF);
+          cmo_inval_event_set.erase(dut_refill->addr);
+          return 0;
+        } else {
+          printf("cacheid=%d,idtfr=%d,realpaddr=0x%lx: Refill test failed!\n", cacheid, dut_refill->idtfr, realpaddr);
+          printf("addr: %lx\nGold: ", dut_refill->addr);
+          for (int j = 0; j < 8; j++) {
+            read_goldenmem(dut_refill->addr + j * 8, &buf, 8);
+            printf("%016lx", *((uint64_t *)buf));
+          }
+          printf("\nCore: ");
+          for (int j = 0; j < 8; j++) {
+            printf("%016lx", dut_refill->data[j]);
+          }
+          printf("\n");
+          // continue run some cycle before aborted to dump wave
+          if (delay == 0) {
+            delay = 1;
+          }
+          return 0;
         }
-        printf("\nCore: ");
-        for (int j = 0; j < 8; j++) {
-          printf("%016lx", dut_refill->data[j]);
-        }
-        printf("\n");
-        // continue run some cycle before aborted to dump wave
-        if (delay == 0) {
-          delay = 1;
-        }
-        return 0;
       }
     }
   }
@@ -1130,6 +1154,15 @@ void Difftest::load_event_record() {
 }
 #endif // CONFIG_DIFFTEST_LOADEVENT
 #endif // CONFIG_DIFFTEST_SQUASH
+
+#ifdef CONFIG_DIFFTEST_REFILLEVENT
+void Difftest::cmo_inval_event_record() {
+  if (dut->cmo_inval.valid) {
+    cmo_inval_event_set.insert(dut->cmo_inval.addr);
+    dut->cmo_inval.valid = 0;
+  }
+}
+#endif
 
 int Difftest::check_timeout() {
   uint64_t cycleCnt = get_trap_event()->cycleCnt;

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -22,6 +22,7 @@
 #include "golden.h"
 #include "refproxy.h"
 #include <queue>
+#include <unordered_set>
 #include <vector>
 #ifdef FUZZING
 #include "emu.h"
@@ -330,6 +331,12 @@ protected:
   std::queue<DifftestStoreEvent> store_event_queue;
   void store_event_record();
 #endif
+
+#ifdef CONFIG_DIFFTEST_REFILLEVENT
+  std::unordered_set<uint64_t> cmo_inval_event_set;
+  void cmo_inval_event_record();
+#endif
+
   void update_last_commit() {
     last_commit = get_trap_event()->cycleCnt;
   }

--- a/src/test/scala/DifftestTop.scala
+++ b/src/test/scala/DifftestTop.scala
@@ -44,6 +44,7 @@ class DifftestTop extends Module {
   val difftest_store_event = DifftestModule(new DiffStoreEvent, dontCare = true)
   val difftest_load_event = DifftestModule(new DiffLoadEvent, dontCare = true)
   val difftest_atomic_event = DifftestModule(new DiffAtomicEvent, dontCare = true)
+  val difftest_cmo_inval_event = DifftestModule(new DiffCMOInvalEvent, dontCare = true)
   val difftest_itlb_event = DifftestModule(new DiffL1TLBEvent, dontCare = true)
   val difftest_ldtlb_event = DifftestModule(new DiffL1TLBEvent, dontCare = true)
   val difftest_sttlb_event = DifftestModule(new DiffL1TLBEvent, dontCare = true)


### PR DESCRIPTION
When the DUT executes a cbo.inval, a set is used to record its cacheline address.
Later, if there is a data mismatch between DUT and GoldenMem in the address space operated by the cbo.inval instruction, the Pmem of REF and GoldenMem will be directly updated using the data of DUT.