### PR TITLE
feat(Uncache): add event and update goldenmem for some uncache cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ coherence via RefillTest.
 | `DiffCriticalErrorEvent` | Raise critical-error | No |
 | `DiffSyncAIAEvent` | Synchronization of AIA | No |
 | `DiffSyncCustomMflushpwrEvent` | custom CSR mflushpwr | No |
+| `DiffUncacheMMStoreEvent` | Uncache buffer main memory store operations | No |
 
 The DiffTest framework comes with a simulation framework with some top-level IOs.
 They will be automatically created when calling `DifftestModule.finish(cpu: String)`.

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -230,6 +230,12 @@ class SbufferEvent extends DifftestBaseBundle with HasValid {
   val mask = UInt(64.W)
 }
 
+class UncacheMMStoreEvent extends DifftestBaseBundle with HasValid {
+  val addr = UInt(64.W)
+  val data = Vec(8, UInt(8.W))
+  val mask = UInt(8.W)
+}
+
 class StoreEvent extends DifftestBaseBundle with HasValid {
   val addr = UInt(64.W)
   val data = UInt(64.W)

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -358,6 +358,11 @@ class DiffSbufferEvent extends SbufferEvent with DifftestBundle with DifftestWit
   override val squashGroup: Seq[String] = Seq("GOLDENMEM")
 }
 
+class DiffUncacheMMStoreEvent extends UncacheMMStoreEvent with DifftestBundle with DifftestWithIndex {
+  override val desiredCppName: String = "uncache_mm_store"
+  override val squashGroup: Seq[String] = Seq("GOLDENMEM")
+}
+
 class DiffStoreEvent extends StoreEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "store"
 }

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1011,7 +1011,7 @@ int Difftest::do_refill_check(int cacheid) {
             for (int j = 0; j < 8; j++) {
               Info("%016lx", dut_refill->data[j]);
             }
-             Info("\n");
+            Info("\n");
             update_goldenmem(dut_refill->addr, dut_refill->data, 0xffffffffffffffffUL, 64);
             proxy->ref_memcpy(dut_refill->addr, dut_refill->data, 64, DUT_TO_REF);
             return 0;

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -839,8 +839,7 @@ void Difftest::do_load_check(int i) {
             len = 8;
           }
         }
