### PR TITLE
feat(difftest): Support override NUM_CORES at compile time

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -609,8 +609,12 @@ object DifftestModule {
 
     val numCores = instances.count(_.isUniqueIdentifier)
     if (instances.nonEmpty) {
-      difftestCpp += s"#define NUM_CORES $numCores"
-      difftestCpp += ""
+      difftestCpp +=
+        s"""
+           |#ifndef NUM_CORES
+           |#define NUM_CORES $numCores
+           |#endif
+           |""".stripMargin
     }
 
     val uniqBundles = instances.groupBy(_.desiredModuleName)


### PR DESCRIPTION
For integration with external SoC, the NUM_CORES was not known at chisel elaboration time. Add the `#ifndef NUM_CORES` to support override core numbers at the final compile stage.