### PR TITLE
feat(ref): add the optional load_flash_bin_v2 API

### DIFF
--- a/src/test/csrc/common/flash.cpp
+++ b/src/test/csrc/common/flash.cpp
@@ -27,7 +27,7 @@ static char *flash_path = NULL;
 
 unsigned long EMU_FLASH_SIZE = DEFAULT_EMU_FLASH_SIZE;
 
-char *get_flash_path() {
+const char *get_flash_path() {
   return flash_path;
 }
 long get_flash_size() {

--- a/src/test/csrc/common/flash.h
+++ b/src/test/csrc/common/flash.h
@@ -19,7 +19,7 @@
 
 #include "common.h"
 
-char *get_flash_path();
+const char *get_flash_path();
 long get_flash_size();
 
 void init_flash(const char *flash_bin);

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -593,7 +593,7 @@ void Difftest::do_first_instr_commit() {
     has_commit = 1;
     nemu_this_pc = FIRST_INST_ADDRESS;
 
-    proxy->load_flash_bin(get_flash_path(), get_flash_size());
+    proxy->flash_init(get_flash_path(), get_flash_size());
     simMemory->clone_on_demand(
         [this](uint64_t offset, void *src, size_t n) {
           uint64_t dest_addr = PMEM_BASE + offset;

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -104,8 +104,7 @@ public:
   f(update_config, update_dynamic_config, void, void*)                        \
   f(uarchstatus_sync, difftest_uarchstatus_sync, void, void*)                 \
   f(store_commit, difftest_store_commit, int, uint64_t*, uint64_t*, uint8_t*) \
-  f(raise_intr, difftest_raise_intr, void, uint64_t)                          \
-  f(load_flash_bin, difftest_load_flash, void, void*, size_t)
+  f(raise_intr, difftest_raise_intr, void, uint64_t)
 
 #ifdef ENABLE_RUNHEAD
 #define REF_RUN_AHEAD(f)                                                      \
@@ -136,6 +135,8 @@ public:
   REF_DEBUG_MODE(f)
 
 #define REF_OPTIONAL(f)                                                                                     \
+  f(load_flash_bin, difftest_load_flash, void, const char*, size_t)                                         \
+  f(load_flash_bin_v2, difftest_load_flash_v2, void, uint8_t*, size_t)                                      \
   f(ref_status, difftest_status, int, )                                                                     \
   f(ref_close, difftest_close, void, )                                                                      \
   f(ref_set_ramsize, difftest_set_ramsize, void, size_t)                                                    \
@@ -307,6 +308,8 @@ public:
       ref_memcpy(dest, src, n, direction);
     }
   }
+
+  void flash_init(const char *flash_bin, size_t size);
 
   inline void get_store_event_other_info(void *info) {
     if (ref_get_store_event_other_info) {


### PR DESCRIPTION
This new API accepts the first argument as a pointer to the flash image in memory instead of a string pointer to the flash filename.