### PR TITLE
gsim: generate cpp extmodule functions

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -19,7 +19,7 @@ import chisel3._
 import chisel3.experimental.ExtModule
 import chisel3.reflect.DataMirror
 import chisel3.util._
-import difftest.DifftestModule.streamToFile
+import difftest.DifftestModule.{createCppExtModule, streamToFile}
 import difftest._
 import difftest.batch.{BatchInfo, BatchIO}
 import difftest.gateway.{GatewayConfig, GatewayResult, GatewaySinkControl}
@@ -39,7 +39,8 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
     val typeString = data.getWidth match {
       case 1                                  => if (isC) "uint8_t" else "bit"
       case width if width > 1 && width <= 8   => if (isC) "uint8_t" else "byte"
-      case width if width > 8 && width <= 32  => if (isC) "uint32_t" else "int"
+      case width if width > 8 && width <= 16  => if (isC) "uint16_t" else "shortint"
+      case width if width > 16 && width <= 32 => if (isC) "uint32_t" else "int"
       case width if width > 32 && width <= 64 => if (isC) "uint64_t" else "longint"
       case width if width > 64 =>
         if (isC)
@@ -72,13 +73,15 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
   }
 
   def desiredName: String
-  def dpicFuncName: String = s"v_difftest_${desiredName.replace("Difftest", "")}"
+  def dpicFuncName: String = s"v_difftest_${desiredName.replace("DiffExt", "")}"
   def dpicFuncArgs: Seq[Seq[(String, Data)]] =
     modPorts.filterNot(p => p.length == 1 && commonPorts.exists(_._1 == p.head._1))
   def dpicFuncProto: String =
     s"""
        |extern "C" void $dpicFuncName (
-       |  ${dpicFuncArgs.flatten.map(arg => getDPICArgString(arg._1, arg._2, true, !config.isFPGA)).mkString(",\n  ")}
+       |  ${dpicFuncArgs.flatten
+        .map(arg => getDPICArgString(arg._1, arg._2, true, config.useDPICtype))
+        .mkString(",\n  ")}
        |)""".stripMargin
   def getPacketDecl(gen: DifftestBundle, prefix: String, config: GatewayConfig): String = {
     val dut_zone = if (config.hasDutZone) "dut_zone" else "0"
@@ -145,12 +148,25 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
          |""".stripMargin
     modDef
   }
+
+  def cppExtModule: String = {
+    val extArgs = modPorts.flatten.filterNot(_._1 == "clock").map(arg => getDPICArgString(arg._1, arg._2, true, false))
+    s"""
+       |void $desiredName(
+       |  ${extArgs.mkString(",\n  ")}
+       |) {
+       |  if (enable) {
+       |    $dpicFuncName (${dpicFuncArgs.flatten.map(_._1).mkString(", ")});
+       |  }
+       |}
+       |""".stripMargin
+  }
 }
 
 class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig) extends DPICBase(config) with DifftestModule[T] {
   val io = IO(Input(gen))
 
-  override def desiredName: String = gen.desiredModuleName
+  override def desiredName: String = gen.desiredModuleName.replace("Difftest", "DiffExt")
   override def modPorts: Seq[Seq[(String, Data)]] = {
     super.modPorts ++ io.elements.toSeq.reverse.map { case (name, data) =>
       data match {
@@ -184,6 +200,7 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig) extends DPICBase(
     packetDecl ++ validAssign ++ body
   }
 
+  createCppExtModule(desiredName, cppExtModule, Some("\"difftest-dpic.h\""))
   setInline(s"$desiredName.v", moduleBody)
 }
 
@@ -208,7 +225,7 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
 
   override def modPorts = super.modPorts ++ Seq(Seq(("io", io)))
 
-  override def desiredName: String = "DifftestBatch"
+  override def desiredName: String = "DiffExtBatch"
   override def dpicFuncAssigns: Seq[String] = {
     val bundleEnum = template.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchInterval", "BatchFinish")
     val bundleAssign = template.zipWithIndex.map { case (t, idx) =>
@@ -268,6 +285,7 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
            |""".stripMargin)
   }
 
+  createCppExtModule(desiredName, cppExtModule, Some("\"difftest-dpic.h\""))
   setInline(s"$desiredName.v", moduleBody)
 }
 
