### PR TITLE
emu: add an abstraction class for RTL simulators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ scala-format:
 CLANG_FORMAT_VER = 18.1.4
 clang-format:
 ifeq ($(shell clang-format --version 2> /dev/null| cut -f3 -d' ' | tr '.' '_'), $(shell echo $(CLANG_FORMAT_VER) | tr '.' '_'))
-	clang-format -i $(shell find ./src/test/csrc -name "*.cpp" -or -name "*.h")
+	clang-format -i $(shell find ./src/test/csrc -name "*.cpp" -or -name "*.h" -or -name "*.inc")
 else
 	@echo "Required clang-format Version: $(CLANG_FORMAT_VER)"
 	@echo "Your Version: $(shell clang-format --version)"

--- a/src/test/csrc/common/common.h
+++ b/src/test/csrc/common/common.h
@@ -26,6 +26,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <stdexcept>
+#include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
 

--- a/src/test/csrc/common/elfloader.h
+++ b/src/test/csrc/common/elfloader.h
@@ -16,19 +16,13 @@
 #ifndef __ELFLOADER_H
 #define __ELFLOADER_H
 
-#include "config.h"
+#include "common.h"
 #include <assert.h>
-#include <cstring>
 #include <fcntl.h>
 #include <iostream>
 #include <map>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string>
-#include <sys/mman.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <vector>
 
 #define IS_ELF(hdr) \

--- a/src/test/csrc/common/flash.cpp
+++ b/src/test/csrc/common/flash.cpp
@@ -16,7 +16,6 @@
 
 #include "flash.h"
 #include "common.h"
-#include <sys/mman.h>
 #ifdef CONFIG_DIFFTEST_PERFCNT
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT

--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -19,7 +19,6 @@
 #include "compress.h"
 #include "elfloader.h"
 #include <iostream>
-#include <sys/mman.h>
 #ifdef CONFIG_DIFFTEST_PERFCNT
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT

--- a/src/test/csrc/difftest/goldenmem.cpp
+++ b/src/test/csrc/difftest/goldenmem.cpp
@@ -20,7 +20,6 @@
 #include "refproxy.h"
 #include <goldenmem.h>
 #include <stdlib.h>
