### PR TITLE
fix(trigger): no need to implement tcontrol in XiangShan trigger

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -160,7 +160,6 @@ class TriggerCSRState extends DifftestBaseBundle {
   val tselect = UInt(64.W)
   val tdata1 = UInt(64.W)
   val tinfo = UInt(64.W)
-  val tcontrol = UInt(64.W)
 }
 
 class DataWriteback(val numElements: Int) extends DifftestBaseBundle with HasValid with HasAddress {

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -76,7 +76,7 @@ static const char *regs_name_fp_csr[] = {
 };
 
 static const char *regs_name_triggercsr[] = {
-  "tselect", "tdata1", "tinfo", "tcontol"
+  "tselect", "tdata1", "tinfo"
 };
 
 /* clang-format on */


### PR DESCRIPTION
In our new trigger solution, we donot need implement tcontrol.