### PR TITLE
vcs: Ensure correct execution order of difftest DPI calls

### DIFF
--- a/vcs.mk
+++ b/vcs.mk
@@ -107,7 +107,7 @@ VCS_FLAGS += +incdir+$(GEN_VSRC_DIR)
 VCS_FLAGS += $(EXTRA)
 
 VCS_VSRC_DIR = $(abspath ./src/test/vsrc/vcs)
-VCS_VFILES   = $(SIM_VSRC) $(shell find $(VCS_VSRC_DIR) -name "*.v")
+VCS_VFILES   = $(SIM_VSRC) $(shell find $(VCS_VSRC_DIR) -name "*.v" -or -name "*.sv")
 $(VCS_TARGET): $(SIM_TOP_V) $(VCS_CXXFILES) $(VCS_VFILES)
 	$(VCS) $(VCS_FLAGS) $(SIM_TOP_V) $(VCS_CXXFILES) $(VCS_VFILES)
 ifeq ($(VCS),verilator)


### PR DESCRIPTION
An additional `simv_step_event` was introduced to control the execution order of the `simv_nstep()` DPI call. The order of DPI calls in different `always` blocks is inherently unpredictable. Since `simv_nstep()` depends on the state updated by other `v_difftest_*` DPI calls, a `#0.1` delay was added to ensure that `simv_nstep()` is executed at the end of each clock posedge. This modification resolves potential timing issues caused by the implicit dependency between difftest DPI calls.

Additionally, the file extension of `DifftestEndpoint.v` was changed to `.sv`, as the `event` mechanism is a feature specific to SystemVerilog.