### PR TITLE
FPGA: add fpga macro define

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -145,12 +145,14 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
          |`ifndef SYNTHESIS
          |`ifdef DIFFTEST
          |`ifndef FPGA_SIM
+         |`ifdef CONFIG_DIFFTEST_FPGA
          |$dpicDecl
          |$gfifoInitial
          |  always @(posedge clock) begin
          |    if (enable)
          |      $dpicFuncName (${dpicFuncArgs.flatten.map(_._1).mkString(", ")});
          |  end
+         |`endif
          |`endif
          |`endif
          |`endif

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -95,6 +95,7 @@ case class GatewayConfig(
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
     if (traceDump || traceLoad) macros += "CONFIG_DIFFTEST_IOTRACE"
+    if (isFPGA) macros += "CONFIG_DIFFTEST_FPGA"
     macros.toSeq
   }
   def check(): Unit = {

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -212,6 +212,7 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
   setInline(
     "SquashControl.v",
     s"""
+       |`include "DifftestMacros.v"
        |module SquashControl(
        |  input clock,
        |  input reset,
@@ -219,6 +220,8 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |);
        |
        |`ifdef SYNTHESIS
+       |  assign enable = 1;
+       |`elsif CONFIG_FPGA_DIFFTEST_XDMA
        |  assign enable = 1;
        |`else
        |`ifdef DIFFTEST


### PR DESCRIPTION
To implement the simulation of FPGA diff configuration on VCS, macros need to be added to avoid calling DPIC.