### PR TITLE
Delta: support bundle spliting and filter duplicate elem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,6 +260,14 @@ jobs:
             ./build/simv +workload=$WORKLOAD +diff=$REF_SO
             make clean
 
+      - name: Verilator Build with VCS Top (with Batch InternalStep Delta PerfCnt)
+        run: |
+            cd $NOOP_HOME
+            make simv MILL_ARGS="--difftest-config BIDP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            ./build/simv +workload=$WORKLOAD +no-diff +max-cycles=100000
+            ./build/simv +workload=$WORKLOAD +diff=$REF_SO
+            make clean
+
       - name: Verilator Build with VCS Top (with GlobalEnable Squash Replay Batch PerfCnt)
         run: |
             cd $NOOP_HOME
@@ -272,6 +280,14 @@ jobs:
         run: |
             cd $NOOP_HOME
             make simv MILL_ARGS="--difftest-config ESRBINP" DIFFTEST_PERFCNT=1 DIFFTEST_QUERY=1 VCS=verilator -j2
+            ./build/simv +workload=$WORKLOAD +no-diff +max-cycles=100000
+            ./build/simv +workload=$WORKLOAD +diff=$REF_SO
+            make clean
+
+      - name: Verilator Build with VCS Top (with GlobalEnable Squash Replay Batch InternalStep Delta NonBlock PerfCnt Query)
+        run: |
+            cd $NOOP_HOME
+            make simv MILL_ARGS="--difftest-config ESRBIDNP" DIFFTEST_PERFCNT=1 DIFFTEST_QUERY=1 VCS=verilator -j2
             ./build/simv +workload=$WORKLOAD +no-diff +max-cycles=100000
             ./build/simv +workload=$WORKLOAD +diff=$REF_SO
             make clean

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -48,6 +48,10 @@ sealed trait DifftestBaseBundle extends Bundle {
   }
 }
 
+class DeltaElem extends DifftestBaseBundle {
+  val data = UInt(64.W)
+}
+
 class ArchEvent extends DifftestBaseBundle with HasValid {
   val interrupt = UInt(32.W)
   val exception = UInt(32.W)

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -22,6 +22,7 @@ import chisel3.util._
 import difftest._
 import difftest.batch.{BatchInfo, BatchIO}
 import difftest.common.FileControl
+import difftest.delta.Delta
 import difftest.gateway.{GatewayConfig, GatewayResult, GatewaySinkControl}
 import difftest.util.Query
 
@@ -84,7 +85,11 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
   def getPacketDecl(gen: DifftestBundle, prefix: String, config: GatewayConfig): String = {
     val dut_zone = if (config.hasDutZone) "dut_zone" else "0"
     val dut_index = if (config.isBatch) "dut_index" else "0"
-    val packet = s"DUT_BUF(${prefix}coreid, $dut_zone, $dut_index)->${gen.desiredCppName}"
+    val packet = if (config.isDelta && gen.isDeltaElem) {
+      s"DELTA_BUF(${prefix}coreid)->${gen.desiredCppName}"
+    } else {
+      s"DUT_BUF(${prefix}coreid, $dut_zone, $dut_index)->${gen.desiredCppName}"
+    }
     val index = if (gen.isIndexed) s"[${prefix}index]" else if (gen.isFlatten) s"[${prefix}address]" else ""
     s"auto packet = &($packet$index);"
   }
@@ -207,12 +212,17 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
       }
     }
     unpack += getPacketDecl(gen, "", config)
-    unpack += s"memcpy(packet, data, sizeof(${gen.desiredModuleName}));"
+    val size = if (config.isDelta && gen.isDeltaElem) {
+      "sizeof(uint64_t)"
+    } else {
+      s"sizeof(${gen.desiredModuleName})"
+    }
+    unpack += s"memcpy(packet, data, $size);"
     unpack += s"data += ${elem_bytes.sum};"
     unpack +=
       s"""
          |#ifdef CONFIG_DIFFTEST_QUERY
-         |  ${Query.writeInvoke(gen)}
+         |        ${Query.writeInvoke(gen)}
          |#endif // CONFIG_DIFFTEST_QUERY
          |""".stripMargin
     unpack.toSeq.mkString("\n        ")
