### PR TITLE
fix(intr): add interrupt delegate

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -59,6 +59,8 @@ class ArchEvent extends DifftestBaseBundle with HasValid {
   val exceptionInst = UInt(32.W)
   val hasNMI = Bool()
   val virtualInterruptIsHvictlInject = Bool()
+  val irToHS = Bool()
+  val irToVS = Bool()
 }
 
 class InstrCommit(val numPhyRegs: Int = 32) extends DifftestBaseBundle with HasValid {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -467,6 +467,10 @@ void Difftest::do_interrupt() {
   } else if (dut->event.virtualInterruptIsHvictlInject) {
     proxy->virtual_interrupt_is_hvictl_inject(dut->event.virtualInterruptIsHvictlInject);
   }
+  struct InterruptDelegate intrDeleg;
+  intrDeleg.irToHS = dut->event.irToHS;
+  intrDeleg.irToVS = dut->event.irToVS;
+  proxy->intr_delegate(intrDeleg);
   proxy->raise_intr(dut->event.interrupt | (1ULL << 63));
   progress = true;
 }

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -147,6 +147,7 @@ public:
   f(ref_memcpy_init, difftest_memcpy_init, void, uint64_t, void*, size_t, bool)                             \
   f(raise_nmi_intr, difftest_raise_nmi_intr, void, bool)                                                    \
   f(ref_virtual_interrupt_is_hvictl_inject, difftest_virtual_interrupt_is_hvictl_inject, void, bool)        \
+  f(ref_interrupt_delegate, difftest_interrupt_delegate, void, void*)                                    \
   f(disambiguation_state, difftest_disambiguation_state, int, )                                             \
   f(ref_non_reg_interrupt_pending, difftest_non_reg_interrupt_pending, void, void*)                         \
   f(raise_mhpmevent_overflow, difftest_raise_mhpmevent_overflow, void, uint64_t)                            \
@@ -265,6 +266,12 @@ public:
       ref_virtual_interrupt_is_hvictl_inject(virtualInterruptIsHvictlInject);
     } else {
       Info("Virtual interrupt without hvictl register injection.\n");
+    }
+  }
+
+  inline void intr_delegate(struct InterruptDelegate &intrDeleg) {
+    if (ref_interrupt_delegate) {
+      ref_interrupt_delegate(&intrDeleg);
     }
   }
 
@@ -467,6 +474,11 @@ struct FromAIA {
   uint64_t stopei;
   uint64_t vstopei;
   uint64_t hgeip;
+};
+
+struct InterruptDelegate {
+  bool irToHS;
+  bool irToVS;
 };
 
 extern const char *difftest_ref_so;


### PR DESCRIPTION
* Since NEMU does not have AIA, a set of signals are added to tell NEMU which mode to delegate interrupt processing to.