### PR TITLE
Replay: clear buffered queue, ensure least error report

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -341,6 +341,7 @@ protected:
     last_commit = get_trap_event()->cycleCnt;
   }
   int check_timeout();
+  int check_all();
   void do_first_instr_commit();
   void do_interrupt();
   void do_exception();


### PR DESCRIPTION
When squashQueue enabled, load/store event may be submitted ahead and buffered in queue before squashed instrs commit along with replay info. So when we recover snapshot and start replaying, we need clear queue, submit and process load/store again.

This change also ensure least report of squashed error before replay, and check if DUT run out of replay range. Also, seperate original step() logic to private do_step(), keep same call interface