### PR TITLE
Batch: disable split strategy for FPGA to reduce gates

### DIFF
--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -56,6 +56,7 @@ case class GatewayConfig(
   def stepWidth: Int = log2Ceil(maxStep + 1)
   def replayWidth: Int = log2Ceil(replaySize + 1)
   def batchArgByteLen: (Int, Int) = if (isNonBlock || isFPGA) (3600, 400) else (7200, 800)
+  def batchSplit: Boolean = !isFPGA // Disable split for FPGA to reduce gates
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
   def needEndpoint: Boolean =


### PR DESCRIPTION
Previous we enable splitting Batch data to handle peak data valid in same cycle (we call these data collected in same cycle Stepdata). The step data may be splitting according to remain space of Batch state, and part of them will be appended to Batch output to make full use of Batch DPIC.

However, this split strategy need some gates to handle splitting and appending behaviour. Now for FPGA, we need to reduce gates of Batch, so we disable split strategy.

According to gateCount of Palladium, disable split strategy will reduce gates of Batch from 12M to 8M (in full Difftest). And in FPGA, LUT of XS and Difftest(Basic-diff) will reduce from 81% to 77%, with XS accounts for 70% itself. 