### PR TITLE
FPGA: support simulate fpga-host with dut

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -331,11 +331,20 @@ jobs:
             cd NutShell && rm -rf difftest && cp -r $GITHUB_WORKSPACE .
             echo "NOOP_HOME=$(pwd)" >> $GITHUB_ENV
 
-      - name: FPGA-difftest Build
+      - name: FPGA-difftest Build (no THREAD, no ASYNC_CLK)
         run: |
             cd $NOOP_HOME
             make sim-verilog MILL_ARGS="--difftest-config ESBIDF" -j2
-            cd ./difftest
-            make fpga-build FPGA=1
-            make fpga-clean
-            make fpga-build FPGA=1 USE_THREAD_MEMPOOL=1
+            make -C difftest fpga-build FPGA=1 FPGA_SIM=1
+            make simv VCS=verilator WITH_CHISELDB=0 WITH_CONSTANTIN=0 FPGA_SIM=1
+            bash difftest/scripts/fpga_sim/ci.sh
+            make -C difftest fpga-clean vcs-clean
+
+      - name: FPGA-difftest Build (with THREAD and ASYNC_CLK)
+        run: |
+            cd $NOOP_HOME
+            make sim-verilog MILL_ARGS="--difftest-config ESBIDF" -j2
+            make -C difftest fpga-build FPGA=1 FPGA_SIM=1 USE_THREAD_MEMPOOL=1
+            make simv VCS=verilator WITH_CHISELDB=0 WITH_CONSTANTIN=0 FPGA_SIM=1 ASYNC_CLK_2N=1
+            bash difftest/scripts/fpga_sim/ci.sh
+            make -C difftest fpga-clean vcs-clean

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ SIM_CXXFLAGS += -DCONFIG_NO_DIFFTEST
 else
 SIM_CXXFILES += $(DIFFTEST_CXXFILES)
 SIM_CXXFLAGS += -I$(DIFFTEST_CSRC_DIR)
+SIM_VFLAGS   += +define+DIFFTEST
 ifeq ($(DIFFTEST_PERFCNT), 1)
 SIM_CXXFLAGS += -DCONFIG_DIFFTEST_PERFCNT
 endif
@@ -99,6 +100,32 @@ SIM_CXXFLAGS += -DCONFIG_DIFFTEST_QUERY
 SIM_LDFLAGS  += -lsqlite3
 endif
 endif
+
+ifeq ($(SYNTHESIS), 1)
+SIM_VFLAGS   += +define+SYNTHESIS +define+TB_NO_DPIC
+else
+ifeq ($(DISABLE_DIFFTEST_RAM_DPIC), 1)
+SIM_VFLAGS   += +define+DISABLE_DIFFTEST_RAM_DPIC
+endif
+ifeq ($(DISABLE_DIFFTEST_FLASH_DPIC), 1)
+SIM_VFLAGS   += +define+DISABLE_DIFFTEST_FLASH_DPIC
+endif
+endif
+
+# FPGA DiffTest Simulate Support
+ifeq ($(FPGA_SIM), 1)
+FPGA_SIM_CSRC_DIR = $(abspath ./src/test/csrc/fpga_sim)
+FPGA_SIM_VSRC_DIR = $(abspath ./src/test/vsrc/fpga_sim)
+SIM_CXXFILES += $(shell find $(FPGA_SIM_CSRC_DIR) -name "*.cpp")
+SIM_CXXFLAGS += -I$(FPGA_SIM_CSRC_DIR) -DFPGA_SIM
+SIM_LDFLAGS  += -lrt
+SIM_VFLAGS   += +define+FPGA_SIM
+SIM_VSRC     += $(shell find $(FPGA_SIM_VSRC_DIR) -name "*.v" -or -name "*.sv")
+ifneq ($(ASYNC_CLK_2N), )
+SIM_VFLAGS   += +define+ASYNC_CLK_2N=$(ASYNC_CLK_2N)
+endif
+endif
+
 
 # ChiselDB
 WITH_CHISELDB ?= 1

--- a/fpga.mk
+++ b/fpga.mk
@@ -3,7 +3,7 @@ FPGA_CSRC_DIR   = $(abspath ./src/test/csrc/fpga)
 FPGA_CONFIG_DIR = $(abspath ./config) # Reserve storage for xdma configuration
 
 FPGA_CXXFILES  = $(SIM_CXXFILES) $(shell find $(FPGA_CSRC_DIR) -name "*.cpp")
