### PR TITLE
fpga: move fpga ddr_load order of calls

### DIFF
--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -81,7 +81,7 @@ void set_diff_ref_so(char *s) {
 }
 
 void fpga_init() {
-  xdma_device = new FpgaXdma(work_load);
+  xdma_device = new FpgaXdma();
   init_ram(work_load, DEFAULT_EMU_RAM_SIZE);
   init_flash(NULL);
 
@@ -90,6 +90,7 @@ void fpga_init() {
   init_device();
   init_goldenmem();
   init_nemuproxy(DEFAULT_EMU_RAM_SIZE);
+  xdma_device->ddr_load_workload(work_load);
 }
 
 void fpga_nstep(uint8_t step) {

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -30,9 +30,8 @@
 #define XDMA_C2H_DEVICE "/dev/xdma0_c2h_"
 #define XDMA_H2C_DEVICE "/dev/xdma0_h2c_0"
 
-FpgaXdma::FpgaXdma(const char *workload) {
+FpgaXdma::FpgaXdma() {
   signal(SIGINT, handle_sigint);
-  ddr_load_workload(workload);
 
   for (int i = 0; i < CONFIG_DMA_CHANNELS; i++) {
     char c2h_device[64];

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -45,7 +45,7 @@ public:
 
   bool running = false;
 
-  FpgaXdma(const char *workload);
+  FpgaXdma();
   ~FpgaXdma() {
     stop_thansmit_thread();
   };


### PR DESCRIPTION
Put the operation on the payload ddr after initializing difftest so that the DUT DDR is set correctly when all initializations are completed