### PR TITLE
fix(dpic): export DPIC for Palladium Z2 and vcs

### DIFF
--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -108,11 +108,11 @@ class ReplayControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |end
        |
        |// For the C/C++ interface
-       |export "DPI-C" task set_replay_head;
-       |task set_replay_head(int head);
+       |export "DPI-C" function set_replay_head;
+       |function set_replay_head(int head);
        |  replay = 1'b1;
        |  replay_head = head;
-       |endtask
+       |endfunction
        |`endif // DIFFTEST
        |`endif // SYNTHESIS
        |endmodule;

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -228,10 +228,10 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |end
        |
        |// For the C/C++ interface
-       |export "DPI-C" task set_squash_enable;
-       |task set_squash_enable(int en);
+       |export "DPI-C" function set_squash_enable;
+       |function set_squash_enable(int en);
        |  enable = en;
-       |endtask
+       |endfunction
        |`endif // DIFFTEST
        |`endif // SYNTHESIS
        |

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -349,7 +349,7 @@ void simv_finish() {
 static uint8_t simv_result = SIMV_RUN;
 #ifdef CONFIG_DIFFTEST_DEFERRED_RESULT
 extern "C" void simv_nstep(uint8_t step) {
-  if (simv_result == SIMV_FAIL || difftest == NULL)
+  if (simv_result == SIMV_DONE || simv_result == SIMV_FAIL || difftest == NULL)
     return;
 #else
 extern "C" uint8_t simv_nstep(uint8_t step) {

--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -12,14 +12,15 @@ module DeferredControl(
 
 import "DPI-C" context function void set_deferred_result_scope();
 
+reg [7:0] _res;
 initial begin
   set_deferred_result_scope();
-  simv_result = 8'b0;
+  _res = 8'b0;
 end
 
 export "DPI-C" function set_deferred_result;
 function void set_deferred_result(byte result);
-  simv_result = result;
+  _res = result;
 endfunction
 
 `ifdef PALLADIUM
@@ -28,22 +29,27 @@ initial $ixc_ctrl("sfifo", "set_deferred_result");
 
 `ifndef CONFIG_DIFFTEST_INTERNAL_STEP
 import "DPI-C" function void simv_nstep(int step);
-
 `ifdef CONFIG_DIFFTEST_NONBLOCK
 `ifdef PALLADIUM
 initial $ixc_ctrl("gfifo", "simv_nstep");
 `endif // PALLADIUM
 `endif // CONFIG_DIFFTEST_NONBLOCK
+`endif // CONFIG_DIFFTEST_INTERNAL_STEP
+
 
 always @(posedge clock) begin
   if (reset) begin
     simv_result <= 8'b0;
   end
-  else if (step != 0) begin
-    simv_nstep(step);
+  else begin
+    simv_result <= _res;
+`ifndef CONFIG_DIFFTEST_INTERNAL_STEP
+    if (step != 0) begin
+      simv_nstep(step);
+    end
+`endif // CONFIG_DIFFTEST_INTERNAL_STEP
   end
 end
-`endif // CONFIG_DIFFTEST_INTERNAL_STEP
 
 endmodule;
 `endif // CONFIG_DIFFTEST_DEFERRED_RESULT


### PR DESCRIPTION
This change move all export DPI-C task to function for Palladim Z2. We also add a reg for result setting from software, avoid multi-driver for simv_result, thus we can enable nonBlock for vcs.