-#include <sys/mman.h>
 
 uint8_t *pmem;
 uint8_t *pmem_flag; // 1: store update but load check skip; 0: update and check. others: assert

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -1,5 +1,5 @@
 /***************************************************************************************
-* Copyright (c) 2020-2023 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
 * Copyright (c) 2020-2021 Peng Cheng Laboratory
 *
 * DiffTest is licensed under Mulan PSL v2.
@@ -17,23 +17,11 @@
 #ifndef __EMU_H
 #define __EMU_H
 
-#ifdef GSIM
-#include "SimTop.h"
-#define DUT_TOP SSimTop
-#else // VERILATOR
-#include "VSimTop.h"
-#include "VSimTop__Syms.h"
-#define DUT_TOP VSimTop
-#endif
 #include "common.h"
 #include "dut.h"
 #include "lightsss.h"
-#include "snapshot.h"
-#include "waveform.h"
+#include "simulator.h"
 #include <sys/types.h>
-#ifdef EMU_THREAD
-#include <verilated_threads.h>
-#endif
 
 struct EmuArgs {
   uint32_t reset_cycles = 50;
@@ -71,7 +59,7 @@ struct EmuArgs {
   bool enable_waveform_full = false;
   bool enable_ref_trace = false;
   bool enable_commit_trace = false;
-  bool enable_snapshot = true;
+  bool enable_snapshot = false;
   bool force_dump_result = false;
   bool enable_diff = true;
   bool enable_fork = false;
@@ -85,17 +73,9 @@ struct EmuArgs {
 
 class Emulator final : public DUT {
 private:
-  DUT_TOP *dut_ptr;
-
-#if VM_TRACE == 1
-  TraceBindFunc trace_bind = [this](VerilatedTraceBaseC *tfp, int levels) { this->dut_ptr->trace(tfp, levels); };
-  EmuWaveform *waveform = nullptr;
-#endif // VM_TRACE == 1
+  Simulator *dut_ptr;
 
   bool force_dump_wave = false;
-#ifdef VM_SAVABLE
-  VerilatedSaveMem *snapshot_slot = nullptr;
-#endif
   EmuArgs args;
   LightSSS *lightsss = NULL;
 #if VM_COVERAGE == 1
@@ -119,9 +99,6 @@ private:
     return create_noop_filename(".db");
   }
 
-  inline const char *snapshot_filename() {
-    return create_noop_filename(".snapshot");
-  }
   void snapshot_save();
   void snapshot_load(const char *filename);
 

--- a/src/test/csrc/verilator/gsim.cpp.inc
+++ b/src/test/csrc/verilator/gsim.cpp.inc
@@ -1,0 +1,22 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#include "simulator.h"
+
+GsimSim::GsimSim() : dut(new SSimTop) {}
+
+GsimSim::~GsimSim() {
+  delete dut;
+}

--- a/src/test/csrc/verilator/gsim.h
+++ b/src/test/csrc/verilator/gsim.h
@@ -51,10 +51,10 @@ public:
   }
 
   inline uint64_t get_difftest_exit() final {
-    return 0; // TODO: gsim API
+    return dut->get_difftest__DOT__exit();
   }
   inline uint64_t get_difftest_step() final {
-    return 1; // TODO: gsim API
+    return dut->get_difftest__DOT__step();
   }
 
   inline void set_perf_clean(unsigned clean) override {

--- a/src/test/csrc/verilator/gsim.h
+++ b/src/test/csrc/verilator/gsim.h
@@ -1,0 +1,75 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef __SIMULATOR_GSIM_H
+#define __SIMULATOR_GSIM_H
+
+#include "SimTop.h"
+
+class GsimSim final : public Simulator {
+private:
+  SSimTop *dut;
+
+protected:
+  inline unsigned get_uart_out_valid() override {
+    return dut->get_difftest__DOT__uart__DOT__out__DOT__valid();
+  }
+  inline uint8_t get_uart_out_ch() override {
+    return dut->get_difftest__DOT__uart__DOT__out__DOT__ch();
+  }
+  inline unsigned get_uart_in_valid() override {
+    return dut->get_difftest__DOT__uart__DOT__in__DOT__valid();
+  }
+  inline void set_uart_in_ch(uint8_t ch) override {
+    dut->set_difftest__DOT__uart__DOT__in__DOT__ch(ch);
+  }
+
+public:
+  GsimSim();
+  ~GsimSim();
+
+  inline void set_clock(unsigned clock) override {
+    // Gsim does not use explicit clock. Simply call step() instead.
+  }
+  inline void set_reset(unsigned reset) override {
+    dut->set_reset(reset);
+  }
+  inline void step() override {
+    dut->step();
+  }
+
+  inline uint64_t get_difftest_exit() final {
+    return 0; // TODO: gsim API
+  }
+  inline uint64_t get_difftest_step() final {
+    return 1; // TODO: gsim API
+  }
+
+  inline void set_perf_clean(unsigned clean) override {
+    dut->set_difftest__DOT__perfCtrl__DOT__clean(clean);
+  }
+  inline void set_perf_dump(unsigned dump) override {
+    dut->set_difftest__DOT__perfCtrl__DOT__dump(dump);
+  }
+
+  inline void set_log_begin(uint64_t begin) override {
+    dut->set_difftest__DOT__logCtrl__DOT__begin(begin);
+  }
+  inline void set_log_end(uint64_t end) override {
+    dut->set_difftest__DOT__logCtrl__DOT__end(end);
+  }
+};
+
+#endif // __SIMULATOR_GSIM_H

--- a/src/test/csrc/verilator/simulator.cpp
+++ b/src/test/csrc/verilator/simulator.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifdef VERILATOR
+#include "verilator.cpp.inc"
+#endif // VERILATOR
+
+#ifdef GSIM
+#include "gsim.cpp.inc"
+#endif // GSIM

--- a/src/test/csrc/verilator/simulator.h
+++ b/src/test/csrc/verilator/simulator.h
@@ -1,0 +1,132 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef __SIMULATOR_H
+#define __SIMULATOR_H
+
+#include "common.h"
+
+class Simulator {
+private:
+  static void report_waveform_error() {
+    printf("Waveform is unsupported in this simulator or disabled.\n");
+    printf("If you are using Verilator, please compile with EMU_TRACE=1 to enable it.\n");
+    throw std::runtime_error("Waveform not supported.");
+  }
+
+  static void report_snapshot_error(void *__restrict datap, size_t size) {
+    printf("Snapshot is unsupported in this simulator or disabled.\n");
+    printf("If you are using Verilator, please compile with EMU_SNAPSHOT=1 to enable it.\n");
+    throw std::runtime_error("Snapshot not supported.");
+  }
+
+protected:
+  virtual unsigned get_uart_out_valid() = 0;
+  virtual uint8_t get_uart_out_ch() = 0;
+  virtual unsigned get_uart_in_valid() = 0;
+  virtual void set_uart_in_ch(uint8_t ch) = 0;
+
+public:
+  Simulator() = default;
+  virtual ~Simulator() {};
+
+  /******* mandatory methods for child classes *******/
+  // Set the clock signal, 0 or 1.
+  virtual void set_clock(unsigned clock) = 0;
+  // Set the reset signal, 0 or 1.
+  virtual void set_reset(unsigned reset) = 0;
+  // Tick one step. Note this method may have various implementations.
+  virtual void step() = 0;
+
+  // Get the exit signal from DiffTest.
+  virtual uint64_t get_difftest_exit() = 0;
+  // Get the step signal from DiffTest.
+  virtual uint64_t get_difftest_step() = 0;
+
+  // Set the clean signal for performance counters.
+  virtual void set_perf_clean(unsigned clean) = 0;
+  // Set the dump signal for performance counters.
+  virtual void set_perf_dump(unsigned dump) = 0;
+
+  // Set the log begin signal.
+  virtual void set_log_begin(uint64_t begin) = 0;
+  // Set the log end signal.
+  virtual void set_log_end(uint64_t end) = 0;
+
+  /******* optional methods for child classes *******/
+  // To re-initialize the simulator upon a `fork()` call.
+  virtual void atClone() {};
+
+  // To initialize the waveform.
+  virtual void waveform_init(uint64_t cycles) {
+    report_waveform_error();
+  }
+  // To tick the waveform.
+  virtual void waveform_init(uint64_t cycles, const char *filename) {
+    report_waveform_error();
+  }
+  // To tick the waveform for one timestamp.
+  virtual void waveform_tick() {
+    report_waveform_error();
+  };
+
+  // To initialize the simulation snapshot.
+  virtual void snapshot_init() {
+    report_snapshot_error(nullptr, 0);
+  }
+  // To clean the simulation snapshot.
+  virtual void snapshot_save(int index) {
+    report_snapshot_error(nullptr, 0);
+  }
+  // To save the simulation snapshot.
+  virtual std::function<void(void *, size_t)> snapshot_take() {
+    return report_snapshot_error;
+  }
+  // To load the simulation snapshot from a file.
+  virtual std::function<void(void *, size_t)> snapshot_load(const char *filename) {
+    return report_snapshot_error;
+  }
+
+  /******* final methods *******/
+
+  // Step the UART, this is used to read/write UART data.
+  // This method cannot be overridden.
+  inline void step_uart() {
+    if (get_uart_out_valid()) {
+      printf("%c", get_uart_out_ch());
+      fflush(stdout);
+    }
+    if (get_uart_in_valid()) {
+      extern uint8_t uart_getc();
+      set_uart_in_ch(uart_getc());
+    }
+  }
+};
+
+#ifdef VERILATOR
+#define SIMULATOR VerilatorSim
+#include "verilator.h"
+#endif // VERILATOR
+
+#ifdef GSIM
+#define SIMULATOR GsimSim
+#include "gsim.h"
+#endif // GSIM
+
+#ifndef SIMULATOR
+#error "SIMULATOR undetected, please define it."
+#endif // SIMULATOR
+
+#endif