-FPGA_CXXFLAGS  = $(subst \\\",\", $(SIM_CXXFLAGS)) -I$(FPGA_CSRC_DIR) -O3 -DCONFIG_DMA_CHANNELS=$(DMA_CHANNELS) -DNUM_CORES=$(NUM_CORES) -DCONFIG_PLATFORM_FPGA 
+FPGA_CXXFLAGS  = $(subst \\\",\", $(SIM_CXXFLAGS)) -I$(FPGA_CSRC_DIR) -O3 -DCONFIG_DMA_CHANNELS=$(DMA_CHANNELS) -DNUM_CORES=$(NUM_CORES) -DCONFIG_PLATFORM_FPGA
 FPGA_LDFLAGS   = $(SIM_LDFLAGS) -lpthread -ldl
 
 DMA_CHANNELS ?= 1

--- a/palladium.mk
+++ b/palladium.mk
@@ -5,30 +5,20 @@ PLDM_SCRIPTS_DIR 	 = $(abspath ./scripts/palladium)
 PLDM_BUILD_DIR 		 = $(abspath $(BUILD_DIR)/pldm-compile)
 PLDM_CC_OBJ_DIR	 	 = $(abspath $(PLDM_BUILD_DIR)/cc_obj)
 
-# Macro Flags
-PLDM_MACRO_FLAGS  	 = +define+TOP_MODULE=$(PLDM_TOP_MODULE)
-PLDM_MACRO_FLAGS 	+= +define+PALLADIUM
-PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_MEM_INIT
-PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_REG_INIT
-PLDM_MACRO_FLAGS 	+= +define+RANDOMIZE_DELAY=0
-ifeq ($(SYNTHESIS), 1)
-PLDM_MACRO_FLAGS 	+= +define+SYNTHESIS +define+TB_NO_DPIC
-else
-PLDM_MACRO_FLAGS 	+= +define+DIFFTEST +define+DISABLE_SIMJTAG_DPIC
-ifneq ($(DIFFTEST_RAM_DPIC), 1)
-PLDM_MACRO_FLAGS 	+= +define+DISABLE_DIFFTEST_RAM_DPIC
-endif
-ifneq ($(DIFFTEST_FLASH_DPIC), 1)
-PLDM_MACRO_FLAGS 	+= +define+DISABLE_DIFFTEST_FLASH_DPIC
-endif
-endif
-PLDM_MACRO_FLAGS 	+= $(PLDM_EXTRA_MACRO)
+# Verilog Flags
+PLDM_VFLAGS 	 = $(SIM_VFLAGS) +define+TOP_MODULE=$(PLDM_TOP_MODULE)
+PLDM_VFLAGS 	+= +define+PALLADIUM
+PLDM_VFLAGS 	+= +define+RANDOMIZE_MEM_INIT
+PLDM_VFLAGS 	+= +define+RANDOMIZE_REG_INIT
+PLDM_VFLAGS 	+= +define+RANDOMIZE_DELAY=0
+PLDM_VFLAGS 	+= +define+DISABLE_SIMJTAG_DPIC
+PLDM_VFLAGS 	+= $(PLDM_EXTRA_MACRO)
 
 ifeq ($(WORKLOAD_SWITCH),1)
-PLDM_MACRO_FLAGS  	+= +define+ENABLE_WORKLOAD_SWITCH
+PLDM_VFLAGS  	+= +define+ENABLE_WORKLOAD_SWITCH
 endif
 ifeq ($(WITH_DRAMSIM3),1)
-PLDM_MACRO_FLAGS  	+= +define+WITH_DRAMSIM3
+PLDM_VFLAGS  	+= +define+WITH_DRAMSIM3
 endif
 
 # UA Args
@@ -43,7 +33,7 @@ endif
 IXCOM_FLAGS 	+= -xecompile compilerOptions=$(PLDM_SCRIPTS_DIR)/compilerOptions.qel
 IXCOM_FLAGS 	+= +gfifoDisp+tb_top
 IXCOM_FLAGS 	+= $(addprefix -incdir , $(PLDM_VSRC_DIR))
-IXCOM_FLAGS 	+= $(PLDM_MACRO_FLAGS)
+IXCOM_FLAGS 	+= $(PLDM_VFLAGS)
 IXCOM_FLAGS 	+= +dut+$(PLDM_TB_TOP)
 ifeq ($(SYNTHESIS), 1)
 PLDM_CLOCK	 = clock_gen
@@ -69,7 +59,7 @@ ifneq ($(SYNTHESIS), 1)
 VLAN_FLAGS 	 = -64 -sv
 VLAN_FLAGS 	+= $(addprefix -incdir , $(PLDM_VSRC_DIR))
 VLAN_FLAGS	+= -vtimescale 1ns/1ns
-VLAN_FLAGS 	+= $(PLDM_MACRO_FLAGS)
+VLAN_FLAGS 	+= $(PLDM_VFLAGS)
 VLAN_FLAGS 	+= -F $(PLDM_VFILELIST)
 endif
 

--- a/scripts/fpga_sim/ci.sh
+++ b/scripts/fpga_sim/ci.sh
@@ -1,0 +1,17 @@
+set -e  # exit when some command failed
+set -o pipefail
+
+./build/fpga-host --diff ready-to-run/riscv64-nemu-interpreter-so -i ready-to-run/microbench.bin &
+HOST_PID=$!
+
+sleep 2
+
+./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so & #> build/try.txt 2>&1 &
+SIMV_PID=$!
+
+wait $HOST_PID
+HOST_EXIT_CODE=$?
+
+kill -9 $SIMV_PID
+
+exit $HOST_EXIT_CODE

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -143,12 +143,14 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
          |);
          |`ifndef SYNTHESIS
          |`ifdef DIFFTEST
+         |`ifndef FPGA_SIM
          |$dpicDecl
          |$gfifoInitial
          |  always @(posedge clock) begin
          |    if (enable)
          |      $dpicFuncName (${dpicFuncArgs.flatten.map(_._1).mkString(", ")});
          |  end
+         |`endif
          |`endif
          |`endif
          |endmodule

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -20,7 +20,7 @@ import chisel3._
 import chisel3.reflect.DataMirror
 import chisel3.util._
 import difftest.common.{DifftestWiring, FileControl}
-import difftest.gateway.{FpgaDiffIO, Gateway, GatewayConfig, GatewayResult}
+import difftest.gateway.{Gateway, GatewayConfig, GatewayResult}
 import difftest.util.Profile
 
 import scala.annotation.tailrec
@@ -558,16 +558,13 @@ object DifftestModule {
     gateway
   }
 
-  def finishFPGA(cpu: String): FpgaDiffIO = {
-    val gateway = collect(cpu)
-    val fpgaIO = gateway.fpgaIO.get
-    val io = IO(Output(chiselTypeOf(fpgaIO)))
-    io := fpgaIO
-    io
-  }
-
   def finish(cpu: String, createTopIO: Boolean): Option[DifftestTopIO] = {
     val gateway = collect(cpu)
+    if (gateway.fpgaIO.isDefined) {
+      val fpgaIO = gateway.fpgaIO.get
+      val io = IO(Output(chiselTypeOf(fpgaIO)))
+      io := fpgaIO
+    }
     Option.when(createTopIO) {
       if (enabled) {
         createTopIOs(gateway.exit, gateway.step)

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -27,22 +27,22 @@
 #include <sys/shm.h>
 #include <thread>
 #include <vector>
+#ifdef FPGA_SIM
+#include "xdma_sim.h"
+#endif // FPGA_SIM
 
-#ifdef CONFIG_DIFFTEST_BATCH
-#define DMA_DIFF_PACKGE_LEN (CONFIG_DIFFTEST_BATCH_BYTELEN)
-#elif defined(CONFIG_DIFFTEST_SQUASH)
-#define DMA_DIFF_PACKGE_LEN 1280 // XDMA Min size
-#endif
 #define DMA_PACKGE_NUM 8
 
 // DMA_PADDING (packge_idx(1) + difftest_data) send width to be calculated by mod up
-#define DMA_PADDING (((1 + DMA_DIFF_PACKGE_LEN + 63) / 64) * 64 - (DMA_DIFF_PACKGE_LEN + 1))
+#define DMA_PACKGE_LEN     (CONFIG_DIFFTEST_BATCH_BYTELEN + 1)
+#define DMA_PACKGE_ALIGNED ((DMA_PACKGE_LEN + 63) / 64 * 64)
+#define DMA_PACKGE_PADDING (DMA_PACKGE_ALIGNED - DMA_PACKGE_LEN)
 
 typedef struct __attribute__((packed)) {
   uint8_t packge_idx; // idx of header packet is valid and idx of intermediate data is placeholder
-  uint8_t diff_packge[DMA_DIFF_PACKGE_LEN];
-#if (DMA_PADDING > 0)
-  uint8_t padding[DMA_PADDING];
+  uint8_t diff_packge[CONFIG_DIFFTEST_BATCH_BYTELEN];
+#if (DMA_PACKGE_PADDING > 0)
+  uint8_t padding[DMA_PACKGE_PADDING];
 #endif
 } DmaDiffPackge;
 
@@ -52,15 +52,41 @@ typedef struct __attribute__((packed)) {
 
 class FpgaXdma {
 public:
-  MemoryIdxPool xdma_mempool;
-
-  bool running = false;
-
   FpgaXdma();
-  ~FpgaXdma() {
-    stop_thansmit_thread();
-  };
 
+  void start() {
+    running = true;
+#ifdef USE_THREAD_MEMPOOL
+    std::unique_lock<std::mutex> lock(thread_mtx);
+    start_transmit_thread();
+    while (running) {
+      thread_cv.wait(lock); // wait notify from stop
+    }
+    stop_thansmit_thread();
+#else
+    read_and_process();
+#endif // USE_THREAD_MEMPOOL
+  }
+  void stop() {
+    running = false;
+#ifdef USE_THREAD_MEMPOOL
+    thread_cv.notify_one();
+#endif // USE_THREAD_MEMPOOL
+  }
+  void ddr_load_workload(const char *workload) {
+    core_reset();
+    device_write(true, workload, 0, 0);
+    core_restart();
+  }
+
+private:
+  bool running = false;
+  int xdma_c2h_fd[CONFIG_DMA_CHANNELS];
+#ifdef CONFIG_USE_XDMA_H2C
+  int xdma_h2c_fd;
+#endif
+
+  void device_write(bool is_bypass, const char *workload, uint64_t addr, uint64_t value);
   void core_reset() {
     device_write(false, nullptr, 0x20000, 0x1);
     device_write(false, nullptr, 0x100000, 0x1);
@@ -72,40 +98,20 @@ public:
     device_write(false, nullptr, 0x100000, 0);
   }
 
-  void ddr_load_workload(const char *workload) {
-    core_reset();
-    device_write(true, workload, 0, 0);
-    core_restart();
-  }
-
-  void device_write(bool is_bypass, const char *workload, uint64_t addr, uint64_t value);
-
-  void *posix_memalignd_malloc(size_t size) {
-    void *ptr = nullptr;
-    int ret = posix_memalign(&ptr, 4096, size);
-    if (ret != 0) {
-      perror("posix_memalign failed");
-      return nullptr;
-    }
-    return ptr;
-  }
-
+#ifdef USE_THREAD_MEMPOOL
+  std::mutex thread_mtx;
+  std::condition_variable thread_cv;
+  MemoryIdxPool xdma_mempool;
+  std::thread receive_thread[CONFIG_DMA_CHANNELS];
+  std::thread process_thread;
   // thread api
   void start_transmit_thread();
   void stop_thansmit_thread();
   void read_xdma_thread(int channel);
   void write_difftest_thread();
-
-private:
-  std::thread receive_thread[CONFIG_DMA_CHANNELS];
-  std::thread process_thread;
-
-  int xdma_c2h_fd[CONFIG_DMA_CHANNELS];
-#ifdef CONFIG_USE_XDMA_H2C
-  int xdma_h2c_fd;
-#endif
-
-  static void handle_sigint(int sig);
+#else
+  void read_and_process();
+#endif // USE_THREAD_MEMPOOL
 };
 
 #endif

--- a/src/test/csrc/fpga_sim/xdma_sim.cpp
+++ b/src/test/csrc/fpga_sim/xdma_sim.cpp
@@ -1,0 +1,145 @@
+/***************************************************************************************
+ * Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+#include "xdma_sim.h"
+#include <assert.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define BUFFER_SIZE 65536
+
+typedef struct {
+  pthread_mutex_t lock;
+  pthread_cond_t read_cond;
+  bool read_waiting;
+  int read_size;
+  int write_size;
+  char buffer[BUFFER_SIZE];
+} xdma_shm;
+
+class xdma_sim {
+private:
+  int shm_fd = -1;
+  xdma_shm *shm_ptr = nullptr;
+  char path[128];
+  bool is_host;
+
+public:
+  xdma_sim(int channel, bool _is_host) {
+    is_host = _is_host;
+    sprintf(path, "/xdma_sim_c2h%d", channel);
+    shm_fd = shm_open(path, O_CREAT | O_RDWR, 0666);
+    if (shm_fd == -1) {
+      perror("XDMA_SIM: Failed to open shared memory device\n");
+      exit(-1);
+    }
+    if (is_host) {
+      ftruncate(shm_fd, sizeof(xdma_shm));
+    }
+    shm_ptr = (xdma_shm *)mmap(NULL, sizeof(xdma_shm), PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+    if (is_host) {
+      memset(shm_ptr, 0, sizeof(xdma_shm));
+      pthread_mutexattr_t attr;
+      pthread_mutexattr_init(&attr);
+      pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+      pthread_mutex_init(&shm_ptr->lock, &attr);
+      pthread_condattr_t cattr;
+      pthread_condattr_init(&cattr);
+      pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED);
+      pthread_cond_init(&shm_ptr->read_cond, &cattr);
+    }
+  }
+  ~xdma_sim() {
+    if (is_host) {
+      shm_unlink(path);
+    }
+    munmap(shm_ptr, sizeof(xdma_shm));
+    close(shm_fd);
+  }
+  int read(char *buf, size_t size) {
+    assert(size <= BUFFER_SIZE);
+    pthread_mutex_lock(&shm_ptr->lock);
+
+    shm_ptr->read_waiting = true;
+    shm_ptr->write_size = 0;
+    shm_ptr->read_size = size;
+    while (shm_ptr->write_size < size) {
+      pthread_cond_wait(&shm_ptr->read_cond, &shm_ptr->lock);
+    }
+    size_t to_copy = size < shm_ptr->write_size ? size : shm_ptr->write_size;
+    memcpy(buf, shm_ptr->buffer, to_copy);
+
+    pthread_mutex_unlock(&shm_ptr->lock);
+
+    return to_copy;
+  }
+  int write(const char *buf, unsigned char tlast, size_t size) {
+    pthread_mutex_lock(&shm_ptr->lock);
+    while (!shm_ptr->read_waiting) {
+      pthread_mutex_unlock(&shm_ptr->lock);
+      pthread_mutex_lock(&shm_ptr->lock);
+    }
+    size_t space = shm_ptr->read_size - shm_ptr->write_size;
+    size_t to_write = size < space ? size : space;
+
+    memcpy(shm_ptr->buffer + shm_ptr->write_size, buf, to_write);
+    shm_ptr->write_size += to_write;
+    if (shm_ptr->write_size >= shm_ptr->read_size) {
+      assert(tlast == 1); // Check if tlast set properly
+      shm_ptr->read_waiting = false;
+      pthread_cond_signal(&shm_ptr->read_cond);
+    } else {
+      assert(tlast == 0);
+    }
+    pthread_mutex_unlock(&shm_ptr->lock);
+
+    return to_write;
+  }
+};
+
+// API for shared XDMA Dev
+xdma_sim *xsim[8] = {nullptr};
+
+void xdma_sim_open(int channel, bool is_host) {
+  xsim[channel] = new xdma_sim(channel, is_host);
+}
+
+void xdma_sim_close(int channel) {
+  delete xsim[channel];
+  xsim[channel] = nullptr;
+}
+
+int xdma_sim_read(int channel, char *buf, size_t size) {
+  return xsim[channel]->read(buf, size);
+}
+
+int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size) {
+  return xsim[channel]->write(buf, tlast, size);
+}
+
+extern "C" unsigned char v_xdma_tready() {
+  return 1;
+}
+
+extern "C" void v_xdma_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {
+  xdma_sim_write(channel, axi_tdata, axi_tlast, 64);
+}

--- a/src/test/csrc/fpga_sim/xdma_sim.h
+++ b/src/test/csrc/fpga_sim/xdma_sim.h
@@ -1,0 +1,26 @@
+/***************************************************************************************
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+#ifndef __XDMA_SIM_H__
+#define __XDMA_SIM_H__
+#include <stddef.h>
+#include <stdint.h>
+
+void xdma_sim_open(int channel, bool is_host);
+void xdma_sim_close(int channel);
+int xdma_sim_read(int channel, char *buf, size_t size);
+int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size);
+
+#endif // __XDMA_SIM_H__

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -33,6 +33,9 @@
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
 #include "remote_bitbang.h"
+#ifdef FPGA_SIM
+#include "xdma_sim.h"
+#endif // FPGA_SIM
 
 static bool has_reset = false;
 static char bin_file[256] = "/dev/zero";
@@ -198,6 +201,10 @@ extern "C" uint8_t simv_init() {
   }
 #endif // CONFIG_NO_DIFFTEST
 
+#ifdef FPGA_SIM
+  xdma_sim_open(0, false);
+#endif // FPGA_SIM
+
   return 0;
 }
 
@@ -259,6 +266,10 @@ void simv_finish() {
   finish_device();
   delete simMemory;
   simMemory = nullptr;
+
+#ifdef FPGA_SIM
+  xdma_sim_close(0);
+#endif //FPGA_SIM
 }
 
 int simv_get_result(uint8_t step) {

--- a/src/test/vsrc/fpga_sim/xdma_axi.v
+++ b/src/test/vsrc/fpga_sim/xdma_axi.v
@@ -1,0 +1,48 @@
+/***************************************************************************************
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+`include "DifftestMacros.v"
+module xdma_axi(
+  input clock,
+  input reset,
+  input [511:0] axi_tdata,
+  input [63:0] axi_tkeep,
+  input axi_tlast,
+  output axi_tready,
+  input axi_tvalid
+);
+
+import "DPI-C" function bit v_xdma_tready();
+import "DPI-C" function void v_xdma_write(
+  input byte channel,
+  input bit [511:0] axi_tdata,
+  input bit axi_tlast
+);
+
+reg axi_tready_r;
+assign axi_tready = axi_tready_r;
+always @(posedge clock) begin
+  if (reset) begin
+    axi_tready_r <= 1'b0;
+  end
+  else begin
+    axi_tready_r <= v_xdma_tready();
+    if (axi_tvalid & axi_tready) begin
+      v_xdma_write(0, axi_tdata, axi_tlast);
+    end
+  end
+end
+
+endmodule

--- a/src/test/vsrc/fpga_sim/xdma_clock.v
+++ b/src/test/vsrc/fpga_sim/xdma_clock.v
@@ -1,0 +1,44 @@
+/***************************************************************************************
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+module xdma_clock(
+  input clock,
+  input reset,
+  input core_clock_enable,
+  output core_clock
+);
+
+`ifdef ASYNC_CLK_2N
+// core_clock = clock / (2 * ASYNC_CLK_2N)
+reg core_clock_r;
+reg [7:0] clk_cnt;
+initial begin
+  core_clock_r = 0;
+  clk_cnt = 0;
+end
+always @(posedge clock) begin
+  if (clk_cnt == `ASYNC_CLK_2N - 1) begin
+    clk_cnt <= 0;
+    core_clock_r <= ~core_clock_r;
+  end
+  else begin
+    clk_cnt <= clk_cnt + 1;
+  end
+end
+assign core_clock = core_clock_r & core_clock_enable;
+`else
+assign core_clock = clock & core_clock_enable;
+`endif // ASYNC_CLK_2N
+endmodule

--- a/src/test/vsrc/fpga_sim/xdma_ctrl.v
+++ b/src/test/vsrc/fpga_sim/xdma_ctrl.v
@@ -1,0 +1,184 @@
+/***************************************************************************************
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+`include "DifftestMacros.v"
+module xdma_ctrl #(
+  parameter DATA_WIDTH = 16000,
+  parameter AXIS_DATA_WIDTH = 512
+)(
+  input clock,
+  input reset,
+  input [`CONFIG_DIFFTEST_BATCH_IO_WITDH - 1:0] difftest_data,
+  input difftest_enable,
+  output core_clock_enable,
+  output [AXIS_DATA_WIDTH - 1:0] axi_tdata,
+  output [63:0] axi_tkeep,
+  output axi_tlast,
+  input  axi_tready,
+  output axi_tvalid
+);
+
+import "DPI-C" function bit v_xdma_tready();
+    localparam NUM_PACKETS_PER_BUFFER = 8; // one send packet num
+    localparam AXIS_SEND_LEN = ((DATA_WIDTH  + 8 + AXIS_DATA_WIDTH - 1) / AXIS_DATA_WIDTH);
+
+    localparam IDLE = 3'b001;
+    localparam TRANSFER = 3'b010;
+    localparam DONE = 3'b100;
+
+    reg [2:0] current_state, next_state;
+
+    reg [DATA_WIDTH + 8 - 1:0] mix_data; // Difftestdata with
+    reg [AXIS_DATA_WIDTH - 1:0]  reg_axi_tdata;
+    reg [7:0] datalen;
+    reg [7:0] data_num;
+    reg [4:0] state;
+
+    reg                  reg_axi_tvalid;
+    reg                  reg_axi_tlast;
+    reg                  reg_core_clock_enable;
+    // Ping-Pong Buffers
+    reg [DATA_WIDTH - 1:0] dual_buffer [1:0][0 : NUM_PACKETS_PER_BUFFER - 1];
+    reg wr_buf;
+    reg rd_buf;
+    reg [7:0] wr_pkt_cnt;   // (0~7)
+    reg [7:0] rd_pkt_cnt;   // (0~7)
+    reg [1:0] buffer_valid;
+
+    assign core_clock_enable = reg_core_clock_enable;
+    assign axi_tdata = reg_axi_tdata;
+    assign axi_tvalid = reg_axi_tvalid;
+    assign axi_tkeep = 64'hffffffff_ffffffff;
+    assign axi_tlast = reg_axi_tlast;
+
+    wire both_full = &buffer_valid;
+
+    // asynchronous clock fetches the signal
+`ifdef ASYNC_CLK_2N
+    reg [7:0] clk_cnt;
+    initial clk_cnt = 0;
+    always @(posedge clock) begin
+        if (clk_cnt == (2 * `ASYNC_CLK_2N - 1)) begin
+            clk_cnt <= 0;
+        end else begin
+            clk_cnt <= clk_cnt + 'b1;
+        end
+    end
+    wire difftest_sampling = difftest_enable && clk_cnt == (2 * `ASYNC_CLK_2N - 1);
+`else
+    wire difftest_sampling = difftest_enable;
+`endif //ASYNC_CLK_2N
+
+
+    wire can_send = buffer_valid[rd_buf];
+    wire last_pkt = rd_pkt_cnt == NUM_PACKETS_PER_BUFFER;
+    // Each package has AXIS_SEND_LEN send
+    wire last_send = datalen == (AXIS_SEND_LEN - 1);
+
+    always @(posedge clock) begin
+        if (reset)
+            current_state <= IDLE;
+        else
+            current_state <= next_state;
+    end
+
+/* verilator lint_off CASEINCOMPLETE */
+    always @(*) begin
+        case(current_state)
+            IDLE:     next_state = can_send ? TRANSFER : IDLE;
+            TRANSFER: next_state = (axi_tready & axi_tvalid & last_pkt & last_send) ? DONE : TRANSFER;
+            DONE:     next_state = IDLE;
+            default:  next_state = IDLE;
+        endcase
+    end
+
+    // Write Buffer: record data from difftest
+    always @(posedge clock) begin
+        if (reset) begin
+            wr_buf <= 0;
+            wr_pkt_cnt <= 0;
+            buffer_valid <= 'b00;
+        end else begin
+            if (difftest_sampling & reg_core_clock_enable) begin
+                dual_buffer[wr_buf][wr_pkt_cnt] <= difftest_data;
+                wr_pkt_cnt <= wr_pkt_cnt + 1'b1;
+                if (wr_pkt_cnt == NUM_PACKETS_PER_BUFFER - 1) begin
+                    buffer_valid[wr_buf] <= 1;
+                    wr_pkt_cnt <= 0;
+                    wr_buf <= ~wr_buf; // Switch buffers
+                end
+            end
+            if (next_state == DONE) begin // Releasing a buffer
+                buffer_valid[rd_buf] <= 0;
+            end
+        end
+    end
+
+    always @(posedge clock) begin // Back pressure control
+        if (reset) begin
+            reg_core_clock_enable <= 1'b1;
+        end else begin
+            reg_core_clock_enable <= ~both_full & ~(wr_pkt_cnt == NUM_PACKETS_PER_BUFFER - 1 & difftest_sampling);
+        end
+    end
+
+    // Read buffer: send data to axi
+    always @(posedge clock) begin
+        if(reset) begin
+            reg_axi_tvalid <= 0;
+            reg_axi_tlast <= 0;
+            rd_buf <= 0;
+            rd_pkt_cnt <= 0;
+            data_num <= 0;
+            datalen <= 0;
+        end else begin
+            case(current_state)
+            IDLE : begin
+                if (can_send) begin
+                    reg_axi_tdata <= {dual_buffer[rd_buf][0][AXIS_DATA_WIDTH - 8 - 1:0], data_num};
+                    mix_data <= dual_buffer[rd_buf][0][DATA_WIDTH - 1:AXIS_DATA_WIDTH - 8];
+                    reg_axi_tvalid <= 1;
+                    rd_pkt_cnt <= 1;
+                    data_num <= data_num + 1'b1;
+                    datalen <= 1;
+                end
+            end
+            TRANSFER: begin
+                if(axi_tready && axi_tvalid) begin
+                    reg_axi_tdata <= mix_data[AXIS_DATA_WIDTH - 1:0];
+                    if(last_pkt & last_send) begin
+                        reg_axi_tlast <= 1;
+                        rd_pkt_cnt <= 0;
+                        datalen <= 0;
+                    end else if (!last_pkt & last_send) begin
+                        mix_data <= {dual_buffer[rd_buf][rd_pkt_cnt], 8'b0};
+                        rd_pkt_cnt <= rd_pkt_cnt + 1'b1;
+                        datalen <= 0;
+                    end else begin
+                        datalen <= datalen + 1'b1;
+                        mix_data <= mix_data >> AXIS_DATA_WIDTH;
+                    end
+                end
+            end
+            DONE: begin
+                reg_axi_tvalid <= 0;
+                reg_axi_tlast <= 0;
+                rd_buf <= ~rd_buf;
+            end
+            endcase
+        end
+    end
+/* verilator lint_on CASEINCOMPLETE */
+endmodule

--- a/src/test/vsrc/fpga_sim/xdma_wrapper.v
+++ b/src/test/vsrc/fpga_sim/xdma_wrapper.v
@@ -1,0 +1,62 @@
+/***************************************************************************************
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+`include "DifftestMacros.v"
+module xdma_wrapper(
+  input clock,
+  input reset,
+  input [`CONFIG_DIFFTEST_BATCH_IO_WITDH - 1:0] difftest_data,
+  input difftest_enable,
+  output core_clock
+);
+
+  wire core_clock_enable;
+  wire [`CONFIG_DIFFTEST_BATCH_IO_WITDH - 1:0] axi_tdata;
+  wire [63:0] axi_tkeep;
+  wire axi_tlast;
+  wire axi_tready;
+  wire axi_tvalid;
+xdma_clock xclock(
+  .clock(clock),
+  .reset(reset),
+  .core_clock_enable(core_clock_enable),
+  .core_clock(core_clock)
+);
+xdma_ctrl #(
+  .DATA_WIDTH(`CONFIG_DIFFTEST_BATCH_IO_WITDH),
+  .AXIS_DATA_WIDTH(512)
+) xctrl(
+  .clock(clock),
+  .reset(reset),
+  .difftest_data(difftest_data),
+  .difftest_enable(difftest_enable),
+  .core_clock_enable(core_clock_enable),
+  .axi_tdata(axi_tdata),
+  .axi_tkeep(axi_tkeep),
+  .axi_tlast(axi_tlast),
+  .axi_tready(axi_tready),
+  .axi_tvalid(axi_tvalid)
+);
+xdma_axi xaxi(
+  .clock(clock),
+  .reset(reset),
+  .axi_tdata(axi_tdata),
+  .axi_tkeep(axi_tkeep),
+  .axi_tlast(axi_tlast),
+  .axi_tready(axi_tready),
+  .axi_tvalid(axi_tvalid)
+);
+
+endmodule

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -111,9 +111,30 @@ end
 always #1 clock <= ~clock;
 `endif // WIRE_CLK
 
-SimTop sim(
+wire core_clock;
+
+`ifdef FPGA_SIM
+  wire [`CONFIG_DIFFTEST_BATCH_IO_WITDH - 1:0] difftest_data;
+  wire difftest_enable;
+xdma_wrapper xdma(
   .clock(clock),
   .reset(reset),
+  .difftest_data(difftest_data),
+  .difftest_enable(difftest_enable),
+  .core_clock(core_clock)
+);
+  // assign core_clock = clock;
+`else
+  assign core_clock = clock;
+`endif // FPGA_SIM
+
+SimTop sim(
+  .clock(core_clock),
+  .reset(reset),
+`ifdef FPGA_SIM
+  .difftest_io_data(difftest_data),
+  .difftest_io_enable(difftest_enable),
+`endif // FPGA_SIM
   .difftest_logCtrl_begin(difftest_logCtrl_begin),
   .difftest_logCtrl_end(difftest_logCtrl_end),
   .difftest_logCtrl_level(difftest_logCtrl_level),
@@ -128,7 +149,7 @@ SimTop sim(
 );
 
 DifftestEndpoint difftest(
-  .clock(clock),
+  .clock(core_clock),
   .reset(reset),
 `ifdef ENABLE_WORKLOAD_SWITCH
   .workload_switch(workload_switch),

--- a/vcs.mk
+++ b/vcs.mk
@@ -28,10 +28,10 @@ VCS_CXXFILES  = $(SIM_CXXFILES) $(shell find $(VCS_CSRC_DIR) -name "*.cpp")
 VCS_CXXFLAGS  = $(SIM_CXXFLAGS) -I$(VCS_CSRC_DIR) -DNUM_CORES=$(NUM_CORES)
 VCS_LDFLAGS   = $(SIM_LDFLAGS) -lpthread -ldl
 
-# DiffTest support
-ifneq ($(NO_DIFF),1)
-VCS_FLAGS    += +define+DIFFTEST
-endif
+VCS_VSRC_DIR 	= $(abspath ./src/test/vsrc/vcs)
+VCS_VFILES    = $(SIM_VSRC) $(shell find $(VCS_VSRC_DIR) -name "*.v" -or -name "*.sv")
+
+VCS_FLAGS 		= $(SIM_VFLAGS)
 
 ifeq ($(RELEASE),1)
 VCS_FLAGS    += +define+SNPS_FAST_SIM_FFV +define+USE_RF_DEBUG
@@ -40,17 +40,6 @@ endif
 # core soft rst
 ifeq ($(WORKLOAD_SWITCH),1)
 VCS_FLAGS    += +define+ENABLE_WORKLOAD_SWITCH
-endif
-
-ifeq ($(SYNTHESIS), 1)
-VCS_FLAGS    += +define+SYNTHESIS +define+TB_NO_DPIC
-else
-ifeq ($(DISABLE_DIFFTEST_RAM_DPIC), 1)
-VCS_FLAGS    += +define+DISABLE_DIFFTEST_RAM_DPIC
-endif
-ifeq ($(DISABLE_DIFFTEST_FLASH_DPIC), 1)
-VCS_FLAGS    += +define+DISABLE_DIFFTEST_FLASH_DPIC
-endif
 endif
 
 # if fsdb is considered
@@ -106,8 +95,6 @@ VCS_FLAGS += +incdir+$(GEN_VSRC_DIR)
 # enable fsdb dump
 VCS_FLAGS += $(EXTRA)
 
-VCS_VSRC_DIR = $(abspath ./src/test/vsrc/vcs)
-VCS_VFILES   = $(SIM_VSRC) $(shell find $(VCS_VSRC_DIR) -name "*.v" -or -name "*.sv")
 $(VCS_TARGET): $(SIM_TOP_V) $(VCS_CXXFILES) $(VCS_VFILES)
 	$(VCS) $(VCS_FLAGS) $(SIM_TOP_V) $(VCS_CXXFILES) $(VCS_VFILES)
 ifeq ($(VCS),verilator)

--- a/verilator.mk
+++ b/verilator.mk
@@ -25,10 +25,7 @@ EMU_CXXFLAGS  = $(SIM_CXXFLAGS) -I$(EMU_CSRC_DIR)
 EMU_CXXFLAGS += -DVERILATOR -DNUM_CORES=$(NUM_CORES) --std=c++17
 EMU_LDFLAGS   = $(SIM_LDFLAGS) -ldl
 
-# DiffTest support
-ifneq ($(NO_DIFF), 1)
-VEXTRA_FLAGS += +define+DIFFTEST
-endif
+VEXTRA_FLAGS  = $(SIM_VFLAGS)
 
 # Link fuzzer libraries
 ifneq ($(FUZZER_LIB), )


### PR DESCRIPTION
This change supports software simulation of FPGA-host interacting with DUT in a xdma-like way. We use a simv process to simulate DUT and send difftest_data with xdma-like pcie. The simv process will interacting with fpga-host by share memory acting as xdma device.

Code of the xdma_ctrl.v is modified from the code of fengkehan <fengkehan@bosc.ac.cn> and fix some bugs.