### PR TITLE
emu: increase default LightSSS interval to 10 seconds

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -84,7 +84,7 @@ static inline void print_help(const char *file) {
 #ifdef ENABLE_IPC
   printf("  -R, --ipc-interval=NUM     the interval insts of drawing IPC curve\n");
 #endif
-  printf("  -X, --fork-interval=NUM    LightSSS snapshot interval (in seconds)\n");
+  printf("  -X, --fork-interval=NUM    LightSSS snapshot interval (in seconds), default: 10\n");
   printf("      --overwrite-nbytes=N   set valid bytes, but less than 0xf00, default: 0xe00\n");
   printf("      --overwrite-auto       overwrite size is automatically set of the new gcpt\n");
   printf("      --force-dump-result    force dump performance counter result in the end\n");

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -40,7 +40,7 @@ struct EmuArgs {
   uint32_t reset_cycles = 50;
   uint32_t seed = 0;
   uint64_t max_cycles = -1;
-  uint64_t fork_interval = 1000;
+  uint64_t fork_interval = 10000; // default: 10 seconds
   uint64_t max_instr = -1;
   uint64_t warmup_instr = -1;
   uint64_t stat_cycles = -1;


### PR DESCRIPTION
- For large designs, we need large intervals as the simulation speed slows down
- Small intervals may bring notable overheads for large footprint workloads