### PR TITLE
chore: place init_flash after init_core

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -377,8 +377,6 @@ Emulator::Emulator(int argc, const char *argv[])
   if (enable_simjtag) {
     jtag_init();
   }
-  // init flash
-  init_flash(args.flash_bin);
 
 #if VM_TRACE == 1
   if (args.enable_waveform) {
@@ -400,6 +398,9 @@ Emulator::Emulator(int argc, const char *argv[])
 
   // init core
   reset_ncycles(args.reset_cycles);
+
+  // init flash
+  init_flash(args.flash_bin);
 
   // init ram
   uint64_t ram_size = DEFAULT_EMU_RAM_SIZE;


### PR DESCRIPTION
First, this does not introduce any functional changes.

Second, the reason for this modification is that with the introduction of https://github.com/OpenXiangShan/XiangShan/pull/4626, the simulation output includes some less elegant messages:

> Using simulated 32768B flash
> Core  0's Commit SHA is: 6683fc49ec, dirty: 1
> Using simulated 8386560MB RAM

This change makes the output look better.