### PR TITLE
fix(wiring): teat chisel version in a more concrate way

### DIFF
--- a/src/main/scala/common/WiringControl.scala
+++ b/src/main/scala/common/WiringControl.scala
@@ -66,12 +66,9 @@ object DifftestWiring {
     }
   }
 
-  // Hierarchical Wiring does not support Chisel 3.
-  def isChisel3: Boolean = chisel3.BuildInfo.version.startsWith("3")
-
   def addSource[T <: Data](data: T, name: String, isHierarchical: Boolean): T = {
     getWire(data, name, isHierarchical).setSource()
-    if (isChisel3) {
+    if (!hasNewBore) {
       WiringControl.addSource(data, name)
     }
     data
@@ -83,7 +80,7 @@ object DifftestWiring {
 
   def addSink[T <: Data](data: T, name: String, isHierarchical: Boolean): T = {
     val info = getWire(data, name, isHierarchical).addSink()
-    if (!isChisel3) {
+    if (hasNewBore) {
       require(!info.isPending, s"[${info.name}]: Wiring requires addSource before addSink")
       if (info.data.isVisible) {
         data := info.data

--- a/src/main/scala/util/DataMirror.scala
+++ b/src/main/scala/util/DataMirror.scala
@@ -34,6 +34,9 @@ private[difftest] object DataMirror {
     methodSymb.map(s => currentMirror.reflect(obj).reflectMethod(s))
   }
 
+  // Whether we have new BoringUtils
+  def hasNewBore: Boolean = loadMethodOfObject("tapAndRead", "chisel3.util.experimental.BoringUtils").isDefined
+
   implicit class DataMirrorLoader[T <: Data](data: T) {
     def isVisible: Boolean = {
       val method = loadMethodOfObject("isVisible", "chisel3.reflect.DataMirror")
@@ -41,20 +44,14 @@ private[difftest] object DataMirror {
     }
 
     def tapAndRead(implicit si: SourceInfo): T = {
-      require(
-        !chisel3.BuildInfo.version.startsWith("3"),
-        "BoringUtils.tapAndRead does not support Chisel 3, use BoringUtils.addSource/addSink in replace.",
-      )
+      require(hasNewBore, "BoringUtils.tapAndRead not supported. Use BoringUtils.addSource/addSink instead.")
       val method = loadMethodOfObject("tapAndRead", "chisel3.util.experimental.BoringUtils")
       val argument: Seq[Any] = Seq(data, si)
       method.get.apply(argument: _*).asInstanceOf[T]
     }
 
     def bore(implicit si: SourceInfo): T = {
-      require(
-        !chisel3.BuildInfo.version.startsWith("3"),
-        "BoringUtils.bore(data) does not support Chisel 3, use BoringUtils.addSource/addSink in replace.",
-      )
+      require(hasNewBore, "BoringUtils.bore(data) not supported. Use BoringUtils.addSource/addSink instead.")
       val method = loadMethodOfObject(
         "bore",
         "chisel3.util.experimental.BoringUtils",


### PR DESCRIPTION
`BoringUtils.tapAndRead` is introduced in chisel 6. Previous testing method ignored chisel 5.