@@ -278,6 +288,7 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
            |      break;
            |    }
            |    else if (id == BatchStep) {
+           |      ${if (config.isDelta) "dStats->sync(0, dut_index);" else ""}
            |      dut_index = (dut_index + 1) % CONFIG_DIFFTEST_BATCH_SIZE;
            |#ifdef CONFIG_DIFFTEST_QUERY
            |      difftest_query_step();
@@ -317,7 +328,8 @@ private class DummyDPICBatchWrapper(
 }
 
 object DPIC {
-  val interfaces = ListBuffer.empty[(String, String, String)]
+  private val interfaces = ListBuffer.empty[(String, String, String)]
+  private val deltaInstances = ListBuffer.empty[DifftestBundle]
   private val perfs = ListBuffer.empty[String]
 
   def apply(control: GatewaySinkControl, io: Valid[DifftestBundle], config: GatewayConfig): Unit = {
@@ -332,6 +344,9 @@ object DPIC {
       val interface = (dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc)
       interfaces += interface
     }
+    if (io.bits.supportsDelta && !deltaInstances.contains(io.bits)) {
+      deltaInstances += io.bits
+    }
   }
 
   def batch(template: Seq[DifftestBundle], control: GatewaySinkControl, io: BatchIO, config: GatewayConfig): Unit = {
@@ -343,9 +358,10 @@ object DPIC {
     interfaces += ((dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc))
     perfs += dpic.dpicFuncName
     perfs ++= template.map("Batch_" + _.desiredModuleName.replace("Difftest", ""))
+    deltaInstances ++= template.filter(_.supportsDelta)
   }
 
-  def collect(): GatewayResult = {
+  def collect(config: GatewayConfig): GatewayResult = {
     if (interfaces.isEmpty) {
       return GatewayResult()
     }
@@ -363,6 +379,10 @@ object DPIC {
     interfaceCpp += "#ifdef CONFIG_DIFFTEST_PERFCNT"
     interfaceCpp += "#include \"perf.h\""
     interfaceCpp += "#endif // CONFIG_DIFFTEST_PERFCNT"
+    if (config.isDelta) {
+      Delta.collect()
+      interfaceCpp += "#include \"difftest-delta.h\""
+    }
     interfaceCpp += ""
     interfaceCpp +=
       """
@@ -394,6 +414,7 @@ object DPIC {
         |  }
         |};
         |""".stripMargin
+
     interfaceCpp +=
       s"""
          |#ifdef CONFIG_DIFFTEST_PERFCNT
@@ -416,6 +437,14 @@ object DPIC {
     interfaceCpp += "#include \"difftest-dpic.h\""
     interfaceCpp += "#include \"difftest-query.h\""
     interfaceCpp += ""
+    if (config.isDelta) {
+      interfaceCpp +=
+        s"""
+           |#include \"difftest-delta.h\"
+           |DeltaStats* dStats = nullptr;
+           |#define DELTA_BUF(core_id) (dStats->get(core_id))
+           |""".stripMargin
+    }
     interfaceCpp +=
       s"""
          |DiffStateBuffer** diffstate_buffer = nullptr;
@@ -426,6 +455,7 @@ object DPIC {
          |  for (int i = 0; i < NUM_CORES; i++) {
          |    diffstate_buffer[i] = new DPICBuffer;
          |  }
+         |  ${if (config.isDelta) "dStats = new DeltaStats;" else ""}
          |}
          |
          |void diffstate_buffer_free() {
@@ -434,6 +464,7 @@ object DPIC {
          |  }
          |  delete[] diffstate_buffer;
          |  diffstate_buffer = nullptr;
+         |  ${if (config.isDelta) "delete dStats;" else ""}
          |}
       """.stripMargin
     val diffstate_perfhead = if (perfs.head.contains("Batch")) 1 else 0

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -1,0 +1,106 @@
+/***************************************************************************************
+ * Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.delta
+
+import chisel3._
+import chisel3.util._
+import difftest._
+import difftest.common.FileControl
+import difftest.gateway.GatewayConfig
+
+import scala.collection.mutable.ListBuffer
+
+object Delta {
+  private val instances = ListBuffer.empty[DifftestBundle]
+  def apply(bundles: MixedVec[Valid[DifftestBundle]], config: GatewayConfig): MixedVec[Valid[DifftestBundle]] = {
+    instances ++= bundles.map(_.bits)
+    val module = Module(new DeltaEndpoint(chiselTypeOf(bundles).toSeq, config))
+    module.in := bundles
+    module.out
+  }
+  def collect(): Unit = {
+    val deltaCpp = ListBuffer.empty[String]
+    val numCores = instances.count(_.isUniqueIdentifier)
+    val deltaInsts = instances.filter(_.supportsDelta)
+    val deltaDecl = deltaInsts.map { inst =>
+      val len = inst.dataElements.flatMap(_._3).length / numCores
+      s"uint64_t ${inst.desiredCppName}_elem[$len];"
+    }
+
+    deltaCpp += "#ifndef __DIFFTEST_DELTA_H__"
+    deltaCpp += "#define __DIFFTEST_DELTA_H__"
+    deltaCpp += "#include \"diffstate.h\""
+    deltaCpp +=
+      s"""
+         |typedef struct {
+         |  ${deltaDecl.mkString("\n  ")}
+         |} DeltaState;
+         |""".stripMargin
+
+    def deltaSync(dst: String, src: String): Seq[String] = {
+      deltaInsts.map { inst =>
+        val name = inst.desiredCppName
+        s"memcpy(&($dst->$name), $src->${name}_elem, sizeof(${inst.desiredModuleName}));"
+      }.toSeq
+    }
+    deltaCpp +=
+      s"""
+         |class DeltaStats {
+         |private:
+         |  DeltaState buffer[NUM_CORES];
+         |public:
+         |  DeltaStats() {
+         |    memset(buffer, 0, sizeof(buffer));
+         |  }
+         |  DeltaState* get(int coreid){
+         |    return buffer + coreid;
+         |  }
+         |  void sync(int zone, int index) {
+         |    for (int i = 0; i < NUM_CORES; i++) {
+         |      DiffTestState* dut = diffstate_buffer[i]->get(zone, index);
+         |      DeltaState* delta = get(i);
+         |      ${deltaSync("dut", "delta").mkString("\n      ")}
+         |    }
+         |  }
+         |};
+         |""".stripMargin
+    deltaCpp += "#endif // __DIFFTEST_DELTA_H__"
+    FileControl.write(deltaCpp, "difftest-delta.h")
+  }
+}
+
+class DeltaEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
+  val in = IO(Input(MixedVec(bundles)))
+  val deltas = in.filter(_.bits.supportsDelta).flatMap { v_gen =>
+    v_gen.bits.dataElements.flatMap(_._3).zipWithIndex.map { case (data, idx) =>
+      val state = RegInit(0.U.asTypeOf(data))
+      val update = v_gen.valid && data =/= state
+      when(update) {
+        state := data
+      }
+      val elem = Wire(Valid(new DiffDeltaElem(v_gen.bits)))
+      elem.valid := update
+      elem.bits.coreid := v_gen.bits.coreid
+      elem.bits.index := idx.U
+      elem.bits.data := data
+      elem
+    }
+  }
+  val withDeltas = MixedVecInit((in.filterNot(_.bits.supportsDelta) ++ deltas).toSeq)
+  val out = IO(Output(chiselTypeOf(withDeltas)))
+  out := withDeltas
+}

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -108,14 +108,16 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
     val macroName = s"CONFIG_DIFFTEST_${desiredModuleName.toUpperCase.replace("DIFFTEST", "")}"
     s"#define $macroName"
   }
-  def toCppDeclaration(packed: Boolean): String = {
+  def toCppDeclaration(packed: Boolean, aligned: Boolean): String = {
     val cpp = ListBuffer.empty[String]
     val attribute = if (packed) "__attribute__((packed))" else ""
     cpp += s"typedef struct $attribute {"
     for ((name, size, elem) <- dataElements) {
       val isRemoved = isFlatten && Seq("valid", "address").contains(name)
       if (!isRemoved) {
-        val arrayType = s"uint${size * 8}_t"
+        // Align elem to 8 bytes for bundle enabled to split when Delta
+        val elemSize = if (this.supportsDelta && aligned) (size + 7) / 8 * 8 else size
+        val arrayType = s"uint${elemSize * 8}_t"
         val arrayWidth = if (elem.length == 1) "" else s"[${elem.length}]"
         cpp += f"  $arrayType%-8s $name$arrayWidth;"
       }
@@ -166,6 +168,9 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
     gen
   }
   def genValidBundle: Valid[DifftestBundle] = genValidBundle(this.getValid)
+
+  val supportsDelta: Boolean = false
+  def isDeltaElem: Boolean = this.isInstanceOf[DiffDeltaElem]
 
   // Byte align all elements
   def getByteAlignElems(isTrace: Boolean): Seq[(String, Data)] = {
@@ -221,6 +226,11 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   }
 }
 
+class DiffDeltaElem(gen: DifftestBundle) extends DeltaElem with DifftestBundle with DifftestWithIndex {
+  override val desiredCppName: String = gen.desiredCppName + "_elem"
+  override def desiredModuleName: String = gen.desiredModuleName + "Elem"
+}
+
 class DiffArchEvent extends ArchEvent with DifftestBundle {
   // DiffArchEvent must be instantiated once for each core.
   override def isUniqueIdentifier: Boolean = true
@@ -266,23 +276,28 @@ class DiffCSRState extends CSRState with DifftestBundle {
   override val desiredCppName: String = "csr"
   override val desiredOffset: Int = 1
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 class DiffHCSRState extends HCSRState with DifftestBundle {
   override val desiredCppName: String = "hcsr"
   override val desiredOffset: Int = 6
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 //class DiffHCSRStateValidate extends DiffHCSRState with DifftestIsValidated
 
 class DiffDebugMode extends DebugModeCSRState with DifftestBundle {
   override val desiredCppName: String = "dmregs"
+  override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 class DiffTriggerCSRState extends TriggerCSRState with DifftestBundle {
   override val desiredCppName: String = "triggercsr"
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 class DiffIntWriteback(numRegs: Int = 32) extends DataWriteback(numRegs) with DifftestBundle {
@@ -312,6 +327,7 @@ class DiffArchIntRegState extends ArchIntRegState with DifftestBundle {
   override val desiredCppName: String = "regs_int"
   override val desiredOffset: Int = 0
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 abstract class DiffArchDelayedUpdate(numRegs: Int)
@@ -333,24 +349,28 @@ class DiffArchFpRegState extends ArchIntRegState with DifftestBundle {
   override val desiredCppName: String = "regs_fp"
   override val desiredOffset: Int = 2
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 class DiffArchVecRegState extends ArchVecRegState with DifftestBundle {
   override val desiredCppName: String = "regs_vec"
   override val desiredOffset: Int = 4
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 class DiffVecCSRState extends VecCSRState with DifftestBundle {
   override val desiredCppName: String = "vcsr"
   override val desiredOffset: Int = 5
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 class DiffFpCSRState extends FpCSRState with DifftestBundle {
   override val desiredCppName: String = "fcsr"
   override val desiredOffset: Int = 7
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  override val supportsDelta: Boolean = true
 }
 
 class DiffSbufferEvent extends SbufferEvent with DifftestBundle with DifftestWithIndex {
@@ -517,7 +537,13 @@ object DifftestModule {
   def finish(cpu: String, createTopIO: Boolean): Option[DifftestTopIO] = {
     val gateway = Gateway.collect()
 
-    generateCppHeader(cpu, gateway.instances, gateway.cppMacros, gateway.structPacked.getOrElse(false))
+    generateCppHeader(
+      cpu,
+      gateway.instances,
+      gateway.cppMacros,
+      gateway.structPacked.getOrElse(false),
+      gateway.structAligned.getOrElse(false),
+    )
     generateVeriogHeader(gateway.vMacros)
     Profile.generateJson(cpu, interfaces.toSeq)
 
@@ -606,6 +632,7 @@ object DifftestModule {
     instances: Seq[DifftestBundle],
     macros: Seq[String],
     structPacked: Boolean,
+    structAligned: Boolean,
   ): Unit = {
     val difftestCpp = ListBuffer.empty[String]
     difftestCpp += "#ifndef __DIFFSTATE_H__"
@@ -647,7 +674,7 @@ object DifftestModule {
           val configWidthName = s"CONFIG_DIFF_${macroName}_WIDTH"
           difftestCpp += s"#define $configWidthName ${bundleType.bits.getNumElements}"
         }
-        difftestCpp += bundleType.toCppDeclaration(structPacked)
+        difftestCpp += bundleType.toCppDeclaration(structPacked, structAligned)
         difftestCpp += ""
       })
 

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -24,6 +24,7 @@ import difftest.dpic.DPIC
 import difftest.preprocess.Preprocess
 import difftest.squash.Squash
 import difftest.batch.{Batch, BatchIO}
+import difftest.delta.Delta
 import difftest.replay.Replay
 import difftest.trace.Trace
 import difftest.util.VerificationExtractor
@@ -38,6 +39,7 @@ case class GatewayConfig(
   hasReplay: Boolean = false,
   replaySize: Int = 1024,
   hasDutZone: Boolean = false,
+  isDelta: Boolean = false,
   isBatch: Boolean = false,
   batchSize: Int = 64,
   hasInternalStep: Boolean = false,
@@ -76,6 +78,7 @@ case class GatewayConfig(
         s"CONFIG_DIFFTEST_BATCH_BYTELEN ${batchArgByteLen._1 + batchArgByteLen._2}",
       )
     if (isSquash) macros ++= Seq("CONFIG_DIFFTEST_SQUASH", s"CONFIG_DIFFTEST_SQUASH_STAMPSIZE 4096") // Stamp Width 12
+    if (isDelta) macros += "CONFIG_DIFFTEST_DELTA"
     if (hasReplay) macros ++= Seq("CONFIG_DIFFTEST_REPLAY", s"CONFIG_DIFFTEST_REPLAY_SIZE ${replaySize}")
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
@@ -96,6 +99,8 @@ case class GatewayConfig(
     if (hasReplay) require(isSquash)
     if (hasInternalStep) require(isBatch)
     if (isBatch) require(!hasDutZone)
+    // Currently Delta depends on Batch to ensure update and sync order
+    if (isDelta) require(isBatch)
     // TODO: support dump and load together
     require(!(traceDump && traceLoad))
   }
@@ -106,6 +111,7 @@ case class GatewayResult(
   vMacros: Seq[String] = Seq(),
   instances: Seq[DifftestBundle] = Seq(),
   structPacked: Option[Boolean] = None,
+  structAligned: Option[Boolean] = None, // Align struct Elem to 8 bytes for Delta Feature
   exit: Option[UInt] = None,
   step: Option[UInt] = None,
 ) {
@@ -115,6 +121,7 @@ case class GatewayResult(
       vMacros = vMacros ++ that.vMacros,
       instances = instances ++ that.instances,
       structPacked = if (structPacked.isDefined) structPacked else that.structPacked,
+      structAligned = if (structAligned.isDefined) structAligned else that.structAligned,
       exit = if (exit.isDefined) exit else that.exit,
       step = if (step.isDefined) step else that.step,
     )
@@ -131,6 +138,7 @@ object Gateway {
       case 'S' => config = config.copy(isSquash = true)
       case 'R' => config = config.copy(hasReplay = true)
       case 'Z' => config = config.copy(hasDutZone = true)
+      case 'D' => config = config.copy(isDelta = true)
       case 'B' => config = config.copy(isBatch = true)
       case 'I' => config = config.copy(hasInternalStep = true)
       case 'N' => config = config.copy(isNonBlock = true)
@@ -184,6 +192,7 @@ object Gateway {
       GatewayResult(
         instances = endpoint.instances,
         structPacked = Some(config.isBatch),
+        structAligned = Some(config.isDelta),
         step = Some(endpoint.step),
       )
     } else {
@@ -230,27 +239,33 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
     WireInit(validated)
   }
   val instances = chiselTypeOf(squashed).map(_.bits).toSeq
+  val deltas = if (config.isDelta) {
+    WireInit(Delta(squashed, config))
+  } else {
+    WireInit(squashed)
+  }
+  val toSink = deltas
 
   val zoneControl = Option.when(config.hasDutZone)(Module(new ZoneControl(config)))
   val step = IO(Output(UInt(config.stepWidth.W)))
   val control = Wire(new GatewaySinkControl(config))
 
   if (config.isBatch) {
-    val batch = Batch(squashed, config)
+    val batch = Batch(toSink, config)
     step := RegNext(batch.step, 0.U) // expose Batch step to check timeout
     control.enable := batch.enable
     GatewaySink.batch(Batch.getTemplate, control, batch.io, config)
   } else {
-    val squashed_enable = VecInit(squashed.map(_.valid).toSeq).asUInt.orR
-    step := RegNext(squashed_enable, 0.U)
-    control.enable := squashed_enable
+    val sink_enable = VecInit(toSink.map(_.valid).toSeq).asUInt.orR
+    step := RegNext(sink_enable, 0.U)
+    control.enable := sink_enable
     if (config.hasDutZone) {
-      zoneControl.get.enable := squashed_enable
+      zoneControl.get.enable := sink_enable
       control.dut_zone.get := zoneControl.get.dut_zone
     }
 
-    for (id <- 0 until squashed.length) {
-      GatewaySink(control, squashed(id), config)
+    for (id <- 0 until toSink.length) {
+      GatewaySink(control, toSink(id), config)
     }
   }
 
@@ -286,8 +301,8 @@ object GatewaySink {
 
   def collect(config: GatewayConfig): GatewayResult = {
     config.style match {
-      case "dpic" => DPIC.collect()
-      case _      => DPIC.collect() // Default: DPI-C
+      case "dpic" => DPIC.collect(config)
+      case _      => DPIC.collect(config) // Default: DPI-C
     }
   }
 }


### PR DESCRIPTION
This change add Delta feature to speed up difftest in Palladium/FPGA. We enable spliting bundle into elems, and only transmit non-duplicate elem through DPIC.

As we need a buffer to record base value for delta-transmission, we generate difftest-delta.h, which provides API to update delta data from elem's DPIC, and sync final data to diffState (just like non-delta transmission). Currectly we rely on Batch to ensure Delta order, which updates delta-buffer during DPIC parsing, and sync at the end of each step.

Based on Config ESBIN (enable Squash and Batch），Delta feature will reduce DPIC bytes by ~40%，which will be better without Squash or under Basic-Diff, where duplicate data from bundle like ArchReg/CSR... acounts for more proportions of DPIC bytes.