### PR TITLE
feat: add design version info at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ RTL_DIR = $(BUILD_DIR)/rtl
 RTL_SUFFIX ?= sv
 SIM_TOP_V = $(RTL_DIR)/$(SIM_TOP).$(RTL_SUFFIX)
 
+# get design version info
+VERSION_COMMIT_ID := $(shell git -C $(DESIGN_DIR) rev-parse --short HEAD)
+VERSION_IS_DIRTY := $(shell git -C $(DESIGN_DIR) diff --quiet HEAD || echo "-dirty")
+
 # generate difftest files for non-chisel design.
 .DEFAULT_GOAL := difftest_verilog
 ifeq ($(MFC), 1)
@@ -226,6 +230,12 @@ endif
 ifeq ($(CXX_NO_WARNING),1)
 SIM_CXXFLAGS += -Werror
 endif
+
+# Generate Version Info File (Always)
+VERSION_HEADER = $(GEN_CSRC_DIR)/version.h
+.PHONY: $(VERSION_HEADER)
+$(VERSION_HEADER):
+	@echo "#define STR_COMMIT_ID \"$(VERSION_COMMIT_ID)\"\n#define STR_IS_DIRTY \"$(VERSION_IS_DIRTY)\"" > $@
 
 include verilator.mk
 include vcs.mk

--- a/src/test/csrc/common/common.cpp
+++ b/src/test/csrc/common/common.cpp
@@ -15,6 +15,7 @@
 ***************************************************************************************/
 
 #include "common.h"
+#include "version.h"
 #include <locale.h>
 #include <signal.h>
 
@@ -69,6 +70,8 @@ void common_init_without_assertion(const char *program_name) {
   const char *elf_name = strrchr(program_name, '/');
   elf_name = elf_name ? elf_name + 1 : program_name;
   Info("%s compiled at %s, %s\n", elf_name, __DATE__, __TIME__);
+
+  Info("Source Code Version: %s%s\n", STR_COMMIT_ID, STR_IS_DIRTY);
 
   // set buffer for stderr
   setbuf(stderr, mybuf);

--- a/vcs.mk
+++ b/vcs.mk
@@ -108,7 +108,7 @@ VCS_FLAGS += $(EXTRA)
 
 VCS_VSRC_DIR = $(abspath ./src/test/vsrc/vcs)
 VCS_VFILES   = $(SIM_VSRC) $(shell find $(VCS_VSRC_DIR) -name "*.v")
-$(VCS_TARGET): $(SIM_TOP_V) $(VCS_CXXFILES) $(VCS_VFILES)
+$(VCS_TARGET): $(SIM_TOP_V) $(VCS_CXXFILES) $(VCS_VFILES) $(VERSION_HEADER)
 	$(VCS) $(VCS_FLAGS) $(SIM_TOP_V) $(VCS_CXXFILES) $(VCS_VFILES)
 ifeq ($(VCS),verilator)
 	$(MAKE) -s -C $(VCS_BUILD_DIR) -f V$(VCS_TOP).mk

--- a/verilator.mk
+++ b/verilator.mk
@@ -164,7 +164,7 @@ else
 					   PGO_LDFLAGS="'"$(PGO_LDFLAGS)"'"'
 endif
 
-$(EMU): $(EMU_MK) $(EMU_DEPS) $(EMU_HEADERS)
+$(EMU): $(EMU_MK) $(EMU_DEPS) $(EMU_HEADERS) $(VERSION_HEADER)
 	@echo -e "\n[c++] Compiling C++ files..." >> $(TIMELOG)
 	@date -R | tee -a $(TIMELOG)
 ifdef PGO_WORKLOAD


### PR DESCRIPTION
Recently, we have added version info of the design code (the commit id) in the XiangShan RTL code. This patch adds the version info in the emu/simv program. Now the emu/simv program will print the commit id of design when initializing.

This patch also resolves the issue where the emu build time would not update when re-compiling. Now, with each build, `version.h` is re-generated, causing `common.cpp`, the source code file which contains printing logic, to be recompiled, which subsequently triggers a relink of `emu`. This process takes a few seconds, which is longer than before, but still acceptable.

![image](https://github.com/user-attachments/assets/a4f3ac75-18ad-4a34-8ec0-b3ba6cd3b872)
