### PR TITLE
Batch: support data split to reduce transmission bubble

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -24,21 +24,27 @@ import difftest.util.Delayer
 
 import scala.collection.mutable.ListBuffer
 
-case class BatchParam(config: GatewayConfig, templateLen: Int) {
+case class BatchParam(config: GatewayConfig, dataWidth: Int) {
   val infoWidth = (new BatchInfo).getWidth
 
   val MaxDataByteLen = config.batchArgByteLen._1
-  val MaxDataByteWidth = log2Ceil(MaxDataByteLen)
   val MaxDataBitLen = MaxDataByteLen * 8
 
   val MaxInfoByteLen = config.batchArgByteLen._2
-  val MaxInfoByteWidth = log2Ceil(MaxInfoByteLen)
   val MaxInfoBitLen = MaxInfoByteLen * 8
+
+  val BitLenWidth = math.max(log2Ceil(MaxDataBitLen), log2Ceil(dataWidth))
+  val ByteLenWidth = BitLenWidth - 3
 }
 
 class BatchIO(dataType: UInt, infoType: UInt) extends Bundle {
   val data = dataType
   val info = infoType
+}
+
+class BatchStats(ByteLenWidth: Int) extends Bundle {
+  val data_len = UInt(ByteLenWidth.W)
+  val info_len = UInt(ByteLenWidth.W)
 }
 
 class BatchOutput(dataType: UInt, infoType: UInt, config: GatewayConfig) extends Bundle {
@@ -57,8 +63,7 @@ object Batch {
 
   def apply(bundles: MixedVec[Valid[DifftestBundle]], config: GatewayConfig): BatchOutput = {
     template ++= chiselTypeOf(bundles).map(_.bits).distinctBy(_.desiredCppName)
-    val param = BatchParam(config, template.length)
-    val module = Module(new BatchEndpoint(chiselTypeOf(bundles).toSeq, config, param))
+    val module = Module(new BatchEndpoint(chiselTypeOf(bundles).toSeq, config))
     module.in := bundles
     module.out
   }
@@ -70,15 +75,16 @@ object Batch {
   }
 }
 
-class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig, param: BatchParam) extends Module {
+class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
   def vecAlignWidth = (vec: Seq[Valid[DifftestBundle]]) => vec.head.bits.getByteAlign.getWidth * vec.length
 
-  // Collect bundles with valid in Pipeline
+  // Collect bundles with valid of same cycle in Pipeline
   val global_enable = VecInit(in.map(_.valid).toSeq).asUInt.orR
   val inCollect =
     in.groupBy(_.bits.desiredCppName).values.toSeq.map(_.toSeq).sortBy(vecAlignWidth).reverse
   val inCollect_w = inCollect.map(vecAlignWidth)
+  val param = BatchParam(config, inCollect_w.sum)
   val dataCollect_vec = WireInit(
     0.U.asTypeOf(
       MixedVec(
@@ -93,8 +99,7 @@ class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig, 
       )
     )
   )
-  val dataLenCollect_vec = WireInit(0.U.asTypeOf(Vec(inCollect.length, UInt(param.MaxDataByteWidth.W))))
-  val infoLenCollect_vec = WireInit(0.U.asTypeOf(Vec(inCollect.length, UInt(param.MaxInfoByteWidth.W))))
+  val statsCollect_vec = WireInit(0.U.asTypeOf(Vec(inCollect.length, new BatchStats(param.ByteLenWidth))))
   inCollect.zipWithIndex.foreach { case (in, idx) =>
     val (dataBaseW, infoBaseW) = if (idx != 0) {
       (dataCollect_vec(idx - 1).getWidth, infoCollect_vec(idx - 1).getWidth)
@@ -116,84 +121,40 @@ class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig, 
     if (idx != 0) {
       collector.data_base := dataCollect_vec(idx - 1)
       collector.info_base := infoCollect_vec(idx - 1)
-      collector.data_len_base := dataLenCollect_vec(idx - 1)
-      collector.info_len_base := infoLenCollect_vec(idx - 1)
+      collector.stats_base := statsCollect_vec(idx - 1)
     } else {
       collector.data_base := 0.U
       collector.info_base := 0.U
-      collector.data_len_base := 0.U
-      collector.info_len_base := 0.U
+      collector.stats_base := 0.U.asTypeOf(new BatchStats(param.ByteLenWidth))
     }
     dataCollect_vec(idx) := collector.data_out
     infoCollect_vec(idx) := collector.info_out
-    dataLenCollect_vec(idx) := collector.data_len_out
-    infoLenCollect_vec(idx) := collector.info_len_out
+    statsCollect_vec(idx) := collector.stats_out
   }
 
   val BatchInterval = WireInit(0.U.asTypeOf(new BatchInfo))
   BatchInterval.id := Batch.getTemplate.length.U
   val step_data = dataCollect_vec.last
-  val step_info = Cat(infoCollect_vec.last, BatchInterval.asUInt)
-  val step_data_len = dataLenCollect_vec.last
-  val step_info_len = infoLenCollect_vec.last + (param.infoWidth / 8).U
-  assert(step_data_len <= param.MaxDataByteLen.U)
-  assert(step_info_len <= param.MaxInfoByteLen.U)
+  val step_info = infoCollect_vec.last
+  val step_stats_vec = statsCollect_vec.zipWithIndex.map { case (stats, idx) =>
+    Delayer(stats, inCollect.length - idx - 1)
+  }
 
-  val state_data = RegInit(0.U(param.MaxDataBitLen.W))
-  val state_data_len = RegInit(0.U(param.MaxDataByteWidth.W))
-  val state_info = RegInit(0.U(param.MaxInfoBitLen.W))
-  val state_info_len = RegInit(0.U(param.MaxInfoByteWidth.W))
-  val state_step_cnt = RegInit(0.U(config.stepWidth.W))
-  val state_trace_size = Option.when(config.hasReplay)(RegInit(0.U(16.W)))
+  // Assemble collected data from different cycles
+  val assembler = Module(new BatchAssembler(step_data.getWidth, step_info.getWidth, inCollect.length, param, config))
+  assembler.step_data := step_data
+  assembler.step_info := step_info
+  assembler.step_stats_vec := step_stats_vec
 
-  val delayed_enable = Delayer(global_enable, inCollect.length)
-
-  val (delayed_trace_size, delayed_in_replay) = if (config.hasReplay) {
+  assembler.enable := Delayer(global_enable, inCollect.length)
+  if (config.hasReplay) {
     val trace_info = in.map(_.bits).filter(_.desiredCppName == "trace_info").head.asInstanceOf[DiffTraceInfo]
-    (Some(Delayer(trace_info.trace_size, inCollect.length)), Some(Delayer(trace_info.in_replay, inCollect.length)))
-  } else (None, None)
-  val data_exceed = delayed_enable && (state_data_len +& step_data_len > param.MaxDataByteLen.U)
-  val info_exceed =
-    delayed_enable && (state_info_len +& step_info_len + (param.infoWidth / 8).U > param.MaxInfoByteLen.U)
-  val step_exceed = delayed_enable && (state_step_cnt === config.batchSize.U)
-  val trace_exceed = Option.when(config.hasReplay) {
-    delayed_enable && (state_trace_size.get +& delayed_trace_size.get +& inCollect.length.U >= config.replaySize.U)
-  }
-  if (config.hasBuiltInPerf) {
-    DifftestPerf("BatchExceed_data", data_exceed.asUInt)
-    DifftestPerf("BatchExceed_info", info_exceed.asUInt)
-    DifftestPerf("BatchExceed_step", step_exceed.asUInt)
-    if (config.hasReplay) DifftestPerf("BatchExceed_trace", trace_exceed.get.asUInt)
+    assembler.step_trace_info.get := Delayer(trace_info, inCollect.length)
   }
 
-  val should_tick =
-    data_exceed || info_exceed || step_exceed || trace_exceed.getOrElse(false.B) || delayed_in_replay.getOrElse(false.B)
-  when(delayed_enable) {
-    when(should_tick) {
-      state_data := step_data
-      state_data_len := step_data_len
-      state_info := step_info
-      state_info_len := step_info_len
-      state_step_cnt := 1.U
-      if (config.hasReplay) state_trace_size.get := delayed_trace_size.get
-    }.otherwise {
-      state_data := state_data | step_data << (state_data_len << 3)
-      state_data_len := state_data_len + step_data_len
-      state_info := state_info | step_info << (state_info_len << 3)
-      state_info_len := state_info_len + step_info_len
-      state_step_cnt := state_step_cnt + 1.U
-      if (config.hasReplay) state_trace_size.get := state_trace_size.get + delayed_trace_size.get
-    }
-  }
-
-  val BatchFinish = Wire(new BatchInfo)
-  BatchFinish.id := (Batch.getTemplate.length + 1).U
-  BatchFinish.num := state_step_cnt
-  val out = IO(Output(new BatchOutput(chiselTypeOf(state_data), chiselTypeOf(state_info), config)))
-  out.io.data := state_data
-  out.io.info := state_info | BatchFinish.asUInt << (state_info_len << 3)
-  out.enable := should_tick
-  out.step := Mux(out.enable, state_step_cnt, 0.U)
+  val assembled = WireInit(assembler.out)
+  val out = IO(Output(chiselTypeOf(assembled)))
+  out := assembled
 }
 
 // Collect Bundles with Valid by pipeline, same Class will be processed in parallel
@@ -214,18 +175,15 @@ class BatchCollector(
 
   val data_base = IO(Input(UInt(dataBase_w.W)))
   val info_base = IO(Input(UInt(infoBase_w.W)))
-  val data_len_base = IO(Input(UInt(param.MaxDataByteWidth.W)))
-  val info_len_base = IO(Input(UInt(param.MaxInfoByteWidth.W)))
+  val stats_base = IO(Input(new BatchStats(param.ByteLenWidth)))
 
   val data_out = IO(Output(UInt(dataOut_w.W)))
   val info_out = IO(Output(UInt(infoOut_w.W)))
-  val data_len_out = IO(Output(UInt(param.MaxDataByteWidth.W)))
-  val info_len_out = IO(Output(UInt(param.MaxInfoByteWidth.W)))
+  val stats_out = IO(Output(new BatchStats(param.ByteLenWidth)))
 
   val data_state = RegInit(0.U(dataOut_w.W))
   val info_state = RegInit(0.U(infoOut_w.W))
-  val data_len_state = RegInit(0.U(param.MaxDataByteWidth.W))
-  val info_len_state = RegInit(0.U(param.MaxInfoByteWidth.W))
+  val stats_state = RegInit(0.U.asTypeOf(new BatchStats(param.ByteLenWidth)))
 
   val align_data = VecInit(data_in.map(i => i.bits.getByteAlign).toSeq)
   val valid_vec = VecInit(data_in.map(i => i.valid && enable))
@@ -249,17 +207,150 @@ class BatchCollector(
   when(delay_valid.asUInt.orR) {
     data_state := (data_base << MuxLookup(valid_num, 0.U)(offset_map)).asUInt | data_site
     info_state := Cat(info_base, info.asUInt)
-    data_len_state := data_len_base + MuxLookup(valid_num, 0.U)(dataLen_map)
-    info_len_state := info_len_base + (param.infoWidth / 8).U
+    stats_state.data_len := stats_base.data_len + MuxLookup(valid_num, 0.U)(dataLen_map)
+    stats_state.info_len := stats_base.info_len + (param.infoWidth / 8).U
   }.otherwise {
     data_state := data_base
     info_state := info_base
-    data_len_state := data_len_base
-    info_len_state := info_len_base
+    stats_state := stats_base
   }
 
   data_out := data_state
   info_out := info_state
-  data_len_out := data_len_state
-  info_len_out := info_len_state
+  stats_out := stats_state
+}
+
+class BatchAssembler(
+  step_data_w: Int,
+  step_info_w: Int,
+  collect_length: Int,
+  param: BatchParam,
+  config: GatewayConfig,
+) extends Module {
+  val enable = IO(Input(Bool()))
+  val step_data = IO(Input(UInt(step_data_w.W)))
+  val step_info = IO(Input(UInt(step_info_w.W)))
+  val step_stats_vec = IO(Input(Vec(collect_length, new BatchStats(param.ByteLenWidth))))
+  val step_trace_info = Option.when(config.hasReplay)(IO(Input(new DiffTraceInfo(config))))
+
+  val state_data = RegInit(0.U(param.MaxDataBitLen.W))
+  val state_info = RegInit(0.U(param.MaxInfoBitLen.W))
+  val state_stats = RegInit(0.U.asTypeOf(new BatchStats(param.ByteLenWidth)))
+  val state_step_cnt = RegInit(0.U(config.stepWidth.W))
+  val state_trace_size = Option.when(config.hasReplay)(RegInit(0.U(param.ByteLenWidth.W)))
+
+  // Interval update index of buffer, Finish end data parse and call difftest comparision if enabled
+  val BatchInterval = Wire(new BatchInfo)
+  BatchInterval.id := Batch.getTemplate.length.U
+  BatchInterval.num := 0.U // unused
+  val BatchFinish = Wire(new BatchInfo)
+  BatchFinish.id := (Batch.getTemplate.length + 1).U
+  BatchFinish.num := state_step_cnt
+
+  // Assemble step data/info into state in 3 stage
+  // Stage 1:
+  //   1. occupy_stats: get statistic of occupied space
+  //   2. data/info_exceed_vec: mark whether different length fragments of step data/info exceed available space
+  //   3. concat/remain_stats: record statistic for data/info to be concatenated to output or remained to state
+  // Calculate data/info space occupied when enable, assigned in the following code
+  val occupy_stats = Wire(new BatchStats(param.ByteLenWidth))
+  // Calculate available space for step data/info
+  val data_limit = param.MaxDataByteLen.U -& occupy_stats.data_len
+  val info_limit = param.MaxInfoByteLen.U -& occupy_stats.info_len
+  val data_exceed_vec = VecInit(step_stats_vec.map(_.data_len > data_limit && enable))
+  // Note: state_info contains Interval and Finish
+  val info_exceed_vec = VecInit(step_stats_vec.map(_.info_len + (2 * param.infoWidth / 8).U > info_limit && enable))
+  val exceed_vec = VecInit(data_exceed_vec.zip(info_exceed_vec).map { case (de, ie) => de | ie })
+  // Extract last non-exceed stats
+  val concat_stats = VecInit(step_stats_vec.dropRight(1).zipWithIndex.map { case (stats, idx) =>
+    val mask = exceed_vec(idx) ^ exceed_vec(idx + 1)
+    Mux(mask, stats.asUInt, 0.U)
+  }).reduceTree(_ | _).asTypeOf(new BatchStats(param.ByteLenWidth))
+  val remain_stats = WireInit(0.U.asTypeOf(new BatchStats(param.ByteLenWidth)))
+  remain_stats.data_len := step_stats_vec.last.data_len -& concat_stats.data_len
+  remain_stats.info_len := step_stats_vec.last.info_len -& concat_stats.info_len
+  assert(remain_stats.info_len + (2 * param.infoWidth / 8).U <= param.MaxInfoByteLen.U)
+
+  // Stage 2:
+  //   1. delay*: RegNext signal calculated in stage 1 to shorten logic length
+  //   2. delay_concat/remain_data/info: split step into parts of concatenated and remained
+  //   3. should_tick: mark output valid
+  //   4. out: append concatenated data/info to output if any
+  val delay_concat_stats = RegNext(concat_stats)
+  val delay_remain_stats = RegNext(remain_stats)
+  val delay_step_data = RegNext(step_data)
+  val delay_step_info = RegNext(step_info)
+  val delay_step_stats = RegNext(step_stats_vec.last)
+  val delay_concat_data = delay_step_data >> (delay_remain_stats.data_len << 3)
+  val delay_concat_info = delay_step_info >> (delay_remain_stats.info_len << 3)
+  val delay_remain_data = (~(~0.U(step_data_w.W) << (delay_remain_stats.data_len << 3).asUInt)).asUInt & delay_step_data
+  val delay_remain_info = (~(~0.U(step_info_w.W) << (delay_remain_stats.info_len << 3).asUInt)).asUInt & delay_step_info
+
+  val delay_enable = RegNext(enable)
+  val delay_step_exceed = delay_enable && (state_step_cnt === config.batchSize.U)
+  val delay_cont_exceed = RegNext(exceed_vec.asUInt.orR)
+  val delay_trace_exceed = Option.when(config.hasReplay) {
+    delay_enable && (state_trace_size.get +& RegNext(
+      step_trace_info.get.trace_size
+    ) +& collect_length.U >= config.replaySize.U)
+  }
+  if (config.hasBuiltInPerf) {
+    DifftestPerf("BatchExceed_data", data_exceed_vec.asUInt.orR)
+    DifftestPerf("BatchExceed_info", info_exceed_vec.asUInt.orR)
+    DifftestPerf("BatchExceed_step", delay_step_exceed.asUInt)
+    if (config.hasReplay) DifftestPerf("BatchExceed_trace", delay_trace_exceed.get.asUInt)
+  }
+  val in_replay = Option.when(config.hasReplay)(step_trace_info.get.in_replay)
+  val should_tick =
+    delay_cont_exceed || delay_step_exceed || delay_trace_exceed.getOrElse(false.B) || in_replay.getOrElse(false.B)
+
+  // When step equals batchSize(delay_step_exceed), last appended data will overwrite first step data
+  val has_append = RegNext(exceed_vec.asUInt.orR && !exceed_vec.asUInt.andR) && !delay_step_exceed
+  val out = IO(Output(new BatchOutput(chiselTypeOf(state_data), chiselTypeOf(state_info), config)))
+  out.io.data := state_data | Mux(has_append, delay_concat_data << (state_stats.data_len << 3), 0.U)
+  val append_info = Mux(
+    has_append,
+    Cat(
+      delay_concat_info,
+      BatchInterval.asUInt,
+    ) | BatchFinish.asUInt << ((delay_concat_stats.info_len + (param.infoWidth / 8).U) << 3),
+    BatchFinish.asUInt,
+  )
+  out.io.info := state_info | append_info << (state_stats.info_len << 3)
+  out.enable := should_tick
+  out.step := Mux(out.enable, state_step_cnt, 0.U)
+
+  // Stage 3: update state
+  val next_state_stats = Wire(new BatchStats(param.ByteLenWidth))
+  next_state_stats.data_len := Mux(
+    should_tick,
+    Mux(has_append, delay_remain_stats.data_len, delay_step_stats.data_len),
+    state_stats.data_len + delay_step_stats.data_len,
+  )
+  next_state_stats.info_len := Mux(
+    should_tick,
+    Mux(has_append, delay_remain_stats.info_len, delay_step_stats.info_len + (param.infoWidth / 8).U),
+    state_stats.info_len + delay_step_stats.info_len + (param.infoWidth / 8).U,
+  )
+  // Calculate occupied space when enable(stage 1), delay_enable means previous step is in stage 2, use next_state_stats ahead
+  occupy_stats := Mux(delay_enable, next_state_stats, state_stats)
+  when(delay_enable) {
+    state_stats := next_state_stats
+    when(should_tick) {
+      state_step_cnt := 1.U
+      when(has_append) {
+        state_data := delay_remain_data
+        state_info := delay_remain_info
+      }.otherwise {
+        state_data := delay_step_data
+        state_info := Cat(delay_step_info, BatchInterval.asUInt)
+      }
+      if (config.hasReplay) state_trace_size.get := RegNext(step_trace_info.get.trace_size)
+    }.otherwise {
+      state_step_cnt := state_step_cnt + 1.U
+      state_data := state_data | delay_step_data << (state_stats.data_len << 3)
+      state_info := state_info | Cat(delay_step_info, BatchInterval.asUInt) << (state_stats.info_len << 3)
+      if (config.hasReplay) state_trace_size.get := state_trace_size.get + RegNext(step_trace_info.get.trace_size)
+    }
+  }
 }

--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -25,26 +25,26 @@ import difftest.util.Delayer
 import scala.collection.mutable.ListBuffer
 
 case class BatchParam(config: GatewayConfig, collectDataWidth: Int, collectLength: Int) {
-  val infoWidth = (new BatchInfo).getWidth
+  def infoWidth = (new BatchInfo).getWidth
 
   // Maximum Byte length decided by transmission function
-  val MaxDataByteLen = config.batchArgByteLen._1
-  val MaxDataBitLen = MaxDataByteLen * 8
-  val MaxDataLenWidth = log2Ceil(MaxDataByteLen)
-  val MaxInfoByteLen = config.batchArgByteLen._2
-  val MaxInfoBitLen = MaxInfoByteLen * 8
-  val MaxInfoLenWidth = log2Ceil(MaxInfoByteLen)
+  def MaxDataByteLen = config.batchArgByteLen._1
+  def MaxDataBitLen = MaxDataByteLen * 8
+  def MaxDataLenWidth = log2Ceil(MaxDataByteLen)
+  def MaxInfoByteLen = config.batchArgByteLen._2
+  def MaxInfoBitLen = MaxInfoByteLen * 8
+  def MaxInfoLenWidth = log2Ceil(MaxInfoByteLen)
 
   // Width of statistic for data/info byte length
-  val StatsDataLenWidth = log2Ceil((collectDataWidth + 7) / 8)
-  val collectInfoWidth = collectLength * infoWidth
-  val StatsInfoLenWidth = log2Ceil((collectInfoWidth + 7) / 8)
+  def StatsDataLenWidth = log2Ceil((collectDataWidth + 7) / 8)
+  def collectInfoWidth = collectLength * infoWidth
+  def StatsInfoLenWidth = log2Ceil((collectInfoWidth + 7) / 8)
 
   // Truncate width when shifting to reduce useless gates
-  val TruncDataBitLen = math.min(MaxDataBitLen, collectDataWidth)
-  val TruncInfoBitLen = math.min(MaxInfoBitLen, collectInfoWidth)
-  val TruncDataLenWidth = math.min(MaxDataLenWidth, StatsDataLenWidth)
-  val TruncInfoLenWidth = math.min(MaxInfoLenWidth, StatsInfoLenWidth)
+  def TruncDataBitLen = math.min(MaxDataBitLen, collectDataWidth)
+  def TruncInfoBitLen = math.min(MaxInfoBitLen, collectInfoWidth)
+  def TruncDataLenWidth = math.min(MaxDataLenWidth, StatsDataLenWidth)
+  def TruncInfoLenWidth = math.min(MaxInfoLenWidth, StatsInfoLenWidth)
 }
 
 class BatchIO(dataType: UInt, infoType: UInt) extends Bundle {

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -247,7 +247,7 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
            |  ${bundleEnum.mkString(",\n  ")}
            |  };
            |  extern void simv_nstep(uint8_t step);
-           |  uint32_t dut_index = 0;
+           |  static int dut_index = -1;
            |  $batchDecl
            |  for (int i = 0; i < $infoLen; i++) {
            |    uint8_t id = info[i].id;
@@ -259,8 +259,8 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
            |#endif // CONFIG_DIFFTEST_INTERNAL_STEP
            |      break;
            |    }
-           |    else if (id == BatchInterval && i != 0) {
-           |      dut_index ++;
+           |    else if (id == BatchInterval) {
+           |      dut_index = (dut_index + 1) % CONFIG_DIFFTEST_BATCH_SIZE;
            |      continue;
            |    }
            |    $bundleAssign
@@ -352,7 +352,7 @@ object DPIC {
         |  }
         |  inline DiffTestState* next() {
         |    DiffTestState* ret = buffer[zone_ptr] + read_ptr;
-        |    read_ptr = read_ptr + 1;
+        |    read_ptr = (read_ptr + 1) % CONFIG_DIFFTEST_BUFLEN;
         |    return ret;
         |  }
         |  inline void switch_zone() {

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -38,7 +38,7 @@ case class GatewayConfig(
   replaySize: Int = 1024,
   hasDutZone: Boolean = false,
   isBatch: Boolean = false,
-  batchSize: Int = 32,
+  batchSize: Int = 64,
   hasInternalStep: Boolean = false,
   isNonBlock: Boolean = false,
   hasBuiltInPerf: Boolean = false,
@@ -53,7 +53,7 @@ case class GatewayConfig(
   def dutBufLen: Int = if (isBatch) batchSize else 1
   def maxStep: Int = if (isBatch) batchSize else 1
   def stepWidth: Int = log2Ceil(maxStep + 1)
-  def batchArgByteLen: (Int, Int) = if (isNonBlock) (3900, 100) else (7800, 200)
+  def batchArgByteLen: (Int, Int) = if (isNonBlock) (3600, 400) else (7200, 800)
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
   def needEndpoint: Boolean =

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -66,7 +66,9 @@ int difftest_state() {
 }
 
 int difftest_nstep(int step, bool enable_diff) {
+#if CONFIG_DIFFTEST_ZONESIZE > 1
   difftest_switch_zone();
+#endif // CONFIG_DIFFTEST_ZONESIZE
   for (int i = 0; i < step; i++) {
     if (enable_diff) {
       if (difftest_step())

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -329,7 +329,9 @@ extern "C" uint8_t simv_nstep(uint8_t step) {
 #endif // CONFIG_DIFFTEST_PERFCNT
 
 #ifndef CONFIG_NO_DIFFTEST
+#if CONFIG_DIFFTEST_ZONESIZE > 1
   difftest_switch_zone();
+#endif // CONFIG_DIFFTEST_ZONESIZE
 #endif // CONFIG_NO_DIFFTEST
 
   for (int i = 0; i < step; i++) {


### PR DESCRIPTION
Previously, we view data collected from same cycle as a whole, end batch assembling when step data longer than available space. It results in bubble in transmission, and cannot handle situation when step data longer than Max width in a single transmission.

This change support spliting step data according to collector, appending part of data to output and updating remained to state. To shorten logic length, we divide complex logic to three stage.

Note step data may be splited to different batch func, and should be read as a whole, so we avoid buffer-zone switch when batch enabled.