### PR TITLE
Validate: update ArchRegState only when commit or event

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -298,6 +298,7 @@ class DiffVecWriteback(numRegs: Int = 32) extends DiffIntWriteback(numRegs) {
 class DiffArchIntRegState extends ArchIntRegState with DifftestBundle {
   override val desiredCppName: String = "regs_int"
   override val desiredOffset: Int = 0
+  override val updateDependency: Seq[String] = Seq("commit", "event")
 }
 
 abstract class DiffArchDelayedUpdate(numRegs: Int)
@@ -318,11 +319,13 @@ class DiffArchFpDelayedUpdate extends DiffArchDelayedUpdate(32) {
 class DiffArchFpRegState extends ArchIntRegState with DifftestBundle {
   override val desiredCppName: String = "regs_fp"
   override val desiredOffset: Int = 2
+  override val updateDependency: Seq[String] = Seq("commit", "event")
 }
 
 class DiffArchVecRegState extends ArchVecRegState with DifftestBundle {
   override val desiredCppName: String = "regs_vec"
   override val desiredOffset: Int = 4
+  override val updateDependency: Seq[String] = Seq("commit", "event")
 }
 
 class DiffVecCSRState extends VecCSRState with DifftestBundle {


### PR DESCRIPTION
When Squash enabled, previous squashed instrCommit may be submitted with new-coming updated ArchRegState, which results in reg mismatch with REF.

In difftest software side, we will only use ArchRegState when instrCommit or event (progress = true in code), so we add updateDependency for ArchRegState to ensure using corresponding ones with squashed commits, just like we add for CSR before.