### PR TITLE
fix(emu): dump performance counters even if NO_DIFF

### DIFF
--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -532,7 +532,7 @@ Emulator::~Emulator() {
 
   // warning: this function may still simulate the circuit
   // simulator resources must be released after this function
-  display_trapinfo();
+  display_stats();
 
 #ifndef CONFIG_NO_DIFFTEST
   stats.update(difftest[0]->dut);
@@ -916,7 +916,7 @@ void Emulator::trigger_stat_dump() {
   single_cycle();
 }
 
-void Emulator::display_trapinfo() {
+void Emulator::display_stats() {
 #ifndef CONFIG_NO_DIFFTEST
   for (int i = 0; i < NUM_CORES; i++) {
     printf("Core %d: ", i);
@@ -943,11 +943,11 @@ void Emulator::display_trapinfo() {
     runahead[i]->memdep_watcher->print_pred_matrix();
 #endif
   }
+#endif // CONFIG_NO_DIFFTEST
 
   if (trapCode != STATE_ABORT) {
     trigger_stat_dump();
   }
-#endif // CONFIG_NO_DIFFTEST
 }
 
 void Emulator::snapshot_save() {

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -93,7 +93,7 @@ private:
   inline void reset_ncycles(size_t cycles);
   inline void single_cycle();
   void trigger_stat_dump();
-  void display_trapinfo();
+  void display_stats();
 
   inline const char *logdb_filename() {
     return create_noop_filename(".db");


### PR DESCRIPTION
Performance counters should be dumped even if NO_DIFF is specified. Note that these top interfaces always exist even if DiffTest is disabled.