### PR TITLE
fix(aia): add support for aia xtopei csr

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ coherence via RefillTest.
 | `DiffNonRegInterruptPengingEvent` | Non-register interrupts pending | No |
 | `DiffMhpmeventOverflowEvent` | Mhpmevent-register overflow | No |
 | `DiffCriticalErrorEvent` | Raise critical-error | No |
+| `DiffAIAXtopeiEvent` | xtopei from IMSIC | No |
 
 The DiffTest framework comes with a simulation framework with some top-level IOs.
 They will be automatically created when calling `DifftestModule.finish(cpu: String)`.

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -330,3 +330,9 @@ class TraceInfo extends DifftestBaseBundle with HasValid {
 class CriticalErrorEvent extends DifftestBaseBundle with HasValid {
   val criticalError = Bool()
 }
+
+class AIAXtopeiEvent extends DifftestBaseBundle with HasValid {
+  val mtopei = UInt(64.W)
+  val stopei = UInt(64.W)
+  val vstopei = UInt(64.W)
+}

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -425,6 +425,10 @@ class DiffCriticalErrorEvent extends CriticalErrorEvent with DifftestBundle {
   override val desiredCppName: String = "critical_error"
 }
 
+class DiffAIAXtopeiEvent extends AIAXtopeiEvent with DifftestBundle {
+  override val desiredCppName: String = "aia_xtopei"
+}
+
 class DiffTraceInfo(config: GatewayConfig) extends TraceInfo with DifftestBundle {
   override val desiredCppName: String = "trace_info"
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -332,6 +332,9 @@ int Difftest::step() {
 #ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
   do_raise_critical_error();
 #endif
+#ifdef CONFIG_DIFFTEST_AIAXTOPEIEVENT
+  do_aia_xtopei();
+#endif
 
   num_commit = 0; // reset num_commit this cycle to 0
   if (dut->event.valid) {
@@ -1318,6 +1321,19 @@ void Difftest::do_raise_critical_error() {
       Info("Core %d dump: DUT critical_error diff REF \n", this->id);
       raise_trap(STATE_ABORT);
     }
+  }
+}
+#endif
+
+#ifdef CONFIG_DIFFTEST_AIAXTOPEIEVENT
+void Difftest::do_aia_xtopei() {
+  if (dut->aia_xtopei.valid) {
+    struct AIAXtopei xtopei;
+    xtopei.mtopei = dut->aia_xtopei.mtopei;
+    xtopei.stopei = dut->aia_xtopei.stopei;
+    xtopei.vstopei = dut->aia_xtopei.vstopei;
+    proxy->aia_xtopei(xtopei);
+    dut->aia_xtopei.valid = 0;
   }
 }
 #endif

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -430,6 +430,9 @@ protected:
 #ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
   void do_raise_critical_error();
 #endif
+#ifdef CONFIG_DIFFTEST_AIAXTOPEIEVENT
+  void do_aia_xtopei();
+#endif
 #ifdef CONFIG_DIFFTEST_REPLAY
   struct {
     bool in_replay = false;

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -150,7 +150,8 @@ public:
   f(ref_non_reg_interrupt_pending, difftest_non_reg_interrupt_pending, void, void*)                         \
   f(raise_mhpmevent_overflow, difftest_raise_mhpmevent_overflow, void, uint64_t)                            \
   f(ref_raise_critical_error, difftest_raise_critical_error, bool)                                          \
-  f(ref_get_store_event_other_info, difftest_get_store_event_other_info, void, void*)     
+  f(ref_get_store_event_other_info, difftest_get_store_event_other_info, void, void*)                       \
+  f(ref_aia_xtopei, difftest_aia_xtopei, void, void*)
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
 /* clang-format on */
@@ -261,6 +262,14 @@ public:
 
   inline bool raise_critical_error() {
     return ref_raise_critical_error ? ref_raise_critical_error() : false;
+  }
+
+  inline void aia_xtopei(struct AIAXtopei &xtopei) {
+    if (ref_aia_xtopei) {
+      ref_aia_xtopei(&xtopei);
+    } else {
+      printf("Does not support the out-of-core part of AIA.\n");
+    }
   }
 
   inline void guided_exec(struct ExecutionGuide &guide) {
@@ -389,6 +398,12 @@ struct NonRegInterruptPending {
   bool platformIRPVseip;
   bool platformIRPVstip;
   bool localCounterOverflowInterruptReq;
+};
+
+struct AIAXtopei {
+  uint64_t mtopei;
+  uint64_t stopei;
+  uint64_t vstopei;
 };
 
 extern const char *difftest_ref_so;

--- a/src/test/scala/DifftestTop.scala
+++ b/src/test/scala/DifftestTop.scala
@@ -57,6 +57,7 @@ class DifftestTop extends Module {
   val difftest_non_reg_interrupt_pending_event = DifftestModule(new DiffNonRegInterruptPendingEvent, dontCare = true)
   val difftest_mhpmevent_overflow_event = DifftestModule(new DiffMhpmeventOverflowEvent, dontCare = true)
   val difftest_critical_error_event = DifftestModule(new DiffCriticalErrorEvent, dontCare = true)
+  val difftest_aia_xtopei_event = DifftestModule(new DiffAIAXtopeiEvent, dontCare = true)
 
   DifftestModule.finish("demo")
 }


### PR DESCRIPTION
In order for NEMU to use the value of the `xtopi` register for interrupt handling, we need to update the `xtopi` register in NEMU. Since NEMU does not support the out-of-core part of AIA, we need to use the value of `xtopei` when updating `xtopi`, so we pass `xtopei` through the difftest framework.