### PR TITLE
fix(wiring): return source only when not using source annotation

### DIFF
--- a/src/main/scala/common/WiringControl.scala
+++ b/src/main/scala/common/WiringControl.scala
@@ -81,11 +81,13 @@ object DifftestWiring {
 
   def addSink[T <: Data](data: T, name: String, isHierarchical: Boolean): T = {
     val info = getWire(data, name, isHierarchical).addSink()
-    if (info.data.isVisible) {
-      data := info.data
-    } else if (isHierarchical && !isChisel3) {
+    if (isHierarchical && !isChisel3) {
       require(!info.isPending, s"[${info.name}]: Hierarchical wiring requires addSource before addSink")
-      data := WiringControl.tapAndRead(info.data)
+      if (info.data.isVisible) {
+        data := info.data
+      } else {
+        data := WiringControl.tapAndRead(info.data)
+      }
     } else {
       WiringControl.addSink(data, name)
     }


### PR DESCRIPTION
Currently we will add source annotation when hierarchical wiring is not enabled. Return source directly will leave source annotation along, causeing sink unresolved error in firtool