### PR TITLE
difftest: move declaration of extern func to header

### DIFF
--- a/src/test/csrc/common/SimJTAG.cpp
+++ b/src/test/csrc/common/SimJTAG.cpp
@@ -1,5 +1,6 @@
 // See LICENSE.SiFive for license details.
 
+#include "SimJTAG.h"
 #include "common.h"
 #include "remote_bitbang.h"
 #include <cstdlib>
@@ -11,12 +12,12 @@ remote_bitbang_t *jtag;
 bool enable_simjtag = false;
 uint16_t remote_jtag_port = 23334;
 
-extern "C" void jtag_init() {
+void jtag_init() {
   jtag = new remote_bitbang_t(remote_jtag_port);
 }
 
-extern "C" int jtag_tick(unsigned char *jtag_TCK, unsigned char *jtag_TMS, unsigned char *jtag_TDI,
-                         unsigned char *jtag_TRSTn, unsigned char jtag_TDO) {
+int jtag_tick(unsigned char *jtag_TCK, unsigned char *jtag_TMS, unsigned char *jtag_TDI, unsigned char *jtag_TRSTn,
+              unsigned char jtag_TDO) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_jtag_tick]++;
   difftest_bytes[perf_jtag_tick] += 5;

--- a/src/test/csrc/common/SimJTAG.h
+++ b/src/test/csrc/common/SimJTAG.h
@@ -1,6 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2020-2023 Institute of Computing Technology, Chinese Academy of Sciences
-* Copyright (c) 2020-2021 Peng Cheng Laboratory
+* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
 *
 * DiffTest is licensed under Mulan PSL v2.
 * You can use this software according to the terms and conditions of the Mulan PSL v2.
@@ -14,14 +14,12 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-#ifndef __SDCARD_H
-#define __SDCARD_H
+#ifndef __SIMJTAG_H
+#define __SIMJTAG_H
 
 #include "common.h"
 
-extern FILE *fp;
-extern "C" void sd_setaddr(uint32_t addr);
-extern "C" void sd_read(uint32_t *data);
-void init_sd(void);
-void finish_sd(void);
-#endif // __SDCARD_H
+extern "C" void jtag_init();
+extern "C" int jtag_tick(unsigned char *jtag_TCK, unsigned char *jtag_TMS, unsigned char *jtag_TDI,
+                         unsigned char *jtag_TRSTn, unsigned char jtag_TDO);
+#endif // __SIMJTAG_H

--- a/src/test/csrc/common/common.cpp
+++ b/src/test/csrc/common/common.cpp
@@ -23,7 +23,7 @@ int signal_num = 0;
 const char *emu_path = NULL;
 
 // Usage in SV/Verilog: xs_assert(`__LINE__);
-extern "C" void xs_assert(long long line) {
+void xs_assert(long long line) {
   if (assert_count >= 0) {
     printf("Assertion failed at line %lld.\n", line);
     assert_count++;
@@ -31,7 +31,7 @@ extern "C" void xs_assert(long long line) {
 }
 
 // Usage in SV/Verilog: xs_assert_v2(`__FILE__, `__LINE__);
-extern "C" void xs_assert_v2(const char *filename, long long line) {
+void xs_assert_v2(const char *filename, long long line) {
   if (assert_count >= 0) {
     printf("Assertion failed at %s:%lld.\n", filename, line);
     assert_count++;

--- a/src/test/csrc/common/common.h
+++ b/src/test/csrc/common/common.h
@@ -99,4 +99,6 @@ void common_finish();
 
 uint32_t uptime(void);
 
+extern "C" void xs_assert(long long line);
+extern "C" void xs_assert_v2(const char *filename, long long line);
 #endif // __COMMON_H

--- a/src/test/csrc/common/device.cpp
+++ b/src/test/csrc/common/device.cpp
@@ -15,18 +15,15 @@
 ***************************************************************************************/
 
 #include "device.h"
+#include "flash.h"
+#include "sdcard.h"
+#include "uart.h"
+#include "vga.h"
 #ifdef SHOW_SCREEN
 #include <SDL2/SDL.h>
 #endif
 
 void send_key(uint8_t, bool);
-void init_sdl(void);
-
-void init_uart(void);
-void finish_uart(void);
-extern "C" void init_sd(void);
-extern "C" void finish_sd(void);
-extern "C" void init_flash(void);
 
 void init_device(void) {
 #ifdef SHOW_SCREEN

--- a/src/test/csrc/common/flash.cpp
+++ b/src/test/csrc/common/flash.cpp
@@ -34,7 +34,7 @@ long get_flash_size() {
   return flash_bin_size;
 }
 
-extern "C" void flash_read(uint32_t addr, uint64_t *data) {
+void flash_read(uint32_t addr, uint64_t *data) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_flash_read]++;
   difftest_bytes[perf_flash_read] += 12;

--- a/src/test/csrc/common/flash.h
+++ b/src/test/csrc/common/flash.h
@@ -25,4 +25,5 @@ long get_flash_size();
 void init_flash(const char *flash_bin);
 void flash_finish();
 
+extern "C" void flash_read(uint32_t addr, uint64_t *data);
 #endif // __FLASH_H

--- a/src/test/csrc/common/golden.cpp
+++ b/src/test/csrc/common/golden.cpp
@@ -23,7 +23,7 @@
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
 
-extern "C" uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level) {
+uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_pte_helper]++;
   difftest_bytes[perf_pte_helper] += 25;
@@ -68,7 +68,7 @@ enum {
 #define GET_LOWER32(data) ((data) & ((1UL << 32) - 1))
 #define GET_UPPER32(data) ((data) >> 32)
 
-extern "C" uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
+uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_amo_helper]++;
   difftest_bytes[perf_amo_helper] += 18;

--- a/src/test/csrc/common/golden.h
+++ b/src/test/csrc/common/golden.h
@@ -24,6 +24,7 @@
 
 // REF Models
 extern "C" uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level);
+extern "C" uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask);
 
 typedef union PageTableEntry {
   struct {

--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -303,7 +303,7 @@ MmapMemory::~MmapMemory() {
 #endif
 }
 
-extern "C" uint64_t difftest_ram_read(uint64_t rIdx) {
+uint64_t difftest_ram_read(uint64_t rIdx) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_difftest_ram_read]++;
   difftest_bytes[perf_difftest_ram_read] += 8;
@@ -321,7 +321,7 @@ extern "C" uint64_t difftest_ram_read(uint64_t rIdx) {
   return rdata;
 }
 
-extern "C" void difftest_ram_write(uint64_t wIdx, uint64_t wdata, uint64_t wmask) {
+void difftest_ram_write(uint64_t wIdx, uint64_t wdata, uint64_t wmask) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_difftest_ram_write]++;
   difftest_bytes[perf_difftest_ram_write] += 24;

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -32,6 +32,8 @@
 
 uint64_t pmem_read(uint64_t raddr);
 void pmem_write(uint64_t waddr, uint64_t wdata);
+extern "C" uint64_t difftest_ram_read(uint64_t rIdx);
+extern "C" void difftest_ram_write(uint64_t wIdx, uint64_t wdata, uint64_t wmask);
 
 class InputReader {
 public:

--- a/src/test/csrc/common/sdcard.cpp
+++ b/src/test/csrc/common/sdcard.cpp
@@ -22,8 +22,6 @@
 
 FILE *fp = NULL;
 
-extern "C" {
-
 void check_sdcard() {
   if (!fp) {
     eprintf(ANSI_COLOR_MAGENTA "[warning] sdcard img not found\n");
@@ -67,5 +65,4 @@ void finish_sd(void) {
 #ifdef SDCARD_IMAGE
   fclose(fp);
 #endif
-}
 }

--- a/src/test/csrc/common/uart.cpp
+++ b/src/test/csrc/common/uart.cpp
@@ -14,6 +14,7 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+#include "uart.h"
 #include "common.h"
 #include "stdlib.h"
 
@@ -63,7 +64,7 @@ uint8_t uart_getc() {
   return ch;
 }
 
-extern "C" void uart_getc_legacy(uint8_t *ch) {
+void uart_getc_legacy(uint8_t *ch) {
   static uint32_t lasttime = 0;
   uint32_t now = uptime();
 

--- a/src/test/csrc/common/uart.h
+++ b/src/test/csrc/common/uart.h
@@ -1,6 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2020-2023 Institute of Computing Technology, Chinese Academy of Sciences
-* Copyright (c) 2020-2021 Peng Cheng Laboratory
+* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
 *
 * DiffTest is licensed under Mulan PSL v2.
 * You can use this software according to the terms and conditions of the Mulan PSL v2.
@@ -14,14 +14,12 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-#ifndef __SDCARD_H
-#define __SDCARD_H
+#ifndef __UART_H
+#define __UART_H
 
 #include "common.h"
 
-extern FILE *fp;
-extern "C" void sd_setaddr(uint32_t addr);
-extern "C" void sd_read(uint32_t *data);
-void init_sd(void);
-void finish_sd(void);
-#endif // __SDCARD_H
+extern "C" void uart_getc_legacy(uint8_t *ch);
+void init_uart(void);
+void finish_uart(void);
+#endif // __UART_H

--- a/src/test/csrc/common/vga.cpp
+++ b/src/test/csrc/common/vga.cpp
@@ -14,8 +14,8 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
+#include "vga.h"
 #include "common.h"
-
 #ifdef CONFIG_DIFFTEST_PERFCNT
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
@@ -33,7 +33,7 @@ static SDL_Window *window;
 static SDL_Renderer *renderer;
 static SDL_Texture *texture;
 
-extern "C" void put_pixel(uint32_t pixel) {
+void put_pixel(uint32_t pixel) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_put_pixel]++;
   difftest_bytes[perf_put_pixel] += 4;
@@ -44,7 +44,7 @@ extern "C" void put_pixel(uint32_t pixel) {
     i = 0;
 }
 
-extern "C" void vmem_sync(void) {
+void vmem_sync(void) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_vmem_sync]++;
 #endif // CONFIG_DIFFTEST_PERFCNT
@@ -65,6 +65,6 @@ void finish_sdl() {
   memset(vmem, 0, sizeof(vmem));
 }
 #else
-extern "C" void put_pixel(uint32_t pixel) {}
-extern "C" void vmem_sync(void) {}
+void put_pixel(uint32_t pixel) {}
+void vmem_sync(void) {}
 #endif

--- a/src/test/csrc/common/vga.h
+++ b/src/test/csrc/common/vga.h
@@ -1,6 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2020-2023 Institute of Computing Technology, Chinese Academy of Sciences
-* Copyright (c) 2020-2021 Peng Cheng Laboratory
+* Copyright (c) 2024 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2024 Institute of Computing Technology, Chinese Academy of Sciences
 *
 * DiffTest is licensed under Mulan PSL v2.
 * You can use this software according to the terms and conditions of the Mulan PSL v2.
@@ -14,14 +14,13 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-#ifndef __SDCARD_H
-#define __SDCARD_H
+#ifndef __VGA_H
+#define __VGA_H
 
 #include "common.h"
 
-extern FILE *fp;
-extern "C" void sd_setaddr(uint32_t addr);
-extern "C" void sd_read(uint32_t *data);
-void init_sd(void);
-void finish_sd(void);
-#endif // __SDCARD_H
+extern "C" void put_pixel(uint32_t pixel);
+extern "C" void vmem_sync(void);
+void init_sdl();
+void finish_sdl();
+#endif // __VGA_H


### PR DESCRIPTION
Previous we declare and implement extern func in cpp file directly, and call by import DPIC in verilog or another extern declaration in other cpp files.

However, when supporting gsim, too many extern declaration and calls in different files make it hard to link and locate, causing undefined reference error.

This change move declaration of extern func to header, add we will include header while generating extern-module func.