### PR TITLE
fix(csr): add difftest of mhpmevent overflow to diff csr mhpmeventn

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ coherence via RefillTest.
 | `DiffRefillEvent` | Cache refill operations | No |
 | `DiffLrScEvent` | Executed LR/SC instructions | No |
 | `DiffNonRegInterruptPengingEvent` | Non-register interrupts pending | No |
+| `DiffMhpmeventOverflowEvent` | Mhpmevent-register overflow | No |
 
 The DiffTest framework comes with a simulation framework with some top-level IOs.
 They will be automatically created when calling `DifftestModule.finish(cpu: String)`.

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -315,6 +315,10 @@ class NonRegInterruptPendingEvent extends DifftestBaseBundle with HasValid {
   val localCounterOverflowInterruptReq = Bool()
 }
 
+class MhpmeventOverflowEvent extends DifftestBaseBundle with HasValid {
+  val mhpmeventOverflow = UInt(64.W)
+}
+
 class TraceInfo extends DifftestBaseBundle with HasValid {
   val in_replay = Bool()
   val trace_head = UInt(16.W)

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -414,7 +414,10 @@ class DiffRunaheadRedirectEvent extends RunaheadRedirectEvent with DifftestBundl
 
 class DiffNonRegInterruptPendingEvent extends NonRegInterruptPendingEvent with DifftestBundle {
   override val desiredCppName: String = "non_reg_interrupt_pending"
+}
 
+class DiffMhpmeventOverflowEvent extends MhpmeventOverflowEvent with DifftestBundle {
+  override val desiredCppName: String = "mhpmevent_overflow"
 }
 
 class DiffTraceInfo(config: GatewayConfig) extends TraceInfo with DifftestBundle {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -324,6 +324,10 @@ int Difftest::step() {
   do_non_reg_interrupt_pending();
 #endif
 
+#ifdef CONFIG_DIFFTEST_MHPMEVENTOVERFLOWEVENT
+  do_mhpmevent_overflow();
+#endif
+
   num_commit = 0; // reset num_commit this cycle to 0
   if (dut->event.valid) {
     // interrupt has a higher priority than exception
@@ -1277,6 +1281,15 @@ void Difftest::do_non_reg_interrupt_pending() {
 
     proxy->non_reg_interrupt_pending(ip);
     dut->non_reg_interrupt_pending.valid = 0;
+  }
+}
+#endif
+
+#ifdef CONFIG_DIFFTEST_MHPMEVENTOVERFLOWEVENT
+void Difftest::do_mhpmevent_overflow() {
+  if (dut->mhpmevent_overflow.valid) {
+    proxy->mhpmevent_overflow(dut->mhpmevent_overflow.mhpmeventOverflow);
+    dut->mhpmevent_overflow.valid = 0;
   }
 }
 #endif

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -419,6 +419,9 @@ protected:
 #ifdef CONFIG_DIFFTEST_NONREGINTERRUPTPENDINGEVENT
   void do_non_reg_interrupt_pending();
 #endif
+#ifdef CONFIG_DIFFTEST_MHPMEVENTOVERFLOWEVENT
+  void do_mhpmevent_overflow();
+#endif
 #ifdef CONFIG_DIFFTEST_REPLAY
   struct {
     bool in_replay = false;

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -147,7 +147,8 @@ public:
   f(raise_nmi_intr, difftest_raise_nmi_intr, void, bool)                                                    \
   f(ref_virtual_interrupt_is_hvictl_inject, difftest_virtual_interrupt_is_hvictl_inject, void, bool)        \
   f(disambiguation_state, difftest_disambiguation_state, int, )               \
-  f(ref_non_reg_interrupt_pending, difftest_non_reg_interrupt_pending, void, void*)
+  f(ref_non_reg_interrupt_pending, difftest_non_reg_interrupt_pending, void, void*) \
+  f(raise_mhpmevent_overflow, difftest_raise_mhpmevent_overflow, void, uint64_t)
 
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
@@ -248,6 +249,12 @@ public:
   inline void non_reg_interrupt_pending(struct NonRegInterruptPending &ip) {
     if (ref_non_reg_interrupt_pending) {
       ref_non_reg_interrupt_pending(&ip);
+    }
+  }
+
+  inline void mhpmevent_overflow(uint64_t mhpmeventOverflow) {
+    if (raise_mhpmevent_overflow) {
+      raise_mhpmevent_overflow(mhpmeventOverflow);
     }
   }
 

--- a/src/test/scala/DifftestTop.scala
+++ b/src/test/scala/DifftestTop.scala
@@ -57,6 +57,7 @@ class DifftestTop extends Module {
   val difftest_runahead_commit_event = DifftestModule(new DiffRunaheadCommitEvent, dontCare = true)
   val difftest_runahead_redirect_event = DifftestModule(new DiffRunaheadRedirectEvent, dontCare = true)
   val difftest_non_reg_interrupt_pending_event = DifftestModule(new DiffNonRegInterruptPendingEvent, dontCare = true)
+  val difftest_mhpmevent_overflow_event = DifftestModule(new DiffMhpmeventOverflowEvent, dontCare = true)
 
   DifftestModule.finish("demo")
 }


### PR DESCRIPTION
This PR adds support `mhpmeventn` registers overflow.
Count overflow comes only from hardware increment of counter register. NEMU cann‘t generate it by itself.
At the same time, we can clear counter overflow signal by software writing 0 to the `of` bit of mhpmevent register.