### PR TITLE
fix(dbltrp): critical-error is not treated as diff error

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ coherence via RefillTest.
 | `DiffLrScEvent` | Executed LR/SC instructions | No |
 | `DiffNonRegInterruptPengingEvent` | Non-register interrupts pending | No |
 | `DiffMhpmeventOverflowEvent` | Mhpmevent-register overflow | No |
-| `DiffDiffCriticalErrorEvent` | Raise critical-error | No |
+| `DiffCriticalErrorEvent` | Raise critical-error | No |
 
 The DiffTest framework comes with a simulation framework with some top-level IOs.
 They will be automatically created when calling `DifftestModule.finish(cpu: String)`.

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1302,9 +1302,15 @@ void Difftest::do_mhpmevent_overflow() {
 #ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
 void Difftest::do_raise_critical_error() {
   if (dut->critical_error.valid) {
-    display();
-    Info("Core %d dump: critical_error raise \n", this->id);
-    raise_trap(STATE_ABORT);
+    bool ref_critical_error = proxy->raise_critical_error();
+    if (ref_critical_error == dut->critical_error.criticalError) {
+      Info("Core %d dump: critical_error raise \n", this->id);
+      raise_trap(STATE_GOODTRAP);
+    } else {
+      display();
+      Info("Core %d dump: DUT critical_error diff REF \n", this->id);
+      raise_trap(STATE_ABORT);
+    }
   }
 }
 #endif

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -146,9 +146,10 @@ public:
   f(ref_memcpy_init, difftest_memcpy_init, void, uint64_t, void*, size_t, bool)                             \
   f(raise_nmi_intr, difftest_raise_nmi_intr, void, bool)                                                    \
   f(ref_virtual_interrupt_is_hvictl_inject, difftest_virtual_interrupt_is_hvictl_inject, void, bool)        \
-  f(disambiguation_state, difftest_disambiguation_state, int, )               \
-  f(ref_non_reg_interrupt_pending, difftest_non_reg_interrupt_pending, void, void*) \
-  f(raise_mhpmevent_overflow, difftest_raise_mhpmevent_overflow, void, uint64_t)
+  f(disambiguation_state, difftest_disambiguation_state, int, )                                             \
+  f(ref_non_reg_interrupt_pending, difftest_non_reg_interrupt_pending, void, void*)                         \
+  f(raise_mhpmevent_overflow, difftest_raise_mhpmevent_overflow, void, uint64_t)                            \
+  f(ref_raise_critical_error, difftest_raise_critical_error, bool)
 
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
@@ -256,6 +257,10 @@ public:
     if (raise_mhpmevent_overflow) {
       raise_mhpmevent_overflow(mhpmeventOverflow);
     }
+  }
+
+  inline bool raise_critical_error() {
+    return ref_raise_critical_error ? ref_raise_critical_error() : false;
   }
 
   inline void guided_exec(struct ExecutionGuide &guide) {


### PR DESCRIPTION
* When both RTL and NEMU report a critical-error, the hardware behavior is considered correct. Upon detecting a critical-error, it should indicate a "good trap."
* If they do not report simultaneously, it results in a diff error and triggers an abort.