### PR TITLE
Batch: collect from different groups in one cycle to reduce gates

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -20,45 +20,49 @@ import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
 import difftest.common.DifftestPerf
-import difftest.util.Delayer
+import difftest.util.LookupTree
 
 import scala.collection.mutable.ListBuffer
 
-case class BatchParam(config: GatewayConfig, collectDataWidth: Int, collectLength: Int) {
-  def infoWidth = (new BatchInfo).getWidth
+// Only instantiated once, use val instead of def
+case class BatchParam(config: GatewayConfig, bundles: Seq[DifftestBundle]) {
+  val infoWidth = (new BatchInfo).getWidth
+  val infoByte = infoWidth / 8 // byteAligned by default
 
   // Maximum Byte length decided by transmission function
-  def MaxDataByteLen = config.batchArgByteLen._1
-  def MaxDataBitLen = MaxDataByteLen * 8
-  def MaxDataLenWidth = log2Ceil(MaxDataByteLen)
-  def MaxInfoByteLen = config.batchArgByteLen._2
-  def MaxInfoBitLen = MaxInfoByteLen * 8
-  def MaxInfoLenWidth = log2Ceil(MaxInfoByteLen)
+  val MaxDataByteLen = config.batchArgByteLen._1
+  val MaxDataBitLen = MaxDataByteLen * 8
+  val MaxInfoByteLen = config.batchArgByteLen._2
+  val MaxInfoBitLen = MaxInfoByteLen * 8
+  val MaxInfoSize = MaxInfoByteLen / infoByte
+
+  val StepGroupSize = bundles.distinctBy(_.desiredCppName).length
+  val StepDataByteLen = bundles.map(_.getByteAlignWidth).map { w => w / 8 }.sum
+  val StepDataBitLen = StepDataByteLen * 8
+  val StepInfoByteLen = StepGroupSize * (infoWidth / 8)
+  val StepInfoBitLen = StepInfoByteLen * 8
 
   // Width of statistic for data/info byte length
-  def StatsDataLenWidth = log2Ceil((collectDataWidth + 7) / 8)
-  def collectInfoWidth = collectLength * infoWidth
-  def StatsInfoLenWidth = log2Ceil((collectInfoWidth + 7) / 8)
+  val StatsDataWidth = log2Ceil(math.max(MaxDataByteLen, StepDataByteLen))
+  val StatsInfoWidth = log2Ceil(math.max(MaxInfoSize, StepGroupSize))
 
   // Truncate width when shifting to reduce useless gates
-  def TruncDataBitLen = math.min(MaxDataBitLen, collectDataWidth)
-  def TruncInfoBitLen = math.min(MaxInfoBitLen, collectInfoWidth)
-  def TruncDataLenWidth = math.min(MaxDataLenWidth, StatsDataLenWidth)
-  def TruncInfoLenWidth = math.min(MaxInfoLenWidth, StatsInfoLenWidth)
+  val TruncDataBitLen = math.min(MaxDataBitLen, StepDataBitLen)
+  val TruncInfoBitLen = math.min(MaxInfoBitLen, StepInfoBitLen)
 }
 
-class BatchIO(dataType: UInt, infoType: UInt) extends Bundle {
-  val data = dataType
-  val info = infoType
+class BatchIO(param: BatchParam) extends Bundle {
+  val data = UInt(param.MaxDataBitLen.W)
+  val info = UInt(param.MaxInfoBitLen.W)
 }
 
 class BatchStats(param: BatchParam) extends Bundle {
-  val data_len = UInt(param.StatsDataLenWidth.W)
-  val info_len = UInt(param.StatsInfoLenWidth.W)
+  val data_bytes = UInt(param.StatsDataWidth.W)
+  val info_size = UInt(param.StatsInfoWidth.W)
 }
 
-class BatchOutput(dataType: UInt, infoType: UInt, config: GatewayConfig) extends Bundle {
-  val io = new BatchIO(dataType, infoType)
+class BatchOutput(param: BatchParam, config: GatewayConfig) extends Bundle {
+  val io = new BatchIO(param)
   val enable = Bool()
   val step = UInt(config.stepWidth.W)
 }
@@ -87,247 +91,194 @@ object Batch {
 
 class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
-  def vecAlignWidth = (vec: Seq[Valid[DifftestBundle]]) => vec.head.bits.getByteAlign.getWidth * vec.length
+  val param = BatchParam(config, in.map(_.bits).toSeq)
 
-  // Collect bundles with valid of same cycle in Pipeline
-  val global_enable = VecInit(in.map(_.valid).toSeq).asUInt.orR
-  val inCollect =
-    in.groupBy(_.bits.desiredCppName).values.toSeq.map(_.toSeq).sortBy(vecAlignWidth).reverse
-  val inCollect_w = inCollect.map(vecAlignWidth)
-  val param = BatchParam(config, inCollect_w.sum, inCollect.length)
-  val dataCollect_vec = WireInit(
-    0.U.asTypeOf(
-      MixedVec(
-        Seq.tabulate(inCollect.length)(i => UInt(inCollect_w.take(i + 1).sum.W))
-      )
-    )
-  )
-  val infoCollect_vec = WireInit(
-    0.U.asTypeOf(
-      MixedVec(
-        Seq.tabulate(inCollect.length)(i => UInt(((i + 1) * param.infoWidth).W))
-      )
-    )
-  )
-  val statsCollect_vec = WireInit(0.U.asTypeOf(Vec(inCollect.length, new BatchStats(param))))
-  inCollect.zipWithIndex.foreach { case (in, idx) =>
-    val (dataBaseW, infoBaseW) = if (idx != 0) {
-      (dataCollect_vec(idx - 1).getWidth, infoCollect_vec(idx - 1).getWidth)
-    } else {
-      (0, 0)
-    }
-    val collector = Module(
-      new BatchCollector(
-        chiselTypeOf(in.head),
-        in.length,
-        dataBaseW,
-        infoBaseW,
-        param,
-        idx,
-      )
-    )
-    collector.data_in := in
-    collector.enable := global_enable
-    if (idx != 0) {
-      collector.data_base := dataCollect_vec(idx - 1)
-      collector.info_base := infoCollect_vec(idx - 1)
-      collector.stats_base := statsCollect_vec(idx - 1)
-    } else {
-      collector.data_base := 0.U
-      collector.info_base := 0.U
-      collector.stats_base := 0.U.asTypeOf(new BatchStats(param))
-    }
-    dataCollect_vec(idx) := collector.data_out
-    infoCollect_vec(idx) := collector.info_out
-    statsCollect_vec(idx) := collector.stats_out
-  }
-
-  val BatchInterval = WireInit(0.U.asTypeOf(new BatchInfo))
-  BatchInterval.id := Batch.getTemplate.length.U
-  val step_data = dataCollect_vec.last
-  val step_info = infoCollect_vec.last
-  val step_stats_vec = statsCollect_vec.zipWithIndex.map { case (stats, idx) =>
-    Delayer(stats, inCollect.length - idx - 1)
-  }
+  // Collect valid bundles of same cycle
+  val collector = Module(new BatchCollector(bundles, param))
+  collector.in := in
+  val step_data = collector.step_data
+  val step_info = collector.step_info
+  val step_enable = collector.step_enable
+  val step_status = collector.step_status
 
   // Assemble collected data from different cycles
-  val assembler = Module(new BatchAssembler(step_data.getWidth, step_info.getWidth, inCollect.length, param, config))
+  val assembler = Module(new BatchAssembler(param, config))
   assembler.step_data := step_data
   assembler.step_info := step_info
-  assembler.step_stats_vec := step_stats_vec
-
-  assembler.enable := Delayer(global_enable, inCollect.length)
+  assembler.step_status := step_status
+  assembler.step_enable := step_enable
   if (config.hasReplay) {
     val trace_info = in.map(_.bits).filter(_.desiredCppName == "trace_info").head.asInstanceOf[DiffTraceInfo]
-    assembler.step_trace_info.get := Delayer(trace_info, inCollect.length)
+    assembler.step_trace_info.get := trace_info
   }
-
-  val assembled = WireInit(assembler.out)
-  val out = IO(Output(chiselTypeOf(assembled)))
-  out := assembled
+  val out = IO(Output(new BatchOutput(param, config)))
+  out := assembler.out
 }
 
-// Collect Bundles with Valid by pipeline, same Class will be processed in parallel
-class BatchCollector(
-  bundleType: Valid[DifftestBundle],
-  length: Int,
-  dataBase_w: Int,
-  infoBase_w: Int,
-  param: BatchParam,
-  delay: Int,
-) extends Module {
-  val alignWidth = bundleType.bits.getByteAlignWidth
-  val dataOut_w = dataBase_w + alignWidth * length
-  val infoOut_w = infoBase_w + param.infoWidth
+class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+  val step_data = IO(Output(UInt(param.StepDataBitLen.W)))
+  val step_info = IO(Output(UInt(param.StepInfoBitLen.W)))
+  // status of step_data_head split in different loc
+  val step_status = IO(Output(Vec(param.StepGroupSize, new BatchStats(param))))
+  val step_enable = IO(Output(Bool()))
 
-  val data_in = IO(Input(Vec(length, bundleType)))
-  val enable = IO(Input(Bool()))
-
-  val data_base = IO(Input(UInt(dataBase_w.W)))
-  val info_base = IO(Input(UInt(infoBase_w.W)))
-  val stats_base = IO(Input(new BatchStats(param)))
-
-  val data_out = IO(Output(UInt(dataOut_w.W)))
-  val info_out = IO(Output(UInt(infoOut_w.W)))
-  val stats_out = IO(Output(new BatchStats(param)))
-
-  val data_state = RegInit(0.U(dataOut_w.W))
-  val info_state = RegInit(0.U(infoOut_w.W))
-  val stats_state = RegInit(0.U.asTypeOf(new BatchStats(param)))
-
-  val align_data = VecInit(data_in.map(i => i.bits.getByteAlign).toSeq)
-  val valid_vec = VecInit(data_in.map(i => i.valid && enable))
-  val delay_data = Delayer(align_data.asUInt, delay, useMem = true).asTypeOf(align_data)
-  val delay_valid = Delayer(valid_vec.asUInt, delay, useMem = true).asTypeOf(valid_vec)
-
-  val valid_num = PopCount(delay_valid)
-  val info = Wire(new BatchInfo)
-  info.id := Batch.getBundleID(bundleType.bits).U
-  info.num := valid_num
-
-  val offset_map = (0 to length).map(i => i.U -> (i * alignWidth).U)
-  val dataLen_map = (0 to length).map(i => i.U -> (i * alignWidth / 8).U)
-
-  val data_site = WireInit(0.U((alignWidth * length).W))
-  data_site := VecInit(delay_data.zipWithIndex.map { case (d, idx) =>
-    val offset = if (idx == 0) 0.U else MuxLookup(PopCount(delay_valid.take(idx)), 0.U)(offset_map)
-    Mux(delay_valid(idx), (d << offset).asUInt, 0.U)
-  }.toSeq).reduce(_ | _)
-
-  when(delay_valid.asUInt.orR) {
-    data_state := (data_base << MuxLookup(valid_num, 0.U)(offset_map)).asUInt | data_site
-    info_state := Cat(info_base, info.asUInt)
-    stats_state.data_len := stats_base.data_len + MuxLookup(valid_num, 0.U)(dataLen_map)
-    stats_state.info_len := stats_base.info_len + (param.infoWidth / 8).U
-  }.otherwise {
-    data_state := data_base
-    info_state := info_base
-    stats_state := stats_base
+  val sorted =
+    in.groupBy(_.bits.desiredCppName).values.toSeq.sortBy(gens => gens.length * gens.head.bits.getByteAlignWidth)
+  // Stage 1: concat bundles with same desiredCppName
+  val group_bitlen = sorted.map(_.head.bits.getByteAlignWidth)
+  val group_length = sorted.map(_.length)
+  val group_info = Wire(Vec(param.StepGroupSize, UInt(param.infoWidth.W)))
+  val group_status = Wire(Vec(param.StepGroupSize, new BatchStats(param)))
+  val group_data = Wire(MixedVec(Seq.tabulate(param.StepGroupSize) { idx =>
+    UInt((group_length(idx) * group_bitlen(idx)).W)
+  }))
+  val group_vsize = Wire(Vec(param.StepGroupSize, UInt(8.W)))
+  sorted.zipWithIndex.foreach { case (v_gens, gid) =>
+    val aligned = v_gens.map(_.bits.getByteAlign)
+    val valids = v_gens.map(_.valid)
+    val valid_sum = Seq.tabulate(valids.length) { idx =>
+      VecInit(valids.map(_.asUInt).take(idx + 1).toSeq).reduce(_ +& _)
+    }
+    val v_size = valid_sum.last
+    group_vsize(gid) := v_size
+    val info = Wire(new BatchInfo)
+    info.id := Batch.getBundleID(v_gens.head.bits).U
+    info.num := v_size
+    group_info(gid) := Mux(v_size =/= 0.U, info.asUInt, 0.U)
+    val data_bytes = {
+      val offset_map = Seq.tabulate(valids.length + 1) { vi => (vi.U, (group_bitlen(gid) / 8 * vi).U) }
+      LookupTree(v_size, offset_map)
+    }
+    val info_size = Mux(VecInit(valids.toSeq).asUInt.orR, 1.U, 0.U)
+    if (gid == 0) {
+      group_status(gid).data_bytes := data_bytes
+      group_status(gid).info_size := info_size
+    } else {
+      group_status(gid).data_bytes := group_status(gid - 1).data_bytes +& data_bytes
+      group_status(gid).info_size := group_status(gid - 1).info_size +& info_size
+    }
+    val v_aligned = aligned.zip(valids).map { case (gen, v) => Mux(v, gen, 0.U) }
+    val collect_data = Wire(Vec(group_length(gid), UInt(group_bitlen(gid).W)))
+    collect_data.zipWithIndex.foreach { case (gen, vid) =>
+      gen := VecInit((vid until group_length(gid)).map { idx =>
+        Mux(valid_sum(idx) === (vid + 1).U, v_aligned(idx), 0.U)
+      }).reduce(_ | _)
+    }
+    group_data(gid) := collect_data.asUInt
   }
 
-  data_out := data_state
-  info_out := info_state
-  stats_out := stats_state
+  // Stage 2: delay grouped data, concat different group
+  val delay_group_data = RegNext(group_data)
+  val delay_group_info = RegNext(group_info)
+  val delay_group_status = RegNext(group_status)
+  val delay_group_vsize = RegNext(group_vsize)
+  val info_num = delay_group_status.last.info_size
+  step_enable := info_num =/= 0.U
+  step_status := delay_group_status
+  val collect_data = Wire(MixedVec(Seq.tabulate(param.StepGroupSize) { idx =>
+    UInt(delay_group_data.take(idx + 1).map(_.getWidth).sum.W)
+  }))
+  val collect_info = Wire(MixedVec(Seq.tabulate(param.StepGroupSize) { idx =>
+    UInt(((idx + 1) * param.infoWidth).W)
+  }))
+  // Collect from head, collect(i) include 0~i
+  collect_data(0) := delay_group_data(0)
+  collect_info(0) := delay_group_info(0)
+  (1 until param.StepGroupSize).foreach { idx =>
+    val cat_map = Seq.tabulate(group_length(idx) + 1) { len =>
+      (len.U, Cat(collect_data(idx - 1), delay_group_data(idx)(len * group_bitlen(idx) - 1, 0)))
+    }
+    collect_data(idx) := LookupTree(delay_group_vsize(idx), cat_map)
+    collect_info(idx) := Mux(
+      delay_group_vsize(idx) =/= 0.U,
+      Cat(collect_info(idx - 1), delay_group_info(idx)),
+      collect_info(idx - 1),
+    )
+  }
+  step_data := collect_data.last
+  step_info := collect_info.last
 }
 
 class BatchAssembler(
-  step_data_w: Int,
-  step_info_w: Int,
-  collect_length: Int,
   param: BatchParam,
   config: GatewayConfig,
 ) extends Module {
-  val enable = IO(Input(Bool()))
-  val step_data = IO(Input(UInt(step_data_w.W)))
-  val step_info = IO(Input(UInt(step_info_w.W)))
-  val step_stats_vec = IO(Input(Vec(collect_length, new BatchStats(param))))
+  val step_data = IO(Input(UInt(param.StepDataBitLen.W)))
+  val step_info = IO(Input(UInt(param.StepInfoBitLen.W)))
+  val step_status = IO(Input(Vec(param.StepGroupSize, new BatchStats(param))))
+  val step_enable = IO(Input(Bool()))
   val step_trace_info = Option.when(config.hasReplay)(IO(Input(new DiffTraceInfo(config))))
+  val out = IO(Output(new BatchOutput(param, config)))
 
   val state_data = RegInit(0.U(param.MaxDataBitLen.W))
   val state_info = RegInit(0.U(param.MaxInfoBitLen.W))
-  val state_data_len = RegInit(0.U(param.MaxDataLenWidth.W))
-  val state_info_len = RegInit(0.U(param.MaxInfoLenWidth.W))
+  val state_status = RegInit(0.U.asTypeOf(new BatchStats(param)))
   val state_step_cnt = RegInit(0.U(config.stepWidth.W))
-  val state_trace_size = Option.when(config.hasReplay)(RegInit(0.U(16.W)))
-
-  // Interval update index of buffer, Finish end data parse and call difftest comparision if enabled
-  val BatchInterval = Wire(new BatchInfo)
-  BatchInterval.id := Batch.getTemplate.length.U
-  BatchInterval.num := 0.U // unused
+  val state_trace_size = Option.when(config.hasReplay)(RegInit(0.U(config.replayWidth.W)))
 
   // Assemble step data/info into state in 3 stage
   // Stage 1:
-  //   1. occupy_stats: get statistic of occupied space
-  //   2. data/info_exceed_vec: mark whether different length fragments of step data/info exceed available space
-  //   3. concat/remain_stats: record statistic for data/info to be concatenated to output or remained to state
-  // Calculate data/info space occupied when enable, assigned in the following code
-  val occupy_data_len = Wire(UInt(param.MaxDataLenWidth.W))
-  val occupy_info_len = Wire(UInt(param.MaxInfoLenWidth.W))
-  // Calculate available space for step data/info
-  val data_limit = param.MaxDataByteLen.U -& occupy_data_len
-  val info_limit = param.MaxInfoByteLen.U -& occupy_info_len
-  val data_exceed_vec = VecInit(step_stats_vec.map(_.data_len > data_limit && enable))
-  // Note: state_info contains Interval and Finish
-  val info_exceed_vec = VecInit(step_stats_vec.map(_.info_len + (2 * param.infoWidth / 8).U > info_limit && enable))
-  val exceed_vec = VecInit(data_exceed_vec.zip(info_exceed_vec).map { case (de, ie) => de | ie })
+  //   1. RegNext signal from BatchCollector to cut of combination logic path
+  //   1. data/info_exceed_vec: mark whether different length fragments of step data/info exceed available space
+  //   2. concat/remain_stats: record statistic for data/info to be concatenated to output or remained to state
+  val delay_step_data = RegNext(step_data)
+  val delay_step_info = RegNext(step_info)
+  val delay_step_status = RegNext(step_status)
+  val delay_step_enable = RegNext(step_enable)
+  val delay_step_trace_info = Option.when(config.hasReplay)(RegNext(step_trace_info.get))
+  val data_bytes_avail = param.MaxDataByteLen.U -& state_status.data_bytes
+  // Always leave space for BatchFinish and BatchInterval, use MaxInfoSize - 2
+  val info_size_avail = (param.MaxInfoSize - 2).U -& state_status.info_size
+  val data_exceed_v = VecInit(delay_step_status.map(_.data_bytes > data_bytes_avail && delay_step_enable))
+  val info_exceed_v = VecInit(delay_step_status.map(_.info_size > info_size_avail && delay_step_enable))
+  val exceed_v = VecInit(data_exceed_v.zip(info_exceed_v).map { case (de, ie) => de | ie })
   // Extract last non-exceed stats
   // When no stats exceeds, return step_stats to append whole step for state flushing
+  val concat_mask = VecInit.tabulate(param.StepGroupSize - 1) { idx => exceed_v(idx) ^ exceed_v(idx + 1) }
   val concat_stats = Mux(
-    !exceed_vec.asUInt.orR,
-    step_stats_vec.last,
-    VecInit(step_stats_vec.dropRight(1).zipWithIndex.map { case (stats, idx) =>
-      val mask = exceed_vec(idx) ^ exceed_vec(idx + 1)
+    !exceed_v.asUInt.orR,
+    delay_step_status.last,
+    VecInit(delay_step_status.dropRight(1).zip(concat_mask).map { case (stats, mask) =>
       Mux(mask, stats.asUInt, 0.U)
     }).reduceTree(_ | _).asTypeOf(new BatchStats(param)),
   )
-  val remain_stats = WireInit(0.U.asTypeOf(new BatchStats(param)))
-  remain_stats.data_len := step_stats_vec.last.data_len -& concat_stats.data_len
-  remain_stats.info_len := step_stats_vec.last.info_len -& concat_stats.info_len
-  assert(remain_stats.data_len <= param.MaxDataByteLen.U)
-  assert(remain_stats.info_len + (2 * param.infoWidth / 8).U <= param.MaxInfoByteLen.U)
+  val remain_stats = Wire(new BatchStats(param))
+  remain_stats.data_bytes := delay_step_status.last.data_bytes -& concat_stats.data_bytes
+  remain_stats.info_size := delay_step_status.last.info_size -& concat_stats.info_size
+  assert(remain_stats.data_bytes <= param.MaxDataByteLen.U)
+  assert(remain_stats.info_size + 1.U <= param.MaxInfoSize.U)
+
+  val concat_data = (delay_step_data >> (remain_stats.data_bytes << 3).asUInt).asUInt
+  val concat_info = (delay_step_info >> (remain_stats.info_size * param.infoWidth.U)).asUInt
+  // Note we need only lowest bits to update state, truncate high bits to reduce gates
+  val remain_data = (~(~0.U(param.TruncDataBitLen.W) <<
+    (remain_stats.data_bytes << 3).asUInt)).asUInt & delay_step_data
+  val remain_info = (~(~0.U(param.TruncInfoBitLen.W) <<
+    (remain_stats.info_size * param.infoWidth.U))).asUInt & delay_step_info
 
   // Stage 2:
-  //   1. delay*: RegNext signal calculated in stage 1 to shorten logic length
-  //   2. delay_concat/remain_data/info: split step into parts of concatenated and remained
-  //   3. should_tick: mark output valid
-  //   4. out: append concatenated data/info to output if any
-  val delay_concat_stats = RegNext(concat_stats)
-  val delay_remain_stats = RegNext(remain_stats)
-  val delay_step_data = RegNext(step_data)
-  val delay_step_info = RegNext(step_info)
-  val delay_step_stats = RegNext(step_stats_vec.last)
-  val delay_concat_data = delay_step_data >> (delay_remain_stats.data_len << 3)
-  val delay_concat_info = delay_step_info >> (delay_remain_stats.info_len << 3)
-  // Note we need only lowest bits to update state, truncate high bits to reduce gates
-  val delay_remain_data = (~(~0.U(param.TruncDataBitLen.W) <<
-    (delay_remain_stats.data_len(param.TruncDataLenWidth - 1, 0) << 3).asUInt)).asUInt & delay_step_data
-  val delay_remain_info = (~(~0.U(param.TruncInfoBitLen.W) <<
-    (delay_remain_stats.info_len(param.TruncInfoLenWidth - 1, 0) << 3).asUInt)).asUInt & delay_step_info
-
-  val delay_enable = RegNext(enable)
-  val delay_step_exceed = delay_enable && (state_step_cnt === config.batchSize.U)
-  val delay_cont_exceed = RegNext(exceed_vec.asUInt.orR)
-  val delay_trace_exceed = Option.when(config.hasReplay) {
-    delay_enable && (state_trace_size.get +& RegNext(
-      step_trace_info.get.trace_size
-    ) +& collect_length.U >= config.replaySize.U)
+  // update state
+  val step_exceed = delay_step_enable && (state_step_cnt === config.batchSize.U)
+  val cont_exceed = exceed_v.asUInt.orR
+  val trace_exceed = Option.when(config.hasReplay) {
+    delay_step_enable && (state_trace_size.get +& delay_step_trace_info.get.trace_size >= config.replaySize.U)
   }
-  // Flush state to provide more space for peak data
-  val state_flush = enable && step_stats_vec.last.data_len > param.MaxDataByteLen.U
+  val state_flush = step_enable && step_status.last.data_bytes >= param.MaxDataByteLen.U // use Stage 1 bytes to flush ahead
   val timeout_count = RegInit(0.U(32.W))
   val timeout = timeout_count === 200000.U
   if (config.hasBuiltInPerf) {
-    DifftestPerf("BatchExceed_data", data_exceed_vec.asUInt.orR)
-    DifftestPerf("BatchExceed_info", info_exceed_vec.asUInt.orR)
-    DifftestPerf("BatchExceed_step", delay_step_exceed.asUInt)
+    DifftestPerf("BatchExceed_data", data_exceed_v.asUInt.orR)
+    DifftestPerf("BatchExceed_info", info_exceed_v.asUInt.orR)
+    DifftestPerf("BatchExceed_step", step_exceed.asUInt)
     DifftestPerf("BatchExceed_flush", state_flush.asUInt)
     DifftestPerf("BatchExceed_timeout", timeout.asUInt)
-    if (config.hasReplay) DifftestPerf("BatchExceed_trace", delay_trace_exceed.get.asUInt)
+    if (config.hasReplay) DifftestPerf("BatchExceed_trace", trace_exceed.get.asUInt)
   }
   val in_replay = Option.when(config.hasReplay)(step_trace_info.get.in_replay)
 
-  val should_tick = timeout || state_flush || delay_cont_exceed || delay_step_exceed ||
-    delay_trace_exceed.getOrElse(false.B) || in_replay.getOrElse(false.B)
+  val should_tick = timeout || state_flush || cont_exceed || step_exceed ||
+    trace_exceed.getOrElse(false.B) || in_replay.getOrElse(false.B)
   when(!should_tick) {
     timeout_count := timeout_count + 1.U
   }.otherwise {
@@ -336,80 +287,77 @@ class BatchAssembler(
   // Delay step can be partly appended to output for making full use of transmission param
   // Avoid appending when step equals batchSize(delay_step_exceed), last appended data will overwrite first step data
   val has_append =
-    delay_enable && (state_flush || delay_cont_exceed) && RegNext(!exceed_vec.asUInt.andR) && !delay_step_exceed
+    delay_step_enable && (state_flush || cont_exceed) && !exceed_v.asUInt.andR && !step_exceed
   // When the whole step is appended to output, state_step should be 0, and output step + 1
-  val append_whole = has_append && !delay_cont_exceed
-  val out = IO(Output(new BatchOutput(chiselTypeOf(state_data), chiselTypeOf(state_info), config)))
-  out.io.data := state_data | Mux(
-    has_append,
-    delay_concat_data(param.TruncDataBitLen - 1, 0) << (state_data_len << 3),
-    0.U,
-  )
+  val append_whole = has_append && !cont_exceed
   val finish_step = state_step_cnt + Mux(append_whole, 1.U, 0.U)
   val BatchFinish = Wire(new BatchInfo)
   BatchFinish.id := (Batch.getTemplate.length + 1).U
   BatchFinish.num := finish_step
-  val append_info = Mux(
-    has_append,
-    Cat(
-      delay_concat_info,
-      BatchInterval.asUInt,
-    ) | BatchFinish.asUInt <<
-      ((delay_concat_stats.info_len + (param.infoWidth / 8).U)(param.TruncInfoLenWidth - 1, 0) << 3),
-    BatchFinish.asUInt,
-  )
-  out.io.info := state_info | append_info(param.TruncInfoBitLen - 1, 0) << (state_info_len << 3)
+  // Use BatchInterval to update index of software buffer
+  val BatchInterval = Wire(new BatchInfo)
+  BatchInterval.id := Batch.getTemplate.length.U
+  BatchInterval.num := delay_step_status.last.info_size // unused, only for debugging
+  val append_finish_map = Seq.tabulate(param.StepGroupSize) { g =>
+    (g.U, (BatchFinish.asUInt << (g * param.infoWidth)).asUInt)
+  }
+  val append_info = Cat(concat_info | LookupTree(concat_stats.info_size, append_finish_map), BatchInterval.asUInt)
+
+  out.io.data := state_data |
+    Mux(has_append, (concat_data(param.TruncDataBitLen - 1, 0) << (state_status.data_bytes << 3).asUInt).asUInt, 0.U)
+  out.io.info := state_info |
+    (Mux(has_append, append_info, BatchFinish.asUInt)(
+      param.TruncInfoBitLen - 1,
+      0,
+    ) << (state_status.info_size * param.infoWidth.U)).asUInt
+
   out.enable := should_tick
   out.step := Mux(out.enable, finish_step, 0.U)
 
-  // Stage 3: update state
-  val next_state_data_len = Mux(
-    delay_enable,
+  val next_state_data_bytes = Mux(
+    delay_step_enable,
     Mux(
       should_tick,
-      Mux(has_append, delay_remain_stats.data_len, delay_step_stats.data_len),
-      state_data_len + delay_step_stats.data_len,
+      Mux(has_append, remain_stats.data_bytes, delay_step_status.last.data_bytes),
+      state_status.data_bytes + delay_step_status.last.data_bytes,
     ),
     0.U,
   )
-
-  val next_state_info_len = Mux(
-    delay_enable,
+  val next_state_info_size = Mux(
+    delay_step_enable,
     Mux(
       should_tick,
-      Mux(has_append, delay_remain_stats.info_len, delay_step_stats.info_len + (param.infoWidth / 8).U),
-      state_info_len + delay_step_stats.info_len + (param.infoWidth / 8).U,
+      Mux(has_append, remain_stats.info_size, delay_step_status.last.info_size + 1.U),
+      state_status.info_size + delay_step_status.last.info_size + 1.U,
     ),
     0.U,
   )
-
-  // Calculate occupied space when enable(stage 1), state_update means previous step is in stage 2, use next_state_stats ahead
-  val state_update = delay_enable || state_flush || timeout
-  occupy_data_len := Mux(state_update, next_state_data_len, state_data_len)
-  occupy_info_len := Mux(state_update, next_state_info_len, state_info_len)
+  val state_update = delay_step_enable || state_flush || timeout
   when(state_update) {
-    state_data_len := next_state_data_len
-    state_info_len := next_state_info_len
-    when(delay_enable) {
+    state_status.data_bytes := next_state_data_bytes
+    state_status.info_size := next_state_info_size
+    when(delay_step_enable) {
       when(should_tick) {
         when(has_append) { // include state_flush with new-coming step
           state_step_cnt := Mux(append_whole, 0.U, 1.U)
-          state_data := delay_remain_data
-          state_info := delay_remain_info
+          state_data := remain_data
+          state_info := remain_info
         }.otherwise {
           state_step_cnt := 1.U
           state_data := delay_step_data
           state_info := Cat(delay_step_info, BatchInterval.asUInt)
         }
-        if (config.hasReplay) state_trace_size.get := RegNext(step_trace_info.get.trace_size)
+        if (config.hasReplay) state_trace_size.get := delay_step_trace_info.get.trace_size
       }.otherwise {
         state_step_cnt := state_step_cnt + 1.U
-        state_data := state_data | delay_step_data(param.TruncDataBitLen - 1, 0) << (state_data_len << 3)
-        state_info := state_info | Cat(
-          delay_step_info,
-          BatchInterval.asUInt,
-        )(param.TruncInfoBitLen - 1, 0) << (state_info_len << 3)
-        if (config.hasReplay) state_trace_size.get := state_trace_size.get + RegNext(step_trace_info.get.trace_size)
+        val append_step_data =
+          (delay_step_data(param.TruncDataBitLen - 1, 0) << (state_status.data_bytes << 3).asUInt).asUInt
+        val append_step_info =
+          (Cat(delay_step_info(param.TruncInfoBitLen - 1, 0), BatchInterval.asUInt)
+            << (state_status.info_size * param.infoWidth.U)).asUInt
+        state_data := state_data | append_step_data
+        state_info := state_info | append_step_info
+        if (config.hasReplay) state_trace_size.get := state_trace_size.get + delay_step_trace_info.get.trace_size
       }
     }.otherwise { // state_flush without new-coming step
       state_step_cnt := 0.U

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -53,6 +53,7 @@ case class GatewayConfig(
   def dutBufLen: Int = if (isBatch) batchSize else 1
   def maxStep: Int = if (isBatch) batchSize else 1
   def stepWidth: Int = log2Ceil(maxStep + 1)
+  def replayWidth: Int = log2Ceil(replaySize + 1)
   def batchArgByteLen: (Int, Int) = if (isNonBlock || isFPGA) (3600, 400) else (7200, 800)
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -42,7 +42,7 @@ class ReplayEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extend
   control.reset := reset
 
   val buffer = Mem(config.replaySize, chiselTypeOf(appendIn))
-  val ptr = RegInit(0.U(log2Ceil(config.replaySize).W))
+  val ptr = RegInit(0.U(config.replayWidth.W))
 
   // write
   // ignore useless data when hasGlobalEnable
@@ -85,7 +85,7 @@ class ReplayControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
   val clock = IO(Input(Clock()))
   val reset = IO(Input(Reset()))
   val replay = IO(Output(Bool()))
-  val replay_head = IO(Output(UInt(log2Ceil(config.replaySize).W)))
+  val replay_head = IO(Output(UInt(config.replayWidth.W)))
 
   setInline(
     "ReplayControl.v",
@@ -94,7 +94,7 @@ class ReplayControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |  input clock,
        |  input reset,
        |  output reg replay,
-       |  output reg [${log2Ceil(config.replaySize) - 1}:0] replay_head
+       |  output reg [${config.replayWidth - 1}:0] replay_head
        |);
        |
        |`ifndef SYNTHESIS
@@ -104,7 +104,7 @@ class ReplayControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |initial begin
        |  set_replay_scope();
        |  replay = 1'b0;
-       |  replay_head = ${log2Ceil(config.replaySize)}'b0;
+       |  replay_head = ${config.replayWidth}'b0;
        |end
        |
        |// For the C/C++ interface

--- a/src/main/scala/util/Lookup.scala
+++ b/src/main/scala/util/Lookup.scala
@@ -1,0 +1,30 @@
+/***************************************************************************************
+ * Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.util
+
+import chisel3._
+import chisel3.util._
+
+object LookupSeq {
+  def apply[T <: Data](key: UInt, default: T, mapping: Iterable[(UInt, T)]): T =
+    MuxLookup(key, default)(mapping.toSeq)
+}
+
+object LookupTree {
+  def apply[T <: Data](key: UInt, mapping: Iterable[(UInt, T)]): T =
+    Mux1H(mapping.map(p => (p._1 === key, p._2)))
+}


### PR DESCRIPTION
Previous we collect data from different groups(a group means Diffstate with same desireCppName) in pipeline (delay different groups to different stage by RegNext). And at each stage Batch will concat valid data from one group to step_data.

This change use two-stage collector to reduce gates: 
Stage1: Different groups will collect data in parallel to get tight-arrangement group_data.
Stage2: Batch will collect data from different groups in one cycle, group_vsize will be used to cut valid data from tight group_data by LookupTree, and valid data from different groups will be concated to step_data.

In pallaium, this change will reduce Batch gates from 21M to 12M. And in FPGA, XS(Basic-Diff) with ESBI config will use 80% LUT (XS needs 70% LUT itself).