### PR TITLE
fix(skip_one): fix floating-point `skip_one` logic

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -527,13 +527,12 @@ int Difftest::do_instr_commit(int i) {
   }
 #endif
 
-  bool realWen = (dut->commit[i].rfwen && dut->commit[i].wdest != 0) || (dut->commit[i].fpwen);
-
   // MMIO accessing should not be a branch or jump, just +2/+4 to get the next pc
   // to skip the checking of an instruction, just copy the reg state to reference design
   if (dut->commit[i].skip || (DEBUG_MODE_SKIP(dut->commit[i].valid, dut->commit[i].pc, dut->commit[i].inst))) {
     // We use the physical register file to get wdata
-    proxy->skip_one(dut->commit[i].isRVC, realWen, dut->commit[i].wdest, get_commit_data(i));
+    proxy->skip_one(dut->commit[i].isRVC, (dut->commit[i].rfwen && dut->commit[i].wdest != 0), dut->commit[i].fpwen,
+                    dut->commit[i].vecwen, dut->commit[i].wdest, get_commit_data(i));
     return 0;
   }
 

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -217,16 +217,26 @@ public:
   int compare(DiffTestState *dut);
   void display(DiffTestState *dut = nullptr);
 
-  inline void skip_one(bool isRVC, bool wen, uint32_t wdest, uint64_t wdata) {
+  inline void skip_one(bool isRVC, bool rfwen, bool fpwen, bool vecwen, uint32_t wdest, uint64_t wdata) {
+    bool wen = rfwen | fpwen;
     if (ref_skip_one) {
       ref_skip_one(isRVC, wen, wdest, wdata);
     } else {
       sync();
       pc += isRVC ? 2 : 4;
-      // TODO: what if skip with fpwen?
-      if (wen) {
+
+      if (rfwen)
         regs_int.value[wdest] = wdata;
-      }
+#ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
+      if (fpwen)
+        regs_fp.value[wdest] = wdata;
+#endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
+#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
+      // TODO: vec skip is not supported at this time.
+      if (vecwen)
+        assert(0);
+#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
+
       sync(true);
     }
   }


### PR DESCRIPTION
Currently, `skip_one` only handles scalar cases. When a floating-point skip_one occurs, the value of the floating-point register is incorrectly synchronized to the scalar register. We have fixed this.
After the modification, we can correctly handle scalar and floating-point skips. However, vector skips will not be allowed, so an assert will be raised when a vector triggers a skip.
Currently, our framework cannot correctly synchronise the data in the vector register. After subsequent discussions, we will add support for this, and this commit will first fix the bug where the floating-point register cannot be correctly synchronised.

---

For reference, the XiangShan processor should never under normal circumstances generate a skip vector, so it is acceptable to add an assert in this place, but we can still choose to add support for vector skip in the future.
The main reason for not adding support for vector skip for the time being is that the width of the vector register needs to be greater than 64, and in some implementations, the vector register may be split into multiple register stacks. For example, in the XiangShan processor, the V0 register is split into a separate register stack.
In summary, we may add support for vector skip in the future, but for now, the priority is to fix the floating-point synchronization bug.
