### PR TITLE
FPGA: expose IO with finishFPGA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -334,6 +334,6 @@ jobs:
       - name: FPGA-difftest Build
         run: |
             cd $NOOP_HOME
-            make sim-verilog MILL_ARGS="--difftest-config SF" -j2
+            make sim-verilog MILL_ARGS="--difftest-config ESBIDF" -j2
             cd ./difftest
             make fpga-build FPGA=1

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -292,7 +292,6 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
            |  enum DifftestBundleType {
            |  ${bundleEnum.mkString(",\n  ")}
            |  };
-           |  extern void simv_nstep(uint8_t step);
            |  static int dut_index = 0;
            |  $batchDecl
            |  for (int i = 0; i < $infoLen; i++) {
@@ -301,7 +300,13 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
            |    uint32_t coreid, index, address;
            |    if (id == BatchFinish) {
            |#ifdef CONFIG_DIFFTEST_INTERNAL_STEP
+           |#ifdef CONFIG_PLATFORM_FPGA
+           |      extern void fpga_nstep(uint8_t step);
+           |      fpga_nstep(num);
+           |#else
+           |      extern void simv_nstep(uint8_t step);
            |      simv_nstep(num);
+           |#endif // CONFIG_PLATFORM_FPGA
            |#endif // CONFIG_DIFFTEST_INTERNAL_STEP
            |      break;
            |    }

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -20,7 +20,7 @@ import chisel3._
 import chisel3.reflect.DataMirror
 import chisel3.util._
 import difftest.common.{DifftestWiring, FileControl}
-import difftest.gateway.{Gateway, GatewayConfig}
+import difftest.gateway.{FpgaDiffIO, Gateway, GatewayConfig, GatewayResult}
 import difftest.util.Profile
 
 import scala.annotation.tailrec
@@ -541,9 +541,8 @@ object DifftestModule {
 
   def get_current_interfaces(): Seq[(DifftestBundle, Int)] = interfaces.toSeq
 
-  def finish(cpu: String, createTopIO: Boolean): Option[DifftestTopIO] = {
+  def collect(cpu: String): GatewayResult = {
     val gateway = Gateway.collect()
-
     generateCppHeader(
       cpu,
       gateway.instances,
@@ -556,7 +555,19 @@ object DifftestModule {
     }
     generateVeriogHeader(gateway.vMacros)
     Profile.generateJson(cpu, interfaces.toSeq)
+    gateway
+  }
 
+  def finishFPGA(cpu: String): FpgaDiffIO = {
+    val gateway = collect(cpu)
+    val fpgaIO = gateway.fpgaIO.get
+    val io = IO(Output(chiselTypeOf(fpgaIO)))
+    io := fpgaIO
+    io
+  }
+
+  def finish(cpu: String, createTopIO: Boolean): Option[DifftestTopIO] = {
+    val gateway = collect(cpu)
     Option.when(createTopIO) {
       if (enabled) {
         createTopIOs(gateway.exit, gateway.step)

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -106,7 +106,7 @@ void fpga_finish() {
   simMemory = nullptr;
 }
 
-void fpga_nstep(uint8_t step) {
+extern "C" void fpga_nstep(uint8_t step) {
   for (int i = 0; i < step; i++) {
     fpga_step();
   }


### PR DESCRIPTION
This change expose FPGA IO with finishFPGA, enabling us to wrap both DUT, Difftest, and changing DiffTestBundle Interface within the same wrapper. Only the output of Batch, with width declared at DifftestMacros.v, will be exposed to FPGA.