### PR TITLE
feat(exception): add hardware error exception

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -477,8 +477,8 @@ void Difftest::do_interrupt() {
 
 void Difftest::do_exception() {
   state->record_exception(dut->event.exceptionPC, dut->event.exceptionInst, dut->event.exception);
-  if (dut->event.exception == 12 || dut->event.exception == 13 || dut->event.exception == 15 ||
-      dut->event.exception == 20 || dut->event.exception == 21 || dut->event.exception == 23) {
+  if (dut->event.exception == EX_IPF || dut->event.exception == EX_LPF || dut->event.exception == EX_SPF ||
+      dut->event.exception == EX_IGPF || dut->event.exception == EX_LGPF || dut->event.exception == EX_SGPF) {
     struct ExecutionGuide guide;
     guide.force_raise_exception = true;
     guide.exception_num = dut->event.exception;
@@ -491,6 +491,8 @@ void Difftest::do_exception() {
 #endif // CONFIG_DIFFTEST_HCSRSTATE
     guide.force_set_jump_target = false;
     proxy->guided_exec(guide);
+  } else if (dut->event.exception == EX_HWE) {
+    proxy->raise_intr(dut->event.exception);
   } else {
 #ifdef DEBUG_MODE_DIFF
     if (DEBUG_MEM_REGION(true, dut->event.exceptionPC)) {

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -30,6 +30,33 @@
 #endif // FUZZING
 
 enum {
+  EX_IAM,       // instruction address misaligned
+  EX_IAF,       // instruction address fault
+  EX_II,        // illegal instruction
+  EX_BP,        // breakpoint
+  EX_LAM,       // load address misaligned
+  EX_LAF,       // load address fault
+  EX_SAM,       // store/amo address misaligned
+  EX_SAF,       // store/amo address fault
+  EX_ECU,       // ecall from U-mode or VU-mode
+  EX_ECS,       // ecall from HS-mode
+  EX_ECVS,      // ecall from VS-mode, H-extention
+  EX_ECM,       // ecall from M-mode
+  EX_IPF,       // instruction page fault
+  EX_LPF,       // load page fault
+  EX_RS0,       // reserved
+  EX_SPF,       // store/amo page fault
+  EX_DT,        // double trap
+  EX_RS1,       // reserved
+  EX_SWC,       // software check
+  EX_HWE,       // hardware error
+  EX_IGPF = 20, // instruction guest-page fault, H-extention
+  EX_LGPF,      // load guest-page fault, H-extention
+  EX_VI,        // virtual instruction, H-extention
+  EX_SGPF       // store/amo guest-page fault, H-extention
+};
+
+enum {
   ICACHEID,
   DCACHEID,
   PAGECACHEID


### PR DESCRIPTION
  * Since the hardware error exception can only be generated by XiangShan, it can be handled similarly to an interrupt — by directly forcing NEMU to trigger the corresponding exception handler.