### PR TITLE
fix(AIA): change DiffAIAXtopeiEvent to DiffSyncAIAEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ coherence via RefillTest.
 | `DiffNonRegInterruptPengingEvent` | Non-register interrupts pending | No |
 | `DiffMhpmeventOverflowEvent` | Mhpmevent-register overflow | No |
 | `DiffCriticalErrorEvent` | Raise critical-error | No |
-| `DiffAIAXtopeiEvent` | xtopei from IMSIC | No |
+| `DiffSyncAIAEvent` | Synchronization of AIA | No |
 | `DiffSyncCustomMflushpwrEvent` | custom CSR mflushpwr | No |
 
 The DiffTest framework comes with a simulation framework with some top-level IOs.

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -332,10 +332,11 @@ class CriticalErrorEvent extends DifftestBaseBundle with HasValid {
   val criticalError = Bool()
 }
 
-class AIAXtopeiEvent extends DifftestBaseBundle with HasValid {
+class AIAEvent extends DifftestBaseBundle with HasValid {
   val mtopei = UInt(64.W)
   val stopei = UInt(64.W)
   val vstopei = UInt(64.W)
+  val hgeip = UInt(64.W)
 }
 
 class SyncCustomMflushpwrEvent extends DifftestBaseBundle with HasValid {

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -433,8 +433,8 @@ class DiffCriticalErrorEvent extends CriticalErrorEvent with DifftestBundle {
   override val desiredCppName: String = "critical_error"
 }
 
-class DiffAIAXtopeiEvent extends AIAXtopeiEvent with DifftestBundle {
-  override val desiredCppName: String = "aia_xtopei"
+class DiffSyncAIAEvent extends AIAEvent with DifftestBundle {
+  override val desiredCppName: String = "sync_aia"
 }
 
 class DiffSyncCustomMflushpwrEvent extends SyncCustomMflushpwrEvent with DifftestBundle {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -365,8 +365,8 @@ inline int Difftest::check_all() {
 #ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
   do_raise_critical_error();
 #endif
-#ifdef CONFIG_DIFFTEST_AIAXTOPEIEVENT
-  do_aia_xtopei();
+#ifdef CONFIG_DIFFTEST_SYNCAIAEVENT
+  do_sync_aia();
 #endif
 #ifdef CONFIG_DIFFTEST_SYNCCUSTOMMFLUSHPWREVENT
   do_sync_custom_mflushpwr();
@@ -1404,15 +1404,16 @@ void Difftest::do_raise_critical_error() {
 }
 #endif
 
-#ifdef CONFIG_DIFFTEST_AIAXTOPEIEVENT
-void Difftest::do_aia_xtopei() {
-  if (dut->aia_xtopei.valid) {
-    struct AIAXtopei xtopei;
-    xtopei.mtopei = dut->aia_xtopei.mtopei;
-    xtopei.stopei = dut->aia_xtopei.stopei;
-    xtopei.vstopei = dut->aia_xtopei.vstopei;
-    proxy->aia_xtopei(xtopei);
-    dut->aia_xtopei.valid = 0;
+#ifdef CONFIG_DIFFTEST_SYNCAIAEVENT
+void Difftest::do_sync_aia() {
+  if (dut->sync_aia.valid) {
+    struct FromAIA aia;
+    aia.mtopei = dut->sync_aia.mtopei;
+    aia.stopei = dut->sync_aia.stopei;
+    aia.vstopei = dut->sync_aia.vstopei;
+    aia.hgeip = dut->sync_aia.hgeip;
+    proxy->sync_aia(aia);
+    dut->sync_aia.valid = 0;
   }
 }
 #endif

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -431,8 +431,8 @@ protected:
 #ifdef CONFIG_DIFFTEST_CRITICALERROREVENT
   void do_raise_critical_error();
 #endif
-#ifdef CONFIG_DIFFTEST_AIAXTOPEIEVENT
-  void do_aia_xtopei();
+#ifdef CONFIG_DIFFTEST_SYNCAIAEVENT
+  void do_sync_aia();
 #endif
 #ifdef CONFIG_DIFFTEST_SYNCCUSTOMMFLUSHPWREVENT
   void do_sync_custom_mflushpwr();

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -152,7 +152,7 @@ public:
   f(raise_mhpmevent_overflow, difftest_raise_mhpmevent_overflow, void, uint64_t)                            \
   f(ref_raise_critical_error, difftest_raise_critical_error, bool)                                          \
   f(ref_get_store_event_other_info, difftest_get_store_event_other_info, void, void*)                       \
-  f(ref_aia_xtopei, difftest_aia_xtopei, void, void*)                                                       \
+  f(ref_sync_aia, difftest_sync_aia, void, void*)                                                           \
   f(ref_sync_custom_mflushpwr, difftest_sync_custom_mflushpwr, void, bool)
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
@@ -276,9 +276,9 @@ public:
     return ref_raise_critical_error ? ref_raise_critical_error() : false;
   }
 
-  inline void aia_xtopei(struct AIAXtopei &xtopei) {
-    if (ref_aia_xtopei) {
-      ref_aia_xtopei(&xtopei);
+  inline void sync_aia(struct FromAIA &src) {
+    if (ref_sync_aia) {
+      ref_sync_aia(&src);
     } else {
       Info("Does not support the out-of-core part of AIA.\n");
     }
@@ -422,10 +422,11 @@ struct NonRegInterruptPending {
   bool localCounterOverflowInterruptReq;
 };
 
-struct AIAXtopei {
+struct FromAIA {
   uint64_t mtopei;
   uint64_t stopei;
   uint64_t vstopei;
+  uint64_t hgeip;
 };
 
 extern const char *difftest_ref_so;

--- a/src/test/scala/DifftestTop.scala
+++ b/src/test/scala/DifftestTop.scala
@@ -57,7 +57,7 @@ class DifftestTop extends Module {
   val difftest_non_reg_interrupt_pending_event = DifftestModule(new DiffNonRegInterruptPendingEvent, dontCare = true)
   val difftest_mhpmevent_overflow_event = DifftestModule(new DiffMhpmeventOverflowEvent, dontCare = true)
   val difftest_critical_error_event = DifftestModule(new DiffCriticalErrorEvent, dontCare = true)
-  val difftest_aia_xtopei_event = DifftestModule(new DiffAIAXtopeiEvent, dontCare = true)
+  val difftest_sync_aia_event = DifftestModule(new DiffSyncAIAEvent, dontCare = true)
   val difftest_sync_custom_mflushpwr_event = DifftestModule(new DiffSyncCustomMflushpwrEvent, dontCare = true)
 
   DifftestModule.finish("demo")


### PR DESCRIPTION
Because not only the xtopei in AIA needs to be synchronized.
Also added support for hgeip synchronization.