### PR TITLE
perf(fpga): use spinLock instead of mutex and delet unwanted locks

### DIFF
--- a/src/test/csrc/common/mpool.h
+++ b/src/test/csrc/common/mpool.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <vector>
+#include <xmmintrin.h>
 
 #define MEMPOOL_SIZE   16384 * 1024 // 16M memory
 #define MEMBLOCK_SIZE  4096         // 4K packge
@@ -67,6 +68,19 @@ public:
   // Disable the copy constructor and copy assignment operator
   MemoryBlock(const MemoryBlock &) = delete;
   MemoryBlock &operator=(const MemoryBlock &) = delete;
+};
+
+class SpinLock {
+  std::atomic_flag locked = ATOMIC_FLAG_INIT;
+
+public:
+  void lock() {
+    while (locked.test_and_set(std::memory_order_acquire))
+      _mm_pause();
+  }
+  void unlock() {
+    locked.clear(std::memory_order_release);
+  }
 };
 
 class MemoryPool {
@@ -122,17 +136,14 @@ private:
   const size_t MAX_GROUP_READ = MAX_GROUPING_IDX - 2; //The window needs to reserve two free Spaces
   const size_t REM_MAX_IDX = (MAX_IDX - 1);
   const size_t REM_MAX_GROUPING_IDX = (MAX_GROUPING_IDX - 1);
-  uint64_t mem_block_size = 4096;
+  uint64_t mem_block_size = MEMBLOCK_SIZE;
 
 public:
-  MemoryIdxPool(uint64_t block_size) {
-    mem_block_size = block_size;
+  MemoryIdxPool(uint64_t block_size) : mem_block_size(block_size) {
     initMemoryPool();
   }
-  MemoryIdxPool() : MemoryIdxPool(4096) {}
-  ~MemoryIdxPool() {
-    cleanupMemoryPool();
-  }
+  MemoryIdxPool() : mem_block_size(MEMBLOCK_SIZE) {}
+  ~MemoryIdxPool() {}
   // Disable copy constructors and copy assignment operators
   MemoryIdxPool(const MemoryIdxPool &) = delete;
   MemoryIdxPool &operator=(const MemoryIdxPool &) = delete;
@@ -144,9 +155,6 @@ public:
       memory_pool.emplace_back(mem_block_size);
     }
   }
-
-  // Cleaning up memory pools
-  void cleanupMemoryPool();
 
   // Write a specified free block of a free window
   bool write_free_chunk(uint8_t idx, const char *data);
@@ -168,17 +176,13 @@ public:
 
 private:
   std::vector<MemoryBlock> memory_pool; // Mempool
-  std::mutex window_mutexes;            // window sliding protection
-  std::mutex offset_mutexes;            // w/r offset protection
-  std::condition_variable cv_empty;     // Free block condition variable
-  std::condition_variable cv_filled;    // Filled block condition variable
+  SpinLock offset_mutexes;              // w/r offset protection
 
   size_t group_r_offset = 0; // The offset used by the current consumer
-  size_t group_w_offset = 0; // The offset used by the current producer
   size_t read_count = 0;
-  size_t write_count = 0;
-  size_t write_next_count = 0;
-
+  std::atomic<size_t> group_w_offset{0}; // The offset used by the current producer
+  std::atomic<size_t> write_count{0};
+  std::atomic<size_t> write_next_count{0};
   std::atomic<size_t> empty_blocks{MAX_GROUP_READ};
   std::atomic<size_t> group_w_idx{1};
   std::atomic<size_t> group_r_idx{1};

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -134,7 +134,6 @@ void FpgaXdma::stop_thansmit_thread() {
 #ifdef CONFIG_USE_XDMA_H2C
   close(xdma_h2c_fd);
 #endif
-  xdma_mempool.cleanupMemoryPool();
 }
 
 void FpgaXdma::read_xdma_thread(int channel) {


### PR DESCRIPTION
Since the overhead per operation is not large, mutexes are replaced by lighter locks. At the same time, by removing cv_wait from the function that controls group offset, the locks that are no longer needed are removed, which improves the processing bandwidth of mempool from  16161MB/S to more than 22450MB/S (The stress test was performed on the Intel(R) Core(TM) i7-11700 platform)
