### PR TITLE
fix(flash): avoid non-trivial designated initializers

### DIFF
--- a/src/test/csrc/common/flash.cpp
+++ b/src/test/csrc/common/flash.cpp
@@ -21,7 +21,12 @@
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
 
-flash_device_t flash_dev = {.size = DEFAULT_EMU_FLASH_SIZE, .img_path = NULL};
+flash_device_t flash_dev = {
+  nullptr,                // base
+  DEFAULT_EMU_FLASH_SIZE, // size
+  nullptr,                // img_path
+  0                       // img_size
+};
 
 void flash_read(uint32_t addr, uint64_t *data) {
 #ifdef CONFIG_DIFFTEST_PERFCNT

--- a/src/test/csrc/common/flash.h
+++ b/src/test/csrc/common/flash.h
@@ -19,12 +19,12 @@
 
 #include "common.h"
 
-typedef struct {
+struct flash_device_t {
   uint64_t *base;
   uint64_t size;
   char *img_path;
   uint64_t img_size;
-} flash_device_t;
+};
 
 extern flash_device_t flash_dev;
 


### PR DESCRIPTION
This is not supported in some C++ standards.