-        read_goldenmem(load_event.paddr, &golden, len);
-        read_goldenmem_flag(load_event.paddr, &golden_flag, len);
+        read_goldenmem_with_flag(load_event.paddr, &golden, &golden_flag, len);
         if (load_event.isLoad) {
           switch (len) {
             case 1:
@@ -871,7 +870,7 @@ void Difftest::do_load_check(int i) {
           Info("load check of uncache mm store flag\n");
           Info("  DUT data: 0x%lx, regWen: %d, refRegPtr: 0x%lx\n", commitData, regWen, refRegPtr);
           proxy->ref_memcpy(load_event.paddr, &commitData, len, DUT_TO_REF);
-          update_goldenmem(load_event.paddr, &commitData, mask, len, 0);
+          update_goldenmem(load_event.paddr, &commitData, mask, len);
           if (regWen) {
             *refRegPtr = commitData;
             proxy->sync(true);
@@ -975,8 +974,7 @@ int Difftest::do_refill_check(int cacheid) {
       return 0;
     }
     for (int i = 0; i < 8; i++) {
-      read_goldenmem(dut_refill->addr + i * 8, &buf, 8);
-      read_goldenmem_flag(dut_refill->addr + i * 8, &flag_buf, 8);
+      read_goldenmem_with_flag(dut_refill->addr + i * 8, &buf, &flag_buf, 8);
       if (dut_refill->data[i] != *((uint64_t *)buf)) {
 #ifdef CONFIG_DIFFTEST_CMOINVALEVENT
         if (cmo_inval_event_set.find(dut_refill->addr) != cmo_inval_event_set.end()) {
@@ -993,7 +991,7 @@ int Difftest::do_refill_check(int cacheid) {
             Info("%016lx", dut_refill->data[j]);
           }
           Info("\n");
-          update_goldenmem(dut_refill->addr, dut_refill->data, 0xffffffffffffffffUL, 64, 0);
+          update_goldenmem(dut_refill->addr, dut_refill->data, 0xffffffffffffffffUL, 64);
           proxy->ref_memcpy(dut_refill->addr, dut_refill->data, 64, DUT_TO_REF);
           cmo_inval_event_set.erase(dut_refill->addr);
           return 0;
@@ -1014,7 +1012,7 @@ int Difftest::do_refill_check(int cacheid) {
               Info("%016lx", dut_refill->data[j]);
             }
             Info("\n");
-            update_goldenmem(dut_refill->addr, dut_refill->data, 0xffffffffffffffffUL, 64, 0);
+            update_goldenmem(dut_refill->addr, dut_refill->data, 0xffffffffffffffffUL, 64);
             proxy->ref_memcpy(dut_refill->addr, dut_refill->data, 64, DUT_TO_REF);
             return 0;
           }
@@ -1308,7 +1306,7 @@ inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData[],
       case 057: ret = (t == cmp) ? rs : t; break;
       default: Info("Unknown atomic fuOpType: 0x%x\n", atomicFuop);
     }
-    update_goldenmem(atomicAddr, &ret, atomicMask, 8, 0);
+    update_goldenmem(atomicAddr, &ret, atomicMask, 8);
   }
 
   if (atomicMask == 0xf || atomicMask == 0xf0) {
@@ -1368,7 +1366,7 @@ inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData[],
     ret_sel = ret;
     if (atomicMask == 0xf0)
       ret_sel = (ret_sel << 32);
-    update_goldenmem(atomicAddr, &ret_sel, atomicMask, 8, 0);
+    update_goldenmem(atomicAddr, &ret_sel, atomicMask, 8);
   }
 
   if (atomicMask == 0xffff) {
@@ -1390,8 +1388,8 @@ inline int handle_atomic(int coreid, uint64_t atomicAddr, uint64_t atomicData[],
       }
       default: Info("Unknown atomic fuOpType: 0x%x\n", atomicFuop);
     }
-    update_goldenmem(atomicAddr, &retl, 0xff, 8, 0);
-    update_goldenmem(atomicAddr + 8, &reth, 0xff, 8, 0);
+    update_goldenmem(atomicAddr, &retl, 0xff, 8);
+    update_goldenmem(atomicAddr + 8, &reth, 0xff, 8);
   }
   return 0;
 }
@@ -1439,7 +1437,7 @@ int Difftest::do_golden_memory_update() {
   for (int i = 0; i < CONFIG_DIFF_SBUFFER_WIDTH; i++) {
     if (dut->sbuffer[i].valid) {
       dut->sbuffer[i].valid = 0;
-      update_goldenmem(dut->sbuffer[i].addr, dut->sbuffer[i].data, dut->sbuffer[i].mask, 64, 0);
+      update_goldenmem(dut->sbuffer[i].addr, dut->sbuffer[i].data, dut->sbuffer[i].mask, 64);
       if (dut->sbuffer[i].addr == track_instr) {
         dumpGoldenMem("Store", track_instr, cycleCnt);
       }

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1002,7 +1002,7 @@ int Difftest::do_refill_check(int cacheid) {
 #ifdef CONFIG_DIFFTEST_UNCACHEMMSTOREEVENT
           // in multi-core, uncache mm store may cause data inconsistencies.
           // so here needs to override the nemu value with the dut value by cacheline granularity.
-          if (*((uint64_t *)flag_buf) != 0){
+          if (*((uint64_t *)flag_buf) != 0) {
             Info("INFO: Sync GoldenMem using refill Data from DUT (Because of uncache main-mem store):\n");
             Info("      cacheid=%d, addr: %lx\n      Gold: ", cacheid, dut_refill->addr);
             for (int j = 0; j < 8; j++) {
@@ -1427,7 +1427,8 @@ int Difftest::do_golden_memory_update() {
       dut->uncache_mm_store[i].valid = 0;
       // the flag is set only in the case of multi-cores and uncache mm store
       uint8_t flag = NUM_CORES > 1 ? 1 : 0;
-      update_goldenmem(dut->uncache_mm_store[i].addr, dut->uncache_mm_store[i].data, dut->uncache_mm_store[i].mask, 8, flag);
+      update_goldenmem(dut->uncache_mm_store[i].addr, dut->uncache_mm_store[i].data, dut->uncache_mm_store[i].mask, 8,
+                       flag);
       if (dut->uncache_mm_store[i].addr == track_instr) {
         dumpGoldenMem("Uncache MM Store", track_instr, cycleCnt);
       }

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -839,7 +839,7 @@ void Difftest::do_load_check(int i) {
             len = 8;
           }
         }
-        read_goldenmem_with_flag(load_event.paddr, &golden, &golden_flag, len);
+        read_goldenmem(load_event.paddr, &golden, len, &golden_flag);
         if (load_event.isLoad) {
           switch (len) {
             case 1:
@@ -974,7 +974,7 @@ int Difftest::do_refill_check(int cacheid) {
       return 0;
     }
     for (int i = 0; i < 8; i++) {
-      read_goldenmem_with_flag(dut_refill->addr + i * 8, &buf, &flag_buf, 8);
+      read_goldenmem(dut_refill->addr + i * 8, &buf, 8, &flag_buf);
       if (dut_refill->data[i] != *((uint64_t *)buf)) {
 #ifdef CONFIG_DIFFTEST_CMOINVALEVENT
         if (cmo_inval_event_set.find(dut_refill->addr) != cmo_inval_event_set.end()) {
@@ -1011,7 +1011,7 @@ int Difftest::do_refill_check(int cacheid) {
             for (int j = 0; j < 8; j++) {
               Info("%016lx", dut_refill->data[j]);
             }
-            Info("\n");
+             Info("\n");
             update_goldenmem(dut_refill->addr, dut_refill->data, 0xffffffffffffffffUL, 64);
             proxy->ref_memcpy(dut_refill->addr, dut_refill->data, 64, DUT_TO_REF);
             return 0;

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1374,6 +1374,17 @@ int Difftest::do_golden_memory_update() {
     dumpGoldenMem("Init", track_instr, cycleCnt);
   }
 
+#ifdef CONFIG_DIFFTEST_UNCACHEMMSTOREEVENT
+  for (int i = 0; i < CONFIG_DIFF_UNCACHE_MM_STORE_WIDTH; i++) {
+    if (dut->uncache_mm_store[i].valid) {
+      dut->uncache_mm_store[i].valid = 0;
+      update_goldenmem(dut->uncache_mm_store[i].addr, dut->uncache_mm_store[i].data, dut->uncache_mm_store[i].mask, 8);
+      if (dut->uncache_mm_store[i].addr == track_instr) {
+        dumpGoldenMem("Uncache MM Store", track_instr, cycleCnt);
+      }
+    }
+  }
+#endif // CONFIG_DIFFTEST_UNCACHEMMSTOREEVENT
 #ifdef CONFIG_DIFFTEST_SBUFFEREVENT
   for (int i = 0; i < CONFIG_DIFF_SBUFFER_WIDTH; i++) {
     if (dut->sbuffer[i].valid) {

--- a/src/test/csrc/difftest/goldenmem.cpp
+++ b/src/test/csrc/difftest/goldenmem.cpp
@@ -60,11 +60,14 @@ void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len, uint8_t
 }
 
 void read_goldenmem(uint64_t addr, void *data, uint64_t len) {
-  *(uint64_t *)data = paddr_read(addr, len);
+  read_goldenmem_with_flag(addr, data, NULL, len);
 }
 
-void read_goldenmem_flag(uint64_t addr, void *flag, uint64_t len) {
-  *(uint64_t *)flag = paddr_flag_read(addr, len);
+void read_goldenmem_with_flag(uint64_t addr, void *data, void *flag, uint64_t len) {
+  *(uint64_t *)data = paddr_read(addr, len);
+  if (flag != NULL) {
+    *(uint64_t *)flag = paddr_flag_read(addr, len);
+  }
 }
 
 bool in_pmem(uint64_t addr) {

--- a/src/test/csrc/difftest/goldenmem.cpp
+++ b/src/test/csrc/difftest/goldenmem.cpp
@@ -24,6 +24,7 @@
 #include <time.h>
 
 uint8_t *pmem;
+uint8_t *pmem_flag; // 1: store update but load check skip; 0: update and check. others: assert
 static uint64_t pmem_size;
 
 void *guest_to_host(uint64_t addr) {
@@ -33,6 +34,7 @@ void *guest_to_host(uint64_t addr) {
 void init_goldenmem() {
   pmem_size = simMemory->get_size();
   pmem = (uint8_t *)mmap(NULL, pmem_size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
+  pmem_flag = (uint8_t *)mmap(NULL, pmem_size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
   if (pmem == (uint8_t *)MAP_FAILED) {
     Info("ERROR allocating physical memory. \n");
   }
@@ -43,20 +45,26 @@ void init_goldenmem() {
 
 void goldenmem_finish() {
   munmap(pmem, pmem_size);
+  munmap(pmem_flag, pmem_size);
   pmem = NULL;
+  pmem_flag = NULL;
 }
 
-void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len) {
+void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len, uint8_t flag) {
   uint8_t *dataArray = (uint8_t *)data;
   for (int i = 0; i < len; i++) {
     if (((mask >> i) & 1) != 0) {
-      paddr_write(addr + i, dataArray[i], 1);
+      paddr_write(addr + i, dataArray[i], flag, 1);
     }
   }
 }
 
 void read_goldenmem(uint64_t addr, void *data, uint64_t len) {
   *(uint64_t *)data = paddr_read(addr, len);
+}
+
+void read_goldenmem_flag(uint64_t addr, void *flag, uint64_t len) {
+  *(uint64_t *)flag = paddr_flag_read(addr, len);
 }
 
 bool in_pmem(uint64_t addr) {
@@ -74,17 +82,34 @@ static inline word_t pmem_read(uint64_t addr, int len) {
   }
 }
 
-static inline void pmem_write(uint64_t addr, word_t data, int len) {
+static inline word_t pmem_flag_read(uint64_t addr, int len) {
+  void *p = &pmem_flag[addr - PMEM_BASE];
+  uint8_t *tmpArray = (uint8_t *)p;
+  for(int i = 0; i < len; i++) {
+    if (*(uint8_t *)(tmpArray + i) != 0 && *(uint8_t *)(tmpArray + i) != 1)
+      assert(0);
+  }
+  switch (len) {
+    case 1: return *(uint8_t *)p;
+    case 2: return *(uint16_t *)p;
+    case 4: return *(uint32_t *)p;
+    case 8: return *(uint64_t *)p;
+    default: assert(0);
+  }
+}
+
+static inline void pmem_write(uint64_t addr, word_t data, word_t flag, int len) {
 #ifdef DIFFTEST_STORE_COMMIT
   store_commit_queue_push(addr, data, len);
 #endif
 
   void *p = &pmem[addr - PMEM_BASE];
+  void *pf = &pmem_flag[addr - PMEM_BASE];
   switch (len) {
-    case 1: *(uint8_t *)p = data; return;
-    case 2: *(uint16_t *)p = data; return;
-    case 4: *(uint32_t *)p = data; return;
-    case 8: *(uint64_t *)p = data; return;
+    case 1: *(uint8_t *)p = data; *(uint8_t *)pf = flag; return;
+    case 2: *(uint16_t *)p = data; *(uint16_t *)pf = flag; return;
+    case 4: *(uint32_t *)p = data; *(uint32_t *)pf = flag; return;
+    case 8: *(uint64_t *)p = data; *(uint64_t *)pf = flag; return;
     default: assert(0);
   }
 }
@@ -95,6 +120,7 @@ static inline void pmem_write(uint64_t addr, word_t data, int len) {
 struct store_log {
   uint64_t addr;
   word_t org_data;
+  word_t org_flag;
 } goldenmem_store_log_buf[GOLDENMEM_STORE_LOG_SIZE];
 
 bool goldenmem_store_log_enable = false;
@@ -113,8 +139,10 @@ void pmem_record_store(uint64_t addr) {
     // align to 8 byte
     addr = (addr >> 3) << 3;
     word_t rdata = pmem_read(addr, 8);
+    word_t rflag = pmem_flag_read(addr, 8);
     goldenmem_store_log_buf[goldenmem_store_log_ptr].addr = addr;
     goldenmem_store_log_buf[goldenmem_store_log_ptr].org_data = rdata;
+    goldenmem_store_log_buf[goldenmem_store_log_ptr].org_flag = rflag;
     ++goldenmem_store_log_ptr;
     if (goldenmem_store_log_ptr >= GOLDENMEM_STORE_LOG_SIZE)
       assert(0);
@@ -123,7 +151,7 @@ void pmem_record_store(uint64_t addr) {
 
 void goldenmem_store_log_restore() {
   for (int i = goldenmem_store_log_ptr - 1; i >= 0; i--) {
-    pmem_write(goldenmem_store_log_buf[i].addr, goldenmem_store_log_buf[i].org_data, 8);
+    pmem_write(goldenmem_store_log_buf[i].addr, goldenmem_store_log_buf[i].org_data, goldenmem_store_log_buf[i].org_flag, 8);
   }
 }
 #endif // ENABLE_STORE_LOG
@@ -140,13 +168,23 @@ inline word_t paddr_read(uint64_t addr, int len) {
   return 0;
 }
 
-inline void paddr_write(uint64_t addr, word_t data, int len) {
+inline word_t paddr_flag_read(uint64_t addr, int len) {
+  if (in_pmem(addr))
+    return pmem_flag_read(addr, len);
+  else {
+    Info("[Hint] read not in pmem, maybe in speculative state! addr: %lx\n", addr);
+    return 0;
+  }
+  return 0;
+}
+
+inline void paddr_write(uint64_t addr, word_t data, word_t flag, int len) {
   if (in_pmem(addr)) {
 #ifdef ENABLE_STORE_LOG
     if (goldenmem_store_log_enable)
       pmem_record_store(addr);
 #endif // ENABLE_STORE_LOG
-    pmem_write(addr, data, len);
+    pmem_write(addr, data, flag, len);
   } else
     panic("write not in pmem!");
 }

--- a/src/test/csrc/difftest/goldenmem.cpp
+++ b/src/test/csrc/difftest/goldenmem.cpp
@@ -85,7 +85,7 @@ static inline word_t pmem_read(uint64_t addr, int len) {
 static inline word_t pmem_flag_read(uint64_t addr, int len) {
   void *p = &pmem_flag[addr - PMEM_BASE];
   uint8_t *tmpArray = (uint8_t *)p;
-  for(int i = 0; i < len; i++) {
+  for (int i = 0; i < len; i++) {
     if (*(uint8_t *)(tmpArray + i) != 0 && *(uint8_t *)(tmpArray + i) != 1)
       assert(0);
   }
@@ -106,10 +106,22 @@ static inline void pmem_write(uint64_t addr, word_t data, word_t flag, int len) 
   void *p = &pmem[addr - PMEM_BASE];
   void *pf = &pmem_flag[addr - PMEM_BASE];
   switch (len) {
-    case 1: *(uint8_t *)p = data; *(uint8_t *)pf = flag; return;
-    case 2: *(uint16_t *)p = data; *(uint16_t *)pf = flag; return;
-    case 4: *(uint32_t *)p = data; *(uint32_t *)pf = flag; return;
-    case 8: *(uint64_t *)p = data; *(uint64_t *)pf = flag; return;
+    case 1:
+      *(uint8_t *)p = data;
+      *(uint8_t *)pf = flag;
+      return;
+    case 2:
+      *(uint16_t *)p = data;
+      *(uint16_t *)pf = flag;
+      return;
+    case 4:
+      *(uint32_t *)p = data;
+      *(uint32_t *)pf = flag;
+      return;
+    case 8:
+      *(uint64_t *)p = data;
+      *(uint64_t *)pf = flag;
+      return;
     default: assert(0);
   }
 }
@@ -151,7 +163,8 @@ void pmem_record_store(uint64_t addr) {
 
 void goldenmem_store_log_restore() {
   for (int i = goldenmem_store_log_ptr - 1; i >= 0; i--) {
-    pmem_write(goldenmem_store_log_buf[i].addr, goldenmem_store_log_buf[i].org_data, goldenmem_store_log_buf[i].org_flag, 8);
+    pmem_write(goldenmem_store_log_buf[i].addr, goldenmem_store_log_buf[i].org_data,
+               goldenmem_store_log_buf[i].org_flag, 8);
   }
 }
 #endif // ENABLE_STORE_LOG

--- a/src/test/csrc/difftest/goldenmem.cpp
+++ b/src/test/csrc/difftest/goldenmem.cpp
@@ -59,11 +59,7 @@ void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len, uint8_t
   }
 }
 
-void read_goldenmem(uint64_t addr, void *data, uint64_t len) {
-  read_goldenmem_with_flag(addr, data, NULL, len);
-}
-
-void read_goldenmem_with_flag(uint64_t addr, void *data, void *flag, uint64_t len) {
+void read_goldenmem(uint64_t addr, void *data, uint64_t len, void *flag) {
   *(uint64_t *)data = paddr_read(addr, len);
   if (flag != NULL) {
     *(uint64_t *)flag = paddr_flag_read(addr, len);

--- a/src/test/csrc/difftest/goldenmem.h
+++ b/src/test/csrc/difftest/goldenmem.h
@@ -35,8 +35,7 @@ void init_goldenmem();
 void goldenmem_finish();
 
 extern "C" void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len, uint8_t flag = 0);
-extern "C" void read_goldenmem(uint64_t addr, void *data, uint64_t len);
-extern "C" void read_goldenmem_with_flag(uint64_t addr, void *data, void *flag, uint64_t len);
+extern "C" void read_goldenmem(uint64_t addr, void *data, uint64_t len, void *flag = NULL);
 
 /* convert the guest physical address in the guest program to host virtual address in NEMU */
 void *guest_to_host(uint64_t addr);

--- a/src/test/csrc/difftest/goldenmem.h
+++ b/src/test/csrc/difftest/goldenmem.h
@@ -34,9 +34,9 @@ extern uint8_t *pmem_flag;
 void init_goldenmem();
 void goldenmem_finish();
 
-extern "C" void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len, uint8_t flag);
+extern "C" void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len, uint8_t flag = 0);
 extern "C" void read_goldenmem(uint64_t addr, void *data, uint64_t len);
-extern "C" void read_goldenmem_flag(uint64_t addr, void *flag, uint64_t len);
+extern "C" void read_goldenmem_with_flag(uint64_t addr, void *data, void *flag, uint64_t len);
 
 /* convert the guest physical address in the guest program to host virtual address in NEMU */
 void *guest_to_host(uint64_t addr);

--- a/src/test/csrc/difftest/goldenmem.h
+++ b/src/test/csrc/difftest/goldenmem.h
@@ -20,6 +20,7 @@
 #include "common.h"
 #include "ram.h"
 #include <assert.h>
+#include <cstdint>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -28,12 +29,14 @@ typedef uint64_t uint64_t;
 typedef uint64_t word_t;
 
 extern uint8_t *pmem;
+extern uint8_t *pmem_flag;
 
 void init_goldenmem();
 void goldenmem_finish();
 
-extern "C" void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len);
+extern "C" void update_goldenmem(uint64_t addr, void *data, uint64_t mask, int len, uint8_t flag);
 extern "C" void read_goldenmem(uint64_t addr, void *data, uint64_t len);
+extern "C" void read_goldenmem_flag(uint64_t addr, void *flag, uint64_t len);
 
 /* convert the guest physical address in the guest program to host virtual address in NEMU */
 void *guest_to_host(uint64_t addr);
@@ -41,7 +44,8 @@ void *guest_to_host(uint64_t addr);
 uint64_t host_to_guest(void *addr);
 
 word_t paddr_read(uint64_t addr, int len);
-void paddr_write(uint64_t addr, word_t data, int len);
+word_t paddr_flag_read(uint64_t addr, int len);
+void paddr_write(uint64_t addr, word_t data, word_t flag, int len);
 bool is_sfence_safe(uint64_t addr, int len);
 bool in_pmem(uint64_t addr);
 


### PR DESCRIPTION
## single core
store: PBMT>0 but PMA=main-mem, this case needs to update the golden memory.


## multi core

However, due to bus transmission delays, the moment when core0 receives the uncache (main-mem store) grant fire may be later than the moment when the data becomes visible to other cores. At this point, it is uncertain whether core1 has performed a load between these two moments. If such a load occurs, core1 in the DUT will read the updated data, whereas goldenmem will still hold the previous data, leading to a difftest mismatch.

Since the timing of data visibility to other cores varies across different simulators/protocols, the solution here is to set a `flag` in advance.

Specifically, after core0 commits the "store" but before the store becomes visible, such as when core0 issues an uncache (main-mem store) acquire request, the goldenmem flag is set. In this case, if there is a inconsistency in read results between NEMU, golden, and DUT, but the flag is set to 1, the DUT result should be considered correct, and both NEMU and goldenmem should be updated accordingly.