### PR TITLE
fix(XDMA): align malloc to 4K Byte for DMA receiving

### DIFF
--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -156,7 +156,7 @@ void FpgaXdma::stop_thansmit_thread() {
 }
 
 void FpgaXdma::read_xdma_thread(int channel) {
-  FpgaPackgeHead *packge = (FpgaPackgeHead *)malloc(sizeof(FpgaPackgeHead));
+  FpgaPackgeHead *packge = (FpgaPackgeHead *)posix_memalignd_malloc(sizeof(FpgaPackgeHead));
   memset(packge, 0, sizeof(FpgaPackgeHead));
   while (running) {
     size_t size = read(xdma_c2h_fd[channel], packge, sizeof(FpgaPackgeHead));

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -74,6 +74,16 @@ public:
 
   void device_write(bool is_bypass, const char *workload, uint64_t addr, uint64_t value);
 
+  void *posix_memalignd_malloc(size_t size) {
+    void *ptr = nullptr;
+    int ret = posix_memalign(&ptr, 4096, size);
+    if (ret != 0) {
+      perror("posix_memalign failed");
+      return nullptr;
+    }
+    return ptr;
+  }
+
   // thread api
   void start_transmit_thread();
   void stop_thansmit_thread();


### PR DESCRIPTION
The posix_memalign request for the xdma data accept area can fix the local data offset bug in the data packet, which may be caused by the DMA requiring 4K alignment memory