### PR TITLE
feat(ref): prefer using load_flash_bin_v2

### DIFF
--- a/src/test/csrc/common/flash.h
+++ b/src/test/csrc/common/flash.h
@@ -19,8 +19,14 @@
 
 #include "common.h"
 
-const char *get_flash_path();
-long get_flash_size();
+typedef struct {
+  uint64_t *base;
+  uint64_t size;
+  char *img_path;
+  uint64_t img_size;
+} flash_device_t;
+
+extern flash_device_t flash_dev;
 
 void init_flash(const char *flash_bin);
 void flash_finish();

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -593,7 +593,7 @@ void Difftest::do_first_instr_commit() {
     has_commit = 1;
     nemu_this_pc = FIRST_INST_ADDRESS;
 
-    proxy->flash_init(get_flash_path(), get_flash_size());
+    proxy->flash_init((const uint8_t *)flash_dev.base, flash_dev.img_size, flash_dev.img_path);
     simMemory->clone_on_demand(
         [this](uint64_t offset, void *src, size_t n) {
           uint64_t dest_addr = PMEM_BASE + offset;

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -250,18 +250,12 @@ void RefProxy::display(DiffTestState *dut) {
   }
 };
 
-void RefProxy::flash_init(const char *flash_bin, size_t size) {
-  if (load_flash_bin) {
+void RefProxy::flash_init(const uint8_t *flash_base, size_t size, const char *flash_bin) {
+  if (load_flash_bin_v2) {
+    load_flash_bin_v2(flash_base, size);
+  } else if (load_flash_bin) {
+    // This API is deprecated because flash_bin may be an empty pointer
     load_flash_bin(flash_bin, size);
-  } else if (load_flash_bin_v2) {
-    std::ifstream file(flash_bin, std::ios::binary);
-    if (!file) {
-      std::cout << "Error loading flash file " << flash_bin << std::endl;
-      assert(0);
-    }
-    std::vector<uint8_t> flash_data(size);
-    file.read(reinterpret_cast<char *>(flash_data.data()), size);
-    load_flash_bin_v2(flash_data.data(), size);
   } else {
     std::cout << "Require load_flash_bin or load_flash_bin_v2 to initialize the flash" << std::endl;
     assert(0);

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -136,7 +136,7 @@ public:
 
 #define REF_OPTIONAL(f)                                                                                     \
   f(load_flash_bin, difftest_load_flash, void, const char*, size_t)                                         \
-  f(load_flash_bin_v2, difftest_load_flash_v2, void, uint8_t*, size_t)                                      \
+  f(load_flash_bin_v2, difftest_load_flash_v2, void, const uint8_t*, size_t)                                \
   f(ref_status, difftest_status, int, )                                                                     \
   f(ref_close, difftest_close, void, )                                                                      \
   f(ref_set_ramsize, difftest_set_ramsize, void, size_t)                                                    \
@@ -309,7 +309,7 @@ public:
     }
   }
 
-  void flash_init(const char *flash_bin, size_t size);
+  void flash_init(const uint8_t *flash_base, size_t size, const char *flash_bin);
 
   inline void get_store_event_other_info(void *info) {
     if (ref_get_store_event_other_info) {


### PR DESCRIPTION
When the flash image is not specified explicitly, load_flash_bin does not know the initial values of flash. Currently the REF loads the same initial instructions as DiffTest, which is not a good practice.