### PR TITLE
feat(dut): always show stats after simulation

### DIFF
--- a/src/test/csrc/common/dut.h
+++ b/src/test/csrc/common/dut.h
@@ -107,7 +107,7 @@ public:
     for (auto cov: cover) {
       cov->display();
     }
-    simstats_display("ExitCode: %d\n", (int)exit_code);
+    // simstats_display("ExitCode: %d\n", (int)exit_code);
   }
 
   void display_uncovered_points() {

--- a/src/test/csrc/common/main.cpp
+++ b/src/test/csrc/common/main.cpp
@@ -51,8 +51,8 @@ int main(int argc, const char *argv[]) {
 
 #ifdef FUZZER_LIB
   stats.accumulate();
-  stats.display();
 #endif
+  stats.display();
 
   common_finish();
 


### PR DESCRIPTION
This would dump coverage metrics after every simulation when enabled.