### PR TITLE
palladium.mk: add O3 option for PLDM_CXX_FLAGS

### DIFF
--- a/palladium.mk
+++ b/palladium.mk
@@ -79,7 +79,7 @@ PLDM_IXCOM 	 = $(shell cds_root ixcom)/share/uxe/etc/ixcom
 DPILIB_EMU    	 = $(PLDM_BUILD_DIR)/libdpi_emu.so
 PLDM_CSRC_DIR 	 = $(abspath ./src/test/csrc/vcs)
 PLDM_CXXFILES 	 = $(SIM_CXXFILES) $(shell find $(PLDM_CSRC_DIR) -name "*.cpp")
-PLDM_CXXFLAGS 	 = -m64 -c -fPIC -g -std=c++11 -I$(PLDM_IXCOM) -I$(PLDM_SIMTOOL)
+PLDM_CXXFLAGS 	 = -O3 -m64 -c -fPIC -g -std=c++11 -I$(PLDM_IXCOM) -I$(PLDM_SIMTOOL)
 PLDM_CXXFLAGS 	+= $(subst \\\",\", $(SIM_CXXFLAGS)) $(SIM_LDFLAGS) -I$(PLDM_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
 
 ifeq ($(WITH_DRAMSIM3),1)


### PR DESCRIPTION
It will slightly speed up the software simulation. Tested in Palladium( with Config ESBIN), time consumed by USER_CODE (including Difftest and NEMU) will reduce about 10%.