### PR TITLE
difftest: submit buffered data in Squash/Batch when timeout

### DIFF
--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -125,6 +125,14 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
       .reduce(_ || _)
   })
 
+  val timeout_count = RegInit(0.U(32.W))
+  val timeout = timeout_count === 200000.U
+  val or_want_tick = want_tick_vec.reduce(_ || _)
+  when(!or_want_tick) {
+    timeout_count := timeout_count + 1.U
+  }.otherwise {
+    timeout_count := 0.U
+  }
   val s_out_vec = uniqBundles.zip(want_tick_vec).map { case (u, wt) =>
     val s_in = in.filter(_.bits.desiredCppName == u.desiredCppName)
     val squasher = Module(new Squasher(chiselTypeOf(s_in.head), s_in.length, numCores, config))
@@ -135,7 +143,7 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
         .zip(group_tick_vec)
         .collect { case (n, gt) if u.squashGroup.contains(n) => gt }
         .foldLeft(false.B)(_ || _)
-    squasher.should_tick := wt || group_tick || global_tick
+    squasher.should_tick := wt || group_tick || global_tick || timeout
     squasher.out
   }
   // Flatten Seq[MixedVec[DifftestBundle]] to MixedVec[DifftestBundle]


### PR DESCRIPTION
Commit the remaining cache for squash and batch when the cpu has not committed an instruction for a long time