### PR TITLE
fix(perf): avoid redundant includes and add missing finish for FPGA

### DIFF
--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -16,7 +16,6 @@
 
 #include "device.h"
 #include "diffstate.h"
-#include "difftest-dpic.h"
 #include "difftest.h"
 #include "flash.h"
 #include "goldenmem.h"
@@ -27,6 +26,8 @@
 #include <condition_variable>
 #include <getopt.h>
 #include <mutex>
+
+void fpga_finish();
 
 enum {
   FPGA_RUN,
@@ -68,7 +69,7 @@ int main(int argc, char *argv[]) {
     }
   }
   xdma_device->running = false;
-  free(xdma_device);
+  fpga_finish();
   printf("difftest releases the fpga device and exits\n");
   return 0;
 }
@@ -90,6 +91,18 @@ void fpga_init() {
   init_device();
   init_goldenmem();
   init_nemuproxy(DEFAULT_EMU_RAM_SIZE);
+}
+
+void fpga_finish() {
+  free(xdma_device);
+  common_finish();
+
+  difftest_finish();
+  goldenmem_finish();
+  finish_device();
+
+  delete simMemory;
+  simMemory = nullptr;
 }
 
 void fpga_nstep(uint8_t step) {

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -18,7 +18,6 @@
 
 #include "common.h"
 #include "diffstate.h"
-#include "difftest-dpic.h"
 #include "mpool.h"
 #include <atomic>
 #include <queue>


### PR DESCRIPTION
Fixed multiple definition not compiling when enable DIFFTEST_PERFCNT