### PR TITLE
fix(wiring): use `bore(data)` for non-hierarchical wiring in chisel6

### DIFF
--- a/src/main/scala/util/DataMirror.scala
+++ b/src/main/scala/util/DataMirror.scala
@@ -44,5 +44,15 @@ private[difftest] object DataMirror {
       val argument: Seq[Any] = Seq(data, si)
       method.get.apply(argument: _*).asInstanceOf[T]
     }
+
+    def bore(implicit si: SourceInfo): T = {
+      require(
+        !chisel3.BuildInfo.version.startsWith("3"),
+        "BoringUtils.bore(data) does not support Chisel 3, use BoringUtils.addSource/addSink in replace.",
+      )
+      val method = loadMethodOfObject("boreOrTap", "chisel3.util.experimental.BoringUtils")
+      val argument: Seq[Any] = Seq(data, None, false, si)
+      method.get.apply(argument: _*).asInstanceOf[T]
+    }
   }
 }


### PR DESCRIPTION
`BoringUtils.addSource` and `BoringUtils.addSink` are deprecated since chisel6. We should avoid using it for the future.

BREAKING CHANGE: this makes wiring require addSource before addSink in chisel6 even without `--difftest-config H`