### PR TITLE
Delta: support variable elemByteSize for narrow data type

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -48,8 +48,8 @@ sealed trait DifftestBaseBundle extends Bundle {
   }
 }
 
-class DeltaElem extends DifftestBaseBundle {
-  val data = UInt(64.W)
+class DeltaElem(elemBytes: Int) extends DifftestBaseBundle {
+  val data = UInt((elemBytes * 8).W)
 }
 
 class ArchEvent extends DifftestBaseBundle with HasValid {

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -235,7 +235,7 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
     }
     unpack += getPacketDecl(gen, "", config)
     val size = if (config.isDelta && gen.isDeltaElem) {
-      "sizeof(uint64_t)"
+      s"sizeof(uint${gen.deltaElemBytes * 8}_t)"
     } else {
       s"sizeof(${gen.desiredModuleName})"
     }

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -37,7 +37,8 @@ object Delta {
     val deltaInsts = instances.filter(_.supportsDelta).distinct
     val deltaDecl = deltaInsts.map { inst =>
       val len = inst.dataElements.flatMap(_._3).length
-      s"uint64_t ${inst.desiredCppName}_elem[$len];"
+      val elemType = s"uint${inst.deltaElemBytes * 8}_t"
+      s"$elemType ${inst.desiredCppName}_elem[$len];"
     }
 
     deltaCpp += "#ifndef __DIFFTEST_DELTA_H__"

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -117,7 +117,7 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
       val isRemoved = isFlatten && Seq("valid", "address").contains(name)
       if (!isRemoved) {
         // Align elem to 8 bytes for bundle enabled to split when Delta
-        val elemSize = if (this.supportsDelta && aligned) (size + 7) / 8 * 8 else size
+        val elemSize = if (this.supportsDelta && aligned) deltaElemBytes else size
         val arrayType = s"uint${elemSize * 8}_t"
         val arrayWidth = if (elem.length == 1) "" else s"[${elem.length}]"
         cpp += f"  $arrayType%-8s $name$arrayWidth;"
@@ -172,6 +172,7 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
 
   val supportsDelta: Boolean = false
   def isDeltaElem: Boolean = this.isInstanceOf[DiffDeltaElem]
+  def deltaElemBytes: Int = dataElements.map(_._2).max
 
   // Byte align all elements
   def getByteAlignElems(isTrace: Boolean): Seq[(String, Data)] = {
@@ -227,7 +228,10 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   }
 }
 
-class DiffDeltaElem(gen: DifftestBundle) extends DeltaElem with DifftestBundle with DifftestWithIndex {
+class DiffDeltaElem(gen: DifftestBundle)
+  extends DeltaElem(gen.deltaElemBytes)
+  with DifftestBundle
+  with DifftestWithIndex {
   override val desiredCppName: String = gen.desiredCppName + "_elem"
   override def desiredModuleName: String = gen.desiredModuleName + "Elem"
 }

--- a/src/main/scala/util/Query.scala
+++ b/src/main/scala/util/Query.scala
@@ -107,7 +107,7 @@ class QueryTable(val gen: DifftestBundle, locPrefix: String) {
        |  }
        |""".stripMargin
   val initInvoke = s"${tableName}_init();"
-  val packetType = if (gen.isDeltaElem) "uint64_t" else gen.desiredModuleName
+  val packetType = if (gen.isDeltaElem) s"uint${gen.deltaElemBytes * 8}_t" else gen.desiredModuleName
   val writeDecl =
     s"""
        |  void ${tableName}_write(${locArgs.map("uint8_t " + _._2).mkString(", ")}, ${packetType}* packet) {


### PR DESCRIPTION
DeltaElem bitwidth is now dynamically determined rather than fixed
at 64 bits, allowing efficient handling of narrower data types such
as RenameTable entries.