### PR TITLE
fix(difftest): fix alignment for C++ type declarations

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -48,8 +48,8 @@ sealed trait DifftestBaseBundle extends Bundle {
   }
 }
 
-class DeltaElem(elemBytes: Int) extends DifftestBaseBundle {
-  val data = UInt((elemBytes * 8).W)
+class DeltaElem(elemWidth: Int) extends DifftestBaseBundle {
+  val data = UInt(elemWidth.W)
 }
 
 class ArchEvent extends DifftestBaseBundle with HasValid {

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -235,7 +235,7 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
     }
     unpack += getPacketDecl(gen, "", config)
     val size = if (config.isDelta && gen.isDeltaElem) {
-      s"sizeof(uint${gen.deltaElemBytes * 8}_t)"
+      s"sizeof(uint${gen.deltaElemWidth}_t)"
     } else {
       s"sizeof(${gen.desiredModuleName})"
     }

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -38,7 +38,7 @@ object Delta {
     val deltaInsts = instances.filter(_.supportsDelta).distinct
     val deltaDecl = deltaInsts.map { inst =>
       val len = inst.dataElements.flatMap(_._3).length
-      val elemType = s"uint${inst.deltaElemBytes * 8}_t"
+      val elemType = s"uint${inst.deltaElemWidth}_t"
       s"$elemType ${inst.desiredCppName}_elem[$len];"
     }
 

--- a/src/main/scala/util/Query.scala
+++ b/src/main/scala/util/Query.scala
@@ -110,7 +110,7 @@ class QueryTable(val gen: DifftestBundle, locPrefix: String) {
        |  }
        |""".stripMargin
   val initInvoke = s"${tableName}_init();"
-  val packetType = if (gen.isDeltaElem) s"uint${gen.deltaElemBytes * 8}_t" else gen.desiredModuleName
+  val packetType = if (gen.isDeltaElem) s"uint${gen.deltaElemWidth}_t" else gen.desiredModuleName
   val writeDecl =
     s"""
        |  void ${tableName}_write(${locArgs.map("uint8_t " + _._2).mkString(", ")}, ${packetType}* packet) {


### PR DESCRIPTION
When generating `arrayType`, not all 8-bit-aligned types are valid in C++.

For example, if someone defines a 41-bit-wide signal, it may result in generating an unsupported C++ type like uint48_t instead of a valid uint64_t.

This change ensures that for any given bit width, a C++-supported type is generated.