### PR TITLE
FPGA: send multiple packets within single xdma request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -337,3 +337,5 @@ jobs:
             make sim-verilog MILL_ARGS="--difftest-config ESBIDF" -j2
             cd ./difftest
             make fpga-build FPGA=1
+            make fpga-clean
+            make fpga-build FPGA=1 USE_THREAD_MEMPOOL=1

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -171,11 +171,13 @@ void FpgaXdma::read_xdma_thread(int channel) {
   memset(packge, 0, sizeof(FpgaPackgeHead));
   while (running) {
     size_t size = read(xdma_c2h_fd[channel], packge, sizeof(FpgaPackgeHead));
+    for (size_t i = 0; i < DMA_PACKGE_NUM; i++) {
 #ifdef CONFIG_DIFFTEST_BATCH
-    v_difftest_Batch(packge->diff_packge);
+      v_difftest_Batch(packge->diff_packge[i].diff_packge);
 #elif defined(CONFIG_DIFFTEST_SQUASH)
-    //TODO: need automatically generates squash data parsing implementations
+      //TODO: need automatically generates squash data parsing implementations
 #endif // CONFIG_DIFFTEST_BATCH
+    }
   }
   free(packge);
 #endif // USE_THREAD_MEMPOOL
@@ -191,17 +193,19 @@ void FpgaXdma::write_difftest_thread() {
       printf("Failed to read data from the XDMA memory pool\n");
       assert(0);
     }
-    if (packge->idx != recv_count) {
-      printf("read mempool idx failed, packge_idx %d need_idx %d\n", packge->idx, recv_count);
+    if (packge->diff_packge[0].packge_idx != recv_count) {
+      printf("read mempool idx failed, packge_idx %d need_idx %d\n", packge->diff_packge[0].packge_idx, recv_count);
       assert(0);
     }
-    recv_count++;
     // packge unpack
+    for (size_t i = 0; i < DMA_PACKGE_NUM; i++) {
+      recv_count++;
 #ifdef CONFIG_DIFFTEST_BATCH
-    v_difftest_Batch(packge->diff_packge);
+      v_difftest_Batch(packge->diff_packge[i].diff_packge);
 #elif defined(CONFIG_DIFFTEST_SQUASH)
-    //TODO: need automatically generates squash data parsing implementations
+      //TODO: need automatically generates squash data parsing implementations
 #endif
+    }
     xdma_mempool.set_free_chunk();
   }
 }

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -33,15 +33,21 @@
 #elif defined(CONFIG_DIFFTEST_SQUASH)
 #define DMA_DIFF_PACKGE_LEN 1280 // XDMA Min size
 #endif
+#define DMA_PACKGE_NUM 8
+
 // DMA_PADDING (packge_idx(1) + difftest_data) send width to be calculated by mod up
 #define DMA_PADDING (((1 + DMA_DIFF_PACKGE_LEN + 63) / 64) * 64 - (DMA_DIFF_PACKGE_LEN + 1))
 
 typedef struct __attribute__((packed)) {
-  uint8_t idx;
+  uint8_t packge_idx; // idx of header packet is valid and idx of intermediate data is placeholder
   uint8_t diff_packge[DMA_DIFF_PACKGE_LEN];
-#if (DMA_PADDING != 0)
+#if (DMA_PADDING > 0)
   uint8_t padding[DMA_PADDING];
 #endif
+} DmaDiffPackge;
+
+typedef struct __attribute__((packed)) {
+  DmaDiffPackge diff_packge[DMA_PACKGE_NUM];
 } FpgaPackgeHead;
 
 class FpgaXdma {


### PR DESCRIPTION
Through this optimization, the bandwidth of PCIE is improved, which will improve the running speed of Xiangshan processor in FPGA difftest from 200K to 400~500K