### PR TITLE
feat(serial): support read/write serial port for FPGA 

### DIFF
--- a/fpga.mk
+++ b/fpga.mk
@@ -3,6 +3,7 @@ FPGA_CSRC_DIR   = $(abspath ./src/test/csrc/fpga)
 FPGA_CONFIG_DIR = $(abspath ./config) # Reserve storage for xdma configuration
 
 DMA_CHANNELS ?= 1
+USE_SERIAL_PORT ?= 1
 
 FPGA_CXXFILES  = $(SIM_CXXFILES) $(shell find $(FPGA_CSRC_DIR) -name "*.cpp")
 FPGA_CXXFLAGS  = $(subst \\\",\", $(SIM_CXXFLAGS)) -I$(FPGA_CSRC_DIR) -DCONFIG_DMA_CHANNELS=$(DMA_CHANNELS) -DNUM_CORES=$(NUM_CORES) -DFPGA_HOST
@@ -10,6 +11,12 @@ FPGA_CXXFLAGS += -std=c++11 -O3 -flto -march=native -mtune=native
 FPGA_LDFLAGS   = $(SIM_LDFLAGS) -lpthread -ldl
 
 fpga-build: fpga-clean fpga-host
+
+ifneq ($(FPGA_SIM), 1)
+ifneq ($(USE_SERIAL_PORT), 0)
+FPGA_CXXFLAGS += -DUSE_SERIAL_PORT
+endif
+endif
 
 ifeq ($(USE_XDMA_DDR_LOAD), 1)
 FPGA_CXXFLAGS += -DUSE_XDMA_DDR_LOAD

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -29,6 +29,9 @@
 #ifdef FPGA_SIM
 #include "xdma_sim.h"
 #endif // FPGA_SIM
+#ifdef USE_SERIAL_PORT
+#include "serial_port.h"
+#endif // USE_SERIAL_PORT
 
 void fpga_finish();
 
@@ -52,7 +55,9 @@ void set_diff_ref_so(char *s);
 void args_parsing(int argc, char *argv[]);
 
 FpgaXdma *xdma_device = NULL;
-
+#ifdef USE_SERIAL_PORT
+SerialPort *serial_port = NULL;
+#endif // USE_SERIAL_PORT
 int main(int argc, char *argv[]) {
   args_parsing(argc, argv);
 
@@ -74,6 +79,12 @@ void set_diff_ref_so(char *s) {
 
 void fpga_init() {
   xdma_device = new FpgaXdma();
+
+#ifdef USE_SERIAL_PORT
+  serial_port = new SerialPort("/dev/ttyUSB0");
+  serial_port->start();
+#endif // USE_SERIAL_PORT
+
   init_ram(work_load, DEFAULT_EMU_RAM_SIZE);
   init_flash(flash_bin_file);
 
@@ -89,6 +100,11 @@ void fpga_init() {
 
 void fpga_finish() {
   delete xdma_device;
+#ifdef USE_SERIAL_PORT
+  serial_port->stop();
+  delete serial_port;
+#endif // USE_SERIAL_PORT
+
   common_finish();
 
   difftest_finish();

--- a/src/test/csrc/fpga/serial_port.cpp
+++ b/src/test/csrc/fpga/serial_port.cpp
@@ -1,0 +1,120 @@
+/***************************************************************************************
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#include "serial_port.h"
+#include <fcntl.h>
+#include <iostream>
+#include <sys/select.h>
+
+#ifdef USE_SERIAL_PORT
+
+bool SerialPort::open_port(int baudrate) {
+  fd_ = open(device_, O_RDWR | O_NOCTTY | O_SYNC);
+  if (fd_ < 0) {
+    std::cerr << "Failed to open " << device_ << std::endl;
+    return false;
+  }
+  struct termios tty;
+  memset(&tty, 0, sizeof tty);
+  if (tcgetattr(fd_, &tty) != 0) {
+    std::cerr << "Error from tcgetattr" << std::endl;
+    return false;
+  }
+  cfsetospeed(&tty, baudrate);
+  cfsetispeed(&tty, baudrate);
+  tty.c_cflag = (tty.c_cflag & ~CSIZE) | CS8; // 8-bit chars
+  tty.c_iflag &= ~IGNBRK;                     // disable break processing
+  tty.c_lflag = 0;                            // no signaling chars, no echo,
+                                              // no canonical processing
+  tty.c_oflag = 0;                            // no remapping, no delays
+  tty.c_cc[VMIN] = 1;                         // read blocks
+  tty.c_cc[VTIME] = 1;                        // 0.1 seconds read timeout
+
+  tty.c_iflag &= ~(IXON | IXOFF | IXANY); // shut off xon/xoff ctrl
+
+  tty.c_cflag |= (CLOCAL | CREAD);   // ignore modem controls,
+                                     // enable reading
+  tty.c_cflag &= ~(PARENB | PARODD); // shut off parity
+  tty.c_cflag &= ~CSTOPB;
+  tty.c_cflag &= ~CRTSCTS;
+
+  if (tcsetattr(fd_, TCSANOW, &tty) != 0) {
+    std::cerr << "Error from tcsetattr" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+void SerialPort::close_port() {
+  if (fd_ >= 0) {
+    close(fd_);
+    fd_ = -1;
+  }
+}
+
+SerialPort::~SerialPort() {
+  close_port();
+}
+void SerialPort::start_read_thread() {
+  char buf[256];
+  try {
+    printf("SerailPort: start read from %s\n", device_);
+    while (running) {
+      fd_set readfds;
+      FD_ZERO(&readfds);
+      FD_SET(fd_, &readfds);
+      int ret = select(fd_ + 1, &readfds, nullptr, nullptr, nullptr);
+      if (ret > 0 && FD_ISSET(fd_, &readfds)) {
+        ssize_t n = read(fd_, buf, sizeof(buf) - 1);
+        if (n > 0) {
+          buf[n] = '\0';
+          printf("%s", buf);
+        }
+      }
+    }
+  } catch (const std::exception &e) {
+    std::cerr << "SerialPort: exception " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "SerialPort: unknown exception" << std::endl;
+  }
+}
+
+void SerialPort::start_write_thread() {
+  try {
+    printf("SerialPort: start write to %s\n", device_);
+    std::string line;
+    while (running) {
+      fd_set readfds;
+      FD_ZERO(&readfds);
+      FD_SET(STDIN_FILENO, &readfds);
+      timeval tv{1, 0}; // eheck timeout per second
+      int ret = select(STDIN_FILENO + 1, &readfds, nullptr, nullptr, &tv);
+      if (ret > 0 && FD_ISSET(STDIN_FILENO, &readfds)) {
+        std::string line;
+        if (std::getline(std::cin, line)) {
+          line.push_back('\n');
+          write(fd_, line.c_str(), line.size());
+        }
+      }
+    }
+  } catch (const std::exception &e) {
+    std::cerr << "SerialPort: exception " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "SerialPort: unknown exception" << std::endl;
+  }
+}
+
+#endif // USE_SERIAL_PORT

--- a/src/test/csrc/fpga/serial_port.h
+++ b/src/test/csrc/fpga/serial_port.h
@@ -1,0 +1,58 @@
+/***************************************************************************************
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+#include <termios.h>
+#include <thread>
+#include <unistd.h>
+#ifdef USE_SERIAL_PORT
+
+class SerialPort {
+public:
+  SerialPort(const char *device) : fd_(-1), device_(device) {}
+  ~SerialPort();
+  void start() {
+    running = true;
+    open_port(B115200);
+    read_thread = std::thread(&SerialPort::start_read_thread, this);
+    write_thread = std::thread(&SerialPort::start_write_thread, this);
+  }
+  void stop() {
+    running = false;
+    if (read_thread.joinable()) {
+      read_thread.join();
+    }
+    if (write_thread.joinable()) {
+      write_thread.join();
+    }
+  }
+
+private:
+  bool running = false;
+  int fd_;
+  const char *device_;
+  std::thread read_thread;
+  std::thread write_thread;
+  bool open_port(int baudrate);
+  void close_port();
+  void start_read_thread();
+  void start_write_thread();
+};
+
+#endif // USE_SERIAL_PORT


### PR DESCRIPTION
This change enable USE_SERIAL_PORT by default, and support read/write
serial with fpga-host instead of another minicom session.