### PR TITLE
refactor(difftest): reuse common nstep logic for emu/simv/fpga

### DIFF
--- a/src/test/csrc/common/perf.cpp
+++ b/src/test/csrc/common/perf.cpp
@@ -44,11 +44,8 @@ void difftest_perfcnt_finish(uint64_t cycleCnt) {
   diffstate_perfcnt_finish(perf_run_msec);
   printf(">>> Other Difftest Func\n");
   const char *func_name[DIFFTEST_PERF_NUM] = {
-#ifndef CONFIG_DIFFTEST_INTERNAL_STEP
-    "simv_nstep",
-#endif // CONFIG_DIFFTEST_INTERNAL_STEP
-    "difftest_ram_read", "difftest_ram_write", "flash_read", "sd_set_addr", "sd_read",
-    "jtag_tick",         "put_pixel",          "vmem_sync",  "pte_helper",  "amo_helper",
+    "difftest_nstep", "difftest_ram_read", "difftest_ram_write", "flash_read", "sd_set_addr", "sd_read",
+    "jtag_tick",      "put_pixel",         "vmem_sync",          "pte_helper", "amo_helper",
   };
   for (int i = 0; i < DIFFTEST_PERF_NUM; i++) {
     difftest_perfcnt_print(func_name[i], difftest_calls[i], difftest_bytes[i], perf_run_msec);

--- a/src/test/csrc/common/perf.h
+++ b/src/test/csrc/common/perf.h
@@ -27,9 +27,7 @@ static inline void difftest_perfcnt_print(const char *name, long long calls, lon
 void difftest_perfcnt_init();
 void difftest_perfcnt_finish(uint64_t cycleCnt);
 enum DIFFTEST_PERF {
-#ifndef CONFIG_DIFFTEST_INTERNAL_STEP
-  perf_simv_nstep,
-#endif // CONFIG_DIFFTEST_INTERNAL_STEP
+  perf_difftest_nstep,
   perf_difftest_ram_read,
   perf_difftest_ram_write,
   perf_flash_read,

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -68,10 +68,15 @@ int difftest_state() {
       return difftest[i]->proxy->get_status();
     }
   }
-  return -1;
+  return STATE_RUNNING;
 }
 
 int difftest_nstep(int step, bool enable_diff) {
+#ifdef CONFIG_DIFFTEST_PERFCNT
+  difftest_calls[perf_difftest_nstep]++;
+  difftest_bytes[perf_difftest_nstep] += 1;
+#endif // CONFIG_DIFFTEST_PERFCNT
+
 #if CONFIG_DIFFTEST_ZONESIZE > 1
   difftest_switch_zone();
 #endif // CONFIG_DIFFTEST_ZONESIZE
@@ -1703,6 +1708,17 @@ void Difftest::display_stats() {
   uint64_t cycleCnt = trap->cycleCnt;
   double ipc = (double)instrCnt / cycleCnt;
   Info(ANSI_COLOR_MAGENTA "Core-%d instrCnt = %'" PRIu64 ", cycleCnt = %'" PRIu64 ", IPC = %lf\n" ANSI_COLOR_RESET,
+       this->id, instrCnt, cycleCnt, ipc);
+}
+
+// API for soft warmup, display final instr/cycle - warmup instr/cycle
+void Difftest::warmup_display_stats() {
+  auto trap = get_trap_event();
+  uint64_t instrCnt = trap->instrCnt - warmup_info.instrCnt;
+  uint64_t cycleCnt = trap->cycleCnt - warmup_info.cycleCnt;
+  double ipc = (double)instrCnt / cycleCnt;
+  Info(ANSI_COLOR_MAGENTA "Core-%d(Soft Warmup) instrCnt = %'" PRIu64 ", cycleCnt = %'" PRIu64
+                          ", IPC = %lf\n" ANSI_COLOR_RESET,
        this->id, instrCnt, cycleCnt, ipc);
 }
 

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -181,6 +181,11 @@ public:
   }
 };
 
+typedef struct {
+  uint64_t instrCnt;
+  uint64_t cycleCnt;
+} WarmupInfo;
+
 class DiffState {
 public:
   bool dump_commit_trace = false;
@@ -242,6 +247,7 @@ public:
   REF_PROXY *proxy = NULL;
   uint32_t num_commit = 0; // # of commits if made progress
   bool has_commit = false;
+  WarmupInfo warmup_info;
   // Trigger a difftest checking procdure
   int step();
   void update_nemuproxy(int, size_t);
@@ -315,6 +321,13 @@ public:
   void set_commit_trace(bool enable) {
     state->dump_commit_trace = enable;
   }
+
+  void warmup_record() {
+    auto trap = get_trap_event();
+    warmup_info.instrCnt = trap->instrCnt;
+    warmup_info.cycleCnt = trap->cycleCnt;
+  }
+  void warmup_display_stats();
 
 protected:
   DiffTrace<DiffTestState> *difftrace = nullptr;


### PR DESCRIPTION
Previously, we use various difftest/simv/fpga_nstep functions for Verilator/VCS/FPGA, resulting in duplicated code and inconsistent simulation conditions.

For example, in the multi-core scenario, VCS/FPGA warmedup and exceed at the same number of instructions for each core, while Verilator warmup and exceed when a certain core reaching instrs.

This change reuse the common difftest_nstep as the comparison logic and aligned the simulation conditions of VCS/FPGA with those of Verilator.

We also the issues of VCS where SIMV_WARMUP did not return correctly to DUT and where the number of instructions was calculated incorrectly during soft warmup.