### PR TITLE
fix(aia): distinguish external interrupts sources from PLIC or IMSIC

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -315,6 +315,8 @@ class NonRegInterruptPendingEvent extends DifftestBaseBundle with HasValid {
   val platformIRPStip = Bool()
   val platformIRPVseip = Bool()
   val platformIRPVstip = Bool()
+  val fromAIAMeip = Bool()
+  val fromAIASeip = Bool()
   val localCounterOverflowInterruptReq = Bool()
 }
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1369,6 +1369,8 @@ void Difftest::do_non_reg_interrupt_pending() {
     ip.platformIRPStip = dut->non_reg_interrupt_pending.platformIRPStip;
     ip.platformIRPVseip = dut->non_reg_interrupt_pending.platformIRPVseip;
     ip.platformIRPVstip = dut->non_reg_interrupt_pending.platformIRPVstip;
+    ip.fromAIAMeip = dut->non_reg_interrupt_pending.fromAIAMeip;
+    ip.fromAIASeip = dut->non_reg_interrupt_pending.fromAIASeip;
     ip.localCounterOverflowInterruptReq = dut->non_reg_interrupt_pending.localCounterOverflowInterruptReq;
 
     proxy->non_reg_interrupt_pending(ip);

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -419,6 +419,8 @@ struct NonRegInterruptPending {
   bool platformIRPStip;
   bool platformIRPVseip;
   bool platformIRPVstip;
+  bool fromAIAMeip;
+  bool fromAIASeip;
   bool localCounterOverflowInterruptReq;
 };
 


### PR DESCRIPTION
* The current external interrupts come from two sources, `PLIC` and `IMSIC`.

* We need to distinguish the source of external interrupts in `NEMU`, so we need to separate the external interrupt source from `PLIC` or `IMSIC` in the `difftest` framework.