### PR TITLE
palladium: map fwrite in LogPerfEndpoint to TB_IMPORT

### DIFF
--- a/scripts/palladium/argConfigs.qel
+++ b/scripts/palladium/argConfigs.qel
@@ -4,3 +4,4 @@
 * $fatal TB_IMPORT
 * $random TB_IMPORT
 * $fwrite GFIFO
+LogPerfEndpoint $fwrite TB_IMPORT


### PR DESCRIPTION
When we enable XSPerf for XiangShan, logPerfs will be collected to LogPerfEndpoint. Previous we map all logPerfs to GFIFO, and LogPerfEndpoint consumes abount 140M gates, more than XiangShan itself.

This change map fwrite in LogPerfEndpoint to TB_IMPORT, reducing gates from 140m to 68M.

Note we cannot map all fwrites to TB_IMPORT, as some fwrites generated by chisel assert will include complex signal, greatly increase compile time from about 4h to more than 1 day.