### PR TITLE
fix(difftest): enable check before first commit

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -337,10 +337,6 @@ inline int Difftest::check_all() {
   cmo_inval_event_record();
 #endif // CONFIG_DIFFTEST_CMOINVALEVENT
 
-  if (!has_commit) {
-    return 0;
-  }
-
 #ifdef DEBUG_REFILL
   if (do_irefill_check() || do_drefill_check() || do_ptwrefill_check()) {
     return 1;


### PR DESCRIPTION
Some checks may be checked before first commits, such as NonRegInterruptPending may be valid at the end of reset, which will be used to sync Time interrupts to REF.

This change remove has_commit cond to allow check before.