--- a/src/test/csrc/verilator/snapshot.cpp.inc
+++ b/src/test/csrc/verilator/snapshot.cpp.inc
@@ -14,8 +14,8 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-#include "snapshot.h"
 #include "compress.h"
+#include "snapshot.h"
 
 #ifdef VM_SAVABLE
 

--- a/src/test/csrc/verilator/snapshot.h
+++ b/src/test/csrc/verilator/snapshot.h
@@ -17,7 +17,6 @@
 #ifndef SNAPSHOT_H
 #define SNAPSHOT_H
 
-#ifdef VM_SAVABLE
 #include "VSimTop.h"
 #include "compress.h"
 #include "ram.h"
@@ -96,6 +95,5 @@ public:
   void flush() override VL_MT_UNSAFE_ONE {}
   void fill() override VL_MT_UNSAFE_ONE;
 };
-#endif
 
-#endif
+#endif // SNAPSHOT_H

--- a/src/test/csrc/verilator/verilator.cpp.inc
+++ b/src/test/csrc/verilator/verilator.cpp.inc
@@ -70,6 +70,8 @@ void VerilatorSim::waveform_init(uint64_t cycles, const char *filename) {
 void VerilatorSim::waveform_tick() {
   waveform->tick();
 }
+
+#include "waveform.cpp.inc"
 #endif // VM_TRACE == 1
 
 #ifdef VM_SAVABLE
@@ -81,8 +83,7 @@ void VerilatorSim::snapshot_save(int index) {
   if (snapshot_slot) {
     if (index >= 0) {
       snapshot_slot[index].save();
-    }
-    else if (index == -1) {
+    } else if (index == -1) {
       Info("Saving snapshots to file system. Please wait.\n");
       snapshot_slot[0].save();
       snapshot_slot[1].save();
@@ -110,4 +111,5 @@ std::function<void(void *, size_t)> VerilatorSim::snapshot_load(const char *file
 
   return [stream](void *datap, size_t size) { stream->read((uint8_t *)datap, size); };
 }
+#include "snapshot.cpp.inc"
 #endif // VM_SAVABLE

--- a/src/test/csrc/verilator/verilator.cpp.inc
+++ b/src/test/csrc/verilator/verilator.cpp.inc
@@ -1,0 +1,113 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifdef EMU_THREAD
+#include <verilated_threads.h>
+#endif
+
+#include "simulator.h"
+
+VerilatorSim::VerilatorSim() : dut(new VSimTop) {}
+
+VerilatorSim::~VerilatorSim() {
+#if VM_TRACE == 1
+  if (waveform) {
+    delete waveform;
+    waveform = nullptr;
+  }
+#endif
+
+#ifdef VM_SAVABLE
+  if (snapshot_slot) {
+    delete[] snapshot_slot;
+    snapshot_slot = nullptr;
+  }
+#endif // VM_SAVABLE
+
+  delete dut;
+}
+
+void VerilatorSim::atClone() {
+#ifdef VERILATOR_VERSION_INTEGER // >= v4.220
+#if VERILATOR_VERSION_INTEGER >= 5016000
+  // This will cause 288 bytes leaked for each one fork call.
+  // However, one million snapshots cause only 288MB leaks, which is still acceptable.
+  // See verilator/test_regress/t/t_wrapper_clone.cpp:48 to avoid leaks.
+  dut->atClone();
+#else
+#error Please use Verilator v5.016 or newer versions.
+#endif                 // check VERILATOR_VERSION_INTEGER values
+#elif EMU_THREAD > 1   // VERILATOR_VERSION_INTEGER not defined
+#ifdef VERILATOR_4_210 // v4.210 <= version < 4.220
+  dut->vlSymsp->__Vm_threadPoolp = new VlThreadPool(dut_ptr->contextp(), EMU_THREAD - 1, 0);
+#else                  // older than v4.210
+  dut->__Vm_threadPoolp = new VlThreadPool(dut_ptr->contextp(), EMU_THREAD - 1, 0);
+#endif
+#endif
+}
+
+#if VM_TRACE == 1
+void VerilatorSim::waveform_init(uint64_t cycles) {
+  waveform = new EmuWaveform(trace_bind, cycles);
+}
+
+void VerilatorSim::waveform_init(uint64_t cycles, const char *filename) {
+  waveform = new EmuWaveform(trace_bind, cycles, filename);
+}
+
+void VerilatorSim::waveform_tick() {
+  waveform->tick();
+}
+#endif // VM_TRACE == 1
+
+#ifdef VM_SAVABLE
+void VerilatorSim::snapshot_init() {
+  snapshot_slot = new VerilatedSaveMem[2];
+}
+
+void VerilatorSim::snapshot_save(int index) {
+  if (snapshot_slot) {
+    if (index >= 0) {
+      snapshot_slot[index].save();
+    }
+    else if (index == -1) {
+      Info("Saving snapshots to file system. Please wait.\n");
+      snapshot_slot[0].save();
+      snapshot_slot[1].save();
+      Info("Please remove unused snapshots manually\n");
+    }
+  }
+}
+
+std::function<void(void *, size_t)> VerilatorSim::snapshot_take() {
+  static int last_slot = 0;
+  VerilatedSaveMem &stream = snapshot_slot[last_slot];
+  last_slot = !last_slot;
+
+  stream.init(create_noop_filename(".snapshot"));
+  stream << *dut;
+  stream.flush();
+
+  return [&stream](void *datap, size_t size) { stream.unbuf_write(datap, size); };
+}
+
+std::function<void(void *, size_t)> VerilatorSim::snapshot_load(const char *filename) {
+  auto stream = std::make_shared<VerilatedRestoreMem>();
+  stream->open(filename);
+  *stream >> *dut;
+
+  return [stream](void *datap, size_t size) { stream->read((uint8_t *)datap, size); };
+}
+#endif // VM_SAVABLE

--- a/src/test/csrc/verilator/verilator.h
+++ b/src/test/csrc/verilator/verilator.h
@@ -1,0 +1,104 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef __SIMULATOR_VERILATOR_H
+#define __SIMULATOR_VERILATOR_H
+
+#include "VSimTop.h"
+#include "VSimTop__Syms.h"
+#include "waveform.h"
+#ifdef VM_SAVABLE
+#include "snapshot.h"
+#endif // VM_SAVABLE
+
+class VerilatorSim final : public Simulator {
+private:
+  VSimTop *dut;
+
+#if VM_TRACE == 1
+  TraceBindFunc trace_bind = [this](VerilatedTraceBaseC *tfp, int levels) { this->dut->trace(tfp, levels); };
+  EmuWaveform *waveform = nullptr;
+#endif // VM_TRACE == 1
+
+#ifdef VM_SAVABLE
+  VerilatedSaveMem *snapshot_slot = nullptr;
+#endif // VM_SAVABLE
+
+protected:
+  inline unsigned get_uart_out_valid() override {
+    return dut->difftest_uart_out_valid;
+  }
+  inline uint8_t get_uart_out_ch() override {
+    return dut->difftest_uart_out_ch;
+  }
+  inline unsigned get_uart_in_valid() override {
+    return dut->difftest_uart_in_valid;
+  }
+  inline void set_uart_in_ch(uint8_t ch) override {
+    dut->difftest_uart_in_ch = ch;
+  }
+
+public:
+  VerilatorSim();
+  ~VerilatorSim();
+
+  inline void set_clock(unsigned clock) override {
+    dut->clock = clock;
+  }
+  inline void set_reset(unsigned reset) override {
+    dut->reset = reset;
+  }
+  inline void step() override {
+    dut->eval();
+  }
+
+  inline uint64_t get_difftest_exit() override {
+    return dut->difftest_exit;
+  }
+  inline uint64_t get_difftest_step() override {
+    return dut->difftest_step;
+  }
+
+  inline void set_perf_clean(unsigned clean) override {
+    dut->difftest_perfCtrl_clean = clean;
+  }
+  inline void set_perf_dump(unsigned dump) override {
+    dut->difftest_perfCtrl_dump = dump;
+  }
+
+  inline void set_log_begin(uint64_t begin) override {
+    dut->difftest_logCtrl_begin = begin;
+  }
+  inline void set_log_end(uint64_t end) override {
+    dut->difftest_logCtrl_end = end;
+  }
+
+  void atClone() override;
+
+#if VM_TRACE == 1
+  void waveform_init(uint64_t cycles) override;
+  void waveform_init(uint64_t cycles, const char *filename) override;
+  void waveform_tick() override;
+#endif // VM_TRACE == 1
+
+#ifdef VM_SAVABLE
+  void snapshot_init() override;
+  void snapshot_save(int index) override;
+  std::function<void(void *, size_t)> snapshot_take() override;
+  std::function<void(void *, size_t)> snapshot_load(const char *filename) override;
+#endif // VM_SAVABLE
+};
+
+#endif // __SIMULATOR_VERILATOR_H

--- a/src/test/csrc/verilator/waveform.cpp.inc
+++ b/src/test/csrc/verilator/waveform.cpp.inc
@@ -13,8 +13,8 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-#include "waveform.h"
 #include "common.h"
+#include "waveform.h"
 
 EmuWaveform::EmuWaveform(TraceBindFunc trace, uint64_t cycles) : EmuWaveform(trace, cycles, default_filename(cycles)) {}
 


### PR DESCRIPTION
This commit adds a standard abstraction for different RTL simulators for emu-mode, where the simulation is driven by C++ code at the top.

For various RTL simulators, they only need to implement the mandatory and some optional methods to work on DiffTest.