### PR TITLE
feat(load_check): add vec load check

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -67,6 +67,9 @@
 #endif
 extern unsigned long EMU_FLASH_SIZE;
 
+#define DIFFTEST_VLEN 128
+#define VLENE_64 DIFFTEST_VLEN/64
+
 // Use sdl to show screen
 // Note: It does not work well with clang, to use that, switch to gcc
 // uncomment the following line to enable this feature

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -63,8 +63,11 @@ class InstrCommit(val numPhyRegs: Int = 32) extends DifftestBaseBundle with HasV
   val rfwen = Bool()
   val fpwen = Bool()
   val vecwen = Bool()
+  val v0wen = Bool()
   val wpdest = UInt(log2Ceil(numPhyRegs).W)
   val wdest = UInt(8.W)
+  val otherwpdest = Vec(8, UInt(8.W))
+  val otherV0Wen = Vec(8, Bool())
 
   val pc = UInt(64.W)
   val instr = UInt(32.W)
@@ -87,6 +90,7 @@ class InstrCommit(val numPhyRegs: Int = 32) extends DifftestBaseBundle with HasV
 // Instantiate inside DiffTest, work for get_commit_data specially
 class CommitData extends DifftestBaseBundle with HasValid {
   val data = UInt(64.W)
+  val vecData = Vec(16, UInt(64.W))
 }
 
 class TrapEvent extends DifftestBaseBundle {
@@ -166,6 +170,10 @@ class DataWriteback(val numElements: Int) extends DifftestBaseBundle with HasVal
   val data = UInt(64.W)
 }
 
