### PR TITLE
feat(dbltrp): add support for critical-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ coherence via RefillTest.
 | `DiffLrScEvent` | Executed LR/SC instructions | No |
 | `DiffNonRegInterruptPengingEvent` | Non-register interrupts pending | No |
 | `DiffMhpmeventOverflowEvent` | Mhpmevent-register overflow | No |
+| `DiffDiffCriticalErrorEvent` | Raise critical-error | No |
 
 The DiffTest framework comes with a simulation framework with some top-level IOs.
 They will be automatically created when calling `DifftestModule.finish(cpu: String)`.

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -324,3 +324,7 @@ class TraceInfo extends DifftestBaseBundle with HasValid {
   val trace_head = UInt(16.W)
   val trace_size = UInt(16.W)
 }
+
+class CriticalErrorEvent extends DifftestBaseBundle with HasValid {
+  val criticalError = Bool()
+}

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -420,6 +420,10 @@ class DiffMhpmeventOverflowEvent extends MhpmeventOverflowEvent with DifftestBun
   override val desiredCppName: String = "mhpmevent_overflow"
 }
 
+class DiffCriticalErrorEvent extends CriticalErrorEvent with DifftestBundle {
+  override val desiredCppName: String = "critical_error"
+}
+
 class DiffTraceInfo(config: GatewayConfig) extends TraceInfo with DifftestBundle {
   override val desiredCppName: String = "trace_info"
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -329,6 +329,9 @@ int Difftest::step() {
 #ifdef CONFIG_DIFFTEST_MHPMEVENTOVERFLOWEVENT
   do_mhpmevent_overflow();
 #endif
+#ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
+  do_raise_critical_error();
+#endif
 
   num_commit = 0; // reset num_commit this cycle to 0
   if (dut->event.valid) {
@@ -1292,6 +1295,16 @@ void Difftest::do_mhpmevent_overflow() {
   if (dut->mhpmevent_overflow.valid) {
     proxy->mhpmevent_overflow(dut->mhpmevent_overflow.mhpmeventOverflow);
     dut->mhpmevent_overflow.valid = 0;
+  }
+}
+#endif
+
+#ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
+void Difftest::do_raise_critical_error() {
+  if (dut->critical_error.valid) {
+    display();
+    Info("Core %d dump: critical_error raise \n", this->id);
+    raise_trap(STATE_ABORT);
   }
 }
 #endif

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -422,6 +422,9 @@ protected:
 #ifdef CONFIG_DIFFTEST_MHPMEVENTOVERFLOWEVENT
   void do_mhpmevent_overflow();
 #endif
+#ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
+  void do_raise_critical_error();
+#endif
 #ifdef CONFIG_DIFFTEST_REPLAY
   struct {
     bool in_replay = false;

--- a/src/test/scala/DifftestTop.scala
+++ b/src/test/scala/DifftestTop.scala
@@ -58,6 +58,7 @@ class DifftestTop extends Module {
   val difftest_runahead_redirect_event = DifftestModule(new DiffRunaheadRedirectEvent, dontCare = true)
   val difftest_non_reg_interrupt_pending_event = DifftestModule(new DiffNonRegInterruptPendingEvent, dontCare = true)
   val difftest_mhpmevent_overflow_event = DifftestModule(new DiffMhpmeventOverflowEvent, dontCare = true)
+  val difftest_critical_error_event = DifftestModule(new DiffCriticalErrorEvent, dontCare = true)
 
   DifftestModule.finish("demo")
 }


### PR DESCRIPTION
This pr raise critical-error in difftest when XiangShan issues a critical-error signal.
The `critical-error` state is defined in the `smdbltrp` extension. This extension specifies that when the `critical-error` signal is asserted, the CPU should halt execution. This PR implements a method for stopping execution in simulation mode, where difftest halts by triggering an `abort`.
In the future, an option to enter debug mode rather than directly halting the CPU will be introduced for handling `critical-error`. This incoming change won’t require modifications to the difftest framework; Xiangshan will only need to control it through an  `valid` signal.