### PR TITLE
feat(difftest): add support for Zacas extension

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -243,7 +243,7 @@ class AtomicEvent extends DifftestBaseBundle with HasValid {
   val mask = UInt(16.W)
   val cmp = Vec(2, UInt(64.W))
   val fuop = UInt(8.W)
-  val out = UInt(64.W)
+  val out = Vec(2, UInt(64.W))
 }
 
 class CMOInvalEvent extends DifftestBaseBundle with HasValid {

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -239,8 +239,9 @@ class LoadEvent extends DifftestBaseBundle with HasValid {
 
 class AtomicEvent extends DifftestBaseBundle with HasValid {
   val addr = UInt(64.W)
-  val data = UInt(64.W)
-  val mask = UInt(8.W)
+  val data = Vec(2, UInt(64.W))
+  val mask = UInt(16.W)
+  val cmp = Vec(2, UInt(64.W))
   val fuop = UInt(8.W)
   val out = UInt(64.W)
 }

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -984,17 +984,18 @@ int Difftest::do_l2tlb_check() {
   return 0;
 }
 
-inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData, uint64_t atomicMask, uint8_t atomicFuop,
-                         uint64_t atomicOut) {
+inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData[], uint64_t atomicMask,
+                         uint64_t atomicCmp[], uint8_t atomicFuop, uint64_t atomicOut[]) {
   // We need to do atmoic operations here so as to update goldenMem
-  if (!(atomicMask == 0xf || atomicMask == 0xf0 || atomicMask == 0xff)) {
+  if (!(atomicMask == 0xf || atomicMask == 0xf0 || atomicMask == 0xff || atomicMask == 0xffff)) {
     printf("Unrecognized mask: %lx\n", atomicMask);
     return 1;
   }
 
   if (atomicMask == 0xff) {
-    uint64_t rs = atomicData; // rs2
-    uint64_t t = atomicOut;   // original value
+    uint64_t rs = atomicData[0]; // rs2
+    uint64_t t = atomicOut[0];   // original value
+    uint64_t cmp = atomicCmp[0]; // rd, data to be compared
     uint64_t ret;
     uint64_t mem;
     read_goldenmem(atomicAddr, &mem, 8);
@@ -1031,14 +1032,18 @@ inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData, u
       case 047: ret = (t < rs) ? t : rs; break;
       case 052:
       case 053: ret = (t > rs) ? t : rs; break;
+      case 074:
+      case 076:
+      case 077: ret = (t == cmp) ? rs : t; break;
       default: printf("Unknown atomic fuOpType: 0x%x\n", atomicFuop);
     }
     update_goldenmem(atomicAddr, &ret, atomicMask, 8);
   }
 
   if (atomicMask == 0xf || atomicMask == 0xf0) {
-    uint32_t rs = (uint32_t)atomicData; // rs2
-    uint32_t t = (uint32_t)atomicOut;   // original value
+    uint32_t rs = (uint32_t)atomicData[0]; // rs2
+    uint32_t t = (uint32_t)atomicOut[0];   // original value
+    uint32_t cmp = (uint32_t)atomicCmp[0]; // rd, data to be compared
     uint32_t ret;
     uint32_t mem;
     uint64_t mem_raw;
@@ -1084,12 +1089,38 @@ inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData, u
       case 047: ret = (t < rs) ? t : rs; break;
       case 052:
       case 053: ret = (t > rs) ? t : rs; break;
+      case 074:
+      case 076:
+      case 077: ret = (t == cmp) ? rs : t; break;
       default: printf("Unknown atomic fuOpType: 0x%x\n", atomicFuop);
     }
     ret_sel = ret;
     if (atomicMask == 0xf0)
       ret_sel = (ret_sel << 32);
     update_goldenmem(atomicAddr, &ret_sel, atomicMask, 8);
+  }
+
+  if (atomicMask == 0xffff) {
+    uint64_t meml, memh;
+    uint64_t retl, reth;
+    read_goldenmem(atomicAddr, &meml, 8);
+    read_goldenmem(atomicAddr+8, &memh, 8);
+    if (meml != atomicOut[0] || memh != atomicOut[1]) {
+      printf("Core %d atomic instr mismatch goldenMem, mem: 0x%lx 0x%lx, t: 0x%lx 0x%lx, op: 0x%x, addr: 0x%lx\n",
+             coreid, memh, meml, atomicOut[1], atomicOut[0], atomicFuop, atomicAddr);
+      return 1;
+    }
+    switch (atomicFuop) {
+      case 074: {
+        bool success = atomicOut[0] == atomicCmp[0] && atomicOut[1] == atomicCmp[1];
+        retl = success ? atomicData[0] : atomicOut[0];
+        reth = success ? atomicData[1] : atomicOut[1];
+        break;
+      }
+      default: printf("Unknown atomic fuOpType: 0x%x\n", atomicFuop);
+    }
+    update_goldenmem(atomicAddr, &retl, 0xff, 8);
+    update_goldenmem(atomicAddr+8, &reth, 0xff, 8);
   }
   return 0;
 }
@@ -1135,7 +1166,8 @@ int Difftest::do_golden_memory_update() {
   if (dut->atomic.valid) {
     dut->atomic.valid = 0;
     int ret =
-        handle_atomic(id, dut->atomic.addr, dut->atomic.data, dut->atomic.mask, dut->atomic.fuop, dut->atomic.out);
+        handle_atomic(id, dut->atomic.addr, (uint64_t*)dut->atomic.data, dut->atomic.mask, (uint64_t*)dut->atomic.cmp, dut->atomic.fuop,
+          (uint64_t*)dut->atomic.out);
     if (dut->atomic.addr == track_instr) {
       dumpGoldenMem("Atmoic", track_instr, cycleCnt);
     }


### PR DESCRIPTION
This pull request adds support for Zacas (atomic compare-and-swap instructions) extension and allows for golden memory update of AMOCAS instructions.