+class VecDataWriteback(val numElements: Int) extends DifftestBaseBundle with HasValid with HasAddress {
+  val data = Vec(2, UInt(64.W))
+}
+
 class ArchIntRegState extends DifftestBaseBundle {
   val value = Vec(32, UInt(64.W))
 
@@ -234,7 +242,8 @@ class LoadEvent extends DifftestBaseBundle with HasValid {
   val paddr = UInt(64.W)
   val opType = UInt(8.W)
   val isAtomic = Bool()
-  val isLoad = Bool() // Todo: support vector load
+  val isLoad = Bool()
+  val isVLoad = Bool()
 }
 
 class AtomicEvent extends DifftestBaseBundle with HasValid {

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -297,8 +297,15 @@ class DiffFpWriteback(numRegs: Int = 32) extends DiffIntWriteback(numRegs) {
   override val desiredCppName: String = "wb_fp"
 }
 
-class DiffVecWriteback(numRegs: Int = 32) extends DiffIntWriteback(numRegs) {
+class DiffVecWriteback(numRegs: Int = 32) extends VecDataWriteback(numRegs) with DifftestBundle {
   override val desiredCppName: String = "wb_vec"
+  override protected val needFlatten: Boolean = true
+  override def supportsSquashBase: Bool = true.B
+  override def classArgs: Map[String, Any] = Map("numRegs" -> numRegs)
+}
+
+class DiffVecV0Writeback(numRegs: Int = 32) extends DiffVecWriteback(numRegs) {
+  override val desiredCppName: String = "wb_v0"
 }
 
 class DiffArchIntRegState extends ArchIntRegState with DifftestBundle {
@@ -366,9 +373,12 @@ class DiffLoadEvent extends LoadEvent with DifftestBundle with DifftestWithIndex
 
 class DiffLoadEventQueue extends DiffLoadEvent with DifftestWithStamp with DiffTestIsInherited {
   val commitData = UInt(64.W)
+  val vecCommitData = Vec(16, UInt(64.W))
   val regWen = Bool()
   val wdest = UInt(8.W)
   val fpwen = Bool()
+  val vecwen = Bool()
+  val v0wen = Bool()
   override val squashQueue: Boolean = true
 }
 

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -67,9 +67,12 @@ class Stamper(bundles: Seq[Valid[DifftestBundle]]) extends Module {
     lq.inheritFrom(ld)
     lq.bits.stamp := stamp(ld.bits.coreid) + sum
     lq.bits.commitData := cd.bits.data
+    lq.bits.vecCommitData := cd.bits.vecData
     lq.bits.regWen := ((c.bits.rfwen && c.bits.wdest =/= 0.U) || c.bits.fpwen) && !c.bits.vecwen
     lq.bits.wdest := c.bits.wdest
     lq.bits.fpwen := c.bits.fpwen
+    lq.bits.vecwen := c.bits.vecwen
+    lq.bits.v0wen := c.bits.v0wen
     lq
   }
 

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -262,6 +262,13 @@ public:
 #endif
               dut->regs_int.value + src;
   }
+
+#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
+  inline uint64_t *arch_vecreg(uint8_t src) {
+    return dut->regs_vec.value + src;
+  }
+#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
+
   inline DiffTestState *get_dut() {
     return dut;
   }
@@ -351,6 +358,9 @@ protected:
   void do_interrupt();
   void do_exception();
   int do_instr_commit(int index);
+#if defined(CONFIG_DIFFTEST_LOADEVENT) && defined(CONFIG_DIFFTEST_ARCHVECREGSTATE)
+  void do_vec_load_check(int index, DifftestLoadEvent load_event);
+#endif // CONFIG_DIFFTEST_LOADEVENT && CONFIG_DIFFTEST_ARCHVECREGSTATE
   void do_load_check(int index);
   int do_store_check();
   int do_refill_check(int cacheid);
@@ -379,7 +389,17 @@ protected:
         if (dut->commit[i].vecwen) {
       return
 #ifdef CONFIG_DIFFTEST_VECWRITEBACK
-          dut->wb_vec[dut->commit[i].wpdest].data;
+          dut->wb_vec[dut->commit[i].wpdest].data[0];
+#else
+          dut->regs_vec.value[dut->commit[i].wdest];
+#endif // CONFIG_DIFFTEST_VECWRITEBACK
+    } else
+#endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
+#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
+        if (dut->commit[i].v0wen) {
+      return
+#ifdef CONFIG_DIFFTEST_VECWRITEBACK
+          dut->wb_v0[dut->commit[i].wpdest].data[0];
 #else
           dut->regs_vec.value[dut->commit[i].wdest];
 #endif // CONFIG_DIFFTEST_VECWRITEBACK

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -153,7 +153,10 @@ public:
   f(ref_raise_critical_error, difftest_raise_critical_error, bool)                                          \
   f(ref_get_store_event_other_info, difftest_get_store_event_other_info, void, void*)                       \
   f(ref_sync_aia, difftest_sync_aia, void, void*)                                                           \
-  f(ref_sync_custom_mflushpwr, difftest_sync_custom_mflushpwr, void, bool)
+  f(ref_sync_custom_mflushpwr, difftest_sync_custom_mflushpwr, void, bool)                                  \
+  f(ref_get_vec_load_vdNum, difftest_get_vec_load_vdNum, int, )                                                 \
+  f(ref_get_vec_load_dual_goldenmem_reg, difftest_get_vec_load_dual_goldenmem_reg, void*, )                                                       \
+  f(ref_update_vec_load_goldenmen, difftest_update_vec_load_pmem, void, )
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
 /* clang-format on */
@@ -212,6 +215,11 @@ public:
               regs_int.value + src;
   }
 
+#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
+  inline uint64_t *arch_vecreg(uint8_t src) {
+    return regs_vec.value + src;
+  }
+#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
   inline void sync(bool is_from_dut = false) {
     ref_regcpy(&regs_int, is_from_dut, is_from_dut);
   }
@@ -289,6 +297,36 @@ public:
       ref_sync_custom_mflushpwr(l2FlushDone);
     } else {
       printf("Does not support sync custom CSR mflushpwr.\n");
+    }
+  }
+
+  inline bool check_ref_vec_load_goldenmem() {
+    return ref_get_vec_load_vdNum && ref_get_vec_load_dual_goldenmem_reg && ref_update_vec_load_goldenmen;
+  }
+
+  inline int get_ref_vdNum() {
+    if (ref_get_vec_load_vdNum) {
+      return ref_get_vec_load_vdNum();
+    } else {
+      Info("Does not support the get vec load vd num.\n");
+      return 0;
+    }
+  }
+
+  inline void *get_vec_goldenmem_reg() {
+    if (ref_get_vec_load_dual_goldenmem_reg) {
+      return ref_get_vec_load_dual_goldenmem_reg();
+    } else {
+      Info("Does not support the get vec load goldenmem reg.\n");
+      return nullptr;
+    }
+  }
+
+  inline void vec_update_goldenmem() {
+    if (ref_update_vec_load_goldenmen) {
+      ref_update_vec_load_goldenmen();
+    } else {
+      Info("Does not support the get vec update goldenmem.\n");
     }
   }
 


### PR DESCRIPTION
This commit adds vector load check.
This is mostly done in the following way:
1. checking for consistency of vector load results in dut and ref's pmem.
2. if not, then check if the vector load results in dut and golden mem are consistent.
3. if the check in (2) passes, update ref.

---

Consider the complexity and diversity of vector.
While accessing pmem in ref, a golden mem access will be performed at the same time, and the related information (addr, data) will be stored temporarily.
When you need to compare the golden mem, you will get the golden mem access result from ref via API.
When the golden mem needs to be updated, the API will ask ref to get the information (addr and data) from the stored information and write them to the golden mem.

---

**I've tested this in a number of different emulations and have added adaptation code for different acceleration strategies.
After testing, this will bring some extra resource usage on palladium, probably around 800W. I'm not sure if the size of this increase is what is expected, so please confirm this for me.**