@@ -365,15 +383,6 @@ object DPIC {
         |  }
         |};
         |""".stripMargin
-    interfaceCpp +=
-      s"""
-         |#ifdef CONFIG_DIFFTEST_PERFCNT
-         |enum DIFFSTATE_PERF {
-         |  ${(interfaces.map("perf_" + _._1) ++ Seq("DIFFSTATE_PERF_NUM")).mkString(",\n  ")}
-         |};
-         |long long dpic_calls[DIFFSTATE_PERF_NUM] = {0}, dpic_bytes[DIFFSTATE_PERF_NUM] = {0};
-         |#endif // CONFIG_DIFFTEST_PERFCNT
-         |""".stripMargin
     interfaceCpp += interfaces.map(_._2 + ";").mkString("\n")
     interfaceCpp += ""
     interfaceCpp += "#endif // __DIFFTEST_DPIC_H__"
@@ -409,6 +418,10 @@ object DPIC {
     interfaceCpp +=
       s"""
          |#ifdef CONFIG_DIFFTEST_PERFCNT
+         |enum DIFFSTATE_PERF {
+         |  ${(interfaces.map("perf_" + _._1) ++ Seq("DIFFSTATE_PERF_NUM")).mkString(",\n  ")}
+         |};
+         |long long dpic_calls[DIFFSTATE_PERF_NUM] = {0}, dpic_bytes[DIFFSTATE_PERF_NUM] = {0};
          |void diffstate_perfcnt_init() {
          |  for (int i = 0; i < DIFFSTATE_PERF_NUM; i++) {
          |    dpic_calls[i] = 0;

--- a/src/main/scala/common/Flash.scala
+++ b/src/main/scala/common/Flash.scala
@@ -35,6 +35,18 @@ class FlashHelper extends ExtModule with HasExtModuleInline {
   val clock = IO(Input(Clock()))
   val r = IO(new DifftestFlashRead)
 
+  val cppExtModule =
+    """
+      |void FlashHelper (
+      |  uint8_t   r_en,
+      |  uint32_t  r_addr,
+      |  uint64_t& r_data
+      |) {
+      |  if (r_en) flash_read(r_addr, r_data);
+      |}
+      |""".stripMargin
+  difftest.DifftestModule.createCppExtModule("FlashHelper", cppExtModule, Some("\"flash.h\""))
+
   setInline(
     "FlashHelper.v",
     """

--- a/src/main/scala/common/LogPerfControl.scala
+++ b/src/main/scala/common/LogPerfControl.scala
@@ -29,6 +29,22 @@ class LogPerfControl extends Bundle {
 private class LogPerfHelper extends BlackBox with HasBlackBoxInline {
   val io = IO(Output(new LogPerfControl))
 
+  val cppExtModule =
+    """
+      |void LogPerfHelper (
+      |  uint64_t& timer,
+      |  uint8_t&  logEnable,
+      |  uint8_t&  clean,
+      |  uint8_t&  dump
+      |) {
+      |  timer     = difftest$$timer;
+      |  logEnable = difftest$$log_enable;
+      |  clean     = difftest$$perfCtrl$$clean;
+      |  dump      = difftest$$perfCtrl$$dump;
+      |}
+      |""".stripMargin
+  difftest.DifftestModule.createCppExtModule("LogPerfHelper", cppExtModule)
+
   val verilog =
     """`ifndef SIM_TOP_MODULE_NAME
       |  `define SIM_TOP_MODULE_NAME SimTop

--- a/src/main/scala/common/SDCard.scala
+++ b/src/main/scala/common/SDCard.scala
@@ -30,6 +30,20 @@ class SDCardHelper extends ExtModule with HasExtModuleInline {
   val clock = IO(Input(Clock()))
   val io = IO(new DifftestSDCardRead)
 
+  val cppExtModule =
+    """
+      |void SDCardHelper (
+      |  uint8_t   io_setAddr,
+      |  uint32_t  io_addr,
+      |  uint8_t   io_ren,
+      |  uint32_t& io_data
+      |) {
+      |  if (io_ren) sd_read(&io_data);
+      |  if (io_setAddr) sd_setaddr(io_addr);
+      |}
+      |""".stripMargin
+  difftest.DifftestModule.createCppExtModule("SDCardHelper", cppExtModule, Some("\"sdcard.h\""))
+
   setInline(
     "SDCardHelper.v",
     s"""


### PR DESCRIPTION
When using GSIM for simulation, we will use generated cpp function to replace extern verilog modules.

This change support generating cppExtFuncs with dependent header, including dpic wrappers and extern module funcs, such as xxHelper.

Note we rename extern module name from DifftestXX to DiffExtXX to avoid extern func name conflicts with stuct. Also, we add uint16_t and shortint support to DPIC args.