### PR TITLE
build: fix VERILATOR_ROOT problem

### DIFF
--- a/libso.mk
+++ b/libso.mk
@@ -15,7 +15,7 @@ endif
 ifneq ($(VCS_HOME),)
 LIB_CXXFLAGS += -I$(VCS_HOME)/include
 else
-VERILATOR_ROOT = $(shell verilator -V 2>/dev/null | awk '/VERILATOR_ROOT/ {print $$3; exit}')
+VERILATOR_ROOT ?= $(shell verilator --getenv VERILATOR_ROOT)
 ifneq ($(VERILATOR_ROOT),)
 LIB_CXXFLAGS += -I$(VERILATOR_ROOT)/include/vltstd
 else


### PR DESCRIPTION
This patch makes two changes:

* Use `?=` rather than `=` to set var VERILATOR_ROOT.

  If environment has VERILATOR_ROOT env, just use it.

* Use `--getenv` to get env var VERILATOR_ROOT.

  This is much simpler and clearer. Additionally, the previous command would make mistake, if the VERILATOR_ROOT during compilation differs from the actual directory of verilator at runtime.