### PR TITLE
fix(serial): flush buffer at every print

### DIFF
--- a/src/test/csrc/fpga/serial_port.cpp
+++ b/src/test/csrc/fpga/serial_port.cpp
@@ -72,6 +72,7 @@ void SerialPort::start_read_thread() {
   char buf[256];
   try {
     printf("SerailPort: start read from %s\n", device_);
+    setvbuf(stdout, NULL, _IONBF, 0);
     while (running) {
       fd_set readfds;
       FD_ZERO(&readfds);


### PR DESCRIPTION
This change disables the output buffer of the FPGA UART, enabling the host to print data from the serial port directly to the terminal in time.