### PR TITLE
feat(simfrontend): add support for the simfrontend(ideal)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,14 @@ SIM_CXXFLAGS += -I$(abspath $(PLUGIN_CSRC_DIR)/runahead)
 SIM_CXXFILES += $(shell find $(PLUGIN_CSRC_DIR)/runahead -name "*.cpp")
 endif
 
+# SimFrontend plugin
+ifeq ($(ENABLE_SIMFRONTEND), 1)
+TRACE_CSR_DIR = $(abspath ./src/test/csrc/plugin/simfrontend)
+SIM_CXXFILES += $(shell find $(TRACE_CSR_DIR) -name "*.cpp")
+SIM_CXXFLAGS += -I$(TRACE_CSR_DIR) -DPLUGIN_SIMFRONTEND
+endif
+
+
 # Check if XFUZZ is set
 ifeq ($(XFUZZ), 1)
 XFUZZ_HOME_VAR = XFUZZ_HOME

--- a/src/test/csrc/plugin/simfrontend/debug.h
+++ b/src/test/csrc/plugin/simfrontend/debug.h
@@ -1,0 +1,45 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef TRACE_DEBUG_H
+#define TRACE_DEBUG_H
+
+#ifdef ENABLE_TRACE_DEBUG
+
+#define DEBUG_INFO_IF(condition, ...) \
+  do {                                \
+    if (condition) {                  \
+      __VA_ARGS__;                    \
+    }                                 \
+  } while (0)
+
+// Implement it anywhere when you need it.
+bool get_debug_flag();
+
+#define DEBUG_INFO(code)     \
+  if (get_debug_flag()) {    \
+    std::cout << "[TRACE] "; \
+    code;                    \
+  }
+
+#else
+
+#define DEBUG_INFO_IF(condition, ...)
+#define DEBUG_INFO(code)
+
+#endif // ENABLE_DEBUG
+
+#endif // TRACE_DEBUG_H

--- a/src/test/csrc/plugin/simfrontend/ftq.cpp
+++ b/src/test/csrc/plugin/simfrontend/ftq.cpp
@@ -1,0 +1,588 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#include "ftq.h"
+#include "debug.h"
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <sys/types.h>
+
+static bool is_link_register(uint32_t reg_idx) {
+  return (reg_idx == 1 || reg_idx == 5);
+}
+
+static BrType get_br_type(uint32_t instr, bool rvc) {
+  if (rvc) {
+    uint32_t opcode = instr & 0x3;
+    uint32_t funct3 = (instr >> 13) & 0x7;
+
+    if (opcode == 0b01) {
+      if (funct3 == 0b101)
+        return BrType::Jal;
+      if (funct3 == 0b110 || funct3 == 0b111)
+        return BrType::Branch; // C.BEQZ, C.BNEZ
+    } else if (opcode == 0b10) {
+      uint32_t funct5 = (instr >> 2) & 0x1F;
+      if (funct3 == 0b100 && funct5 == 0b00000)
+        return BrType::Jalr;
+    }
+  } else {
+    uint32_t opcode = instr & 0x7F;
+    uint32_t funct3 = (instr >> 13) & 0x7;
+    if (opcode == 0b1100011)
+      return BrType::Branch; // B-type instructions
+    if (opcode == 0b1101111)
+      return BrType::Jal; // JAL
+    if (opcode == 0b1100111 && funct3 == 0b000)
+      return BrType::Jalr; // JALR
+  }
+  return BrType::NotCfi;
+}
+
+bool parse_line(std::string_view line, uint64_t &pc, uint32_t &instr) {
+  size_t colon_pos = line.find(':');
+  if (colon_pos == std::string_view::npos) {
+    std::cout << "This: { " << line << " } parsec failed" << std::endl;
+    assert(false && "Line format error: no colon found");
+  }
+
+  std::string_view pc_sv = line.substr(0, colon_pos);
+  std::string_view instr_sv = line.substr(colon_pos + 1);
+
+  if (pc_sv.empty() || instr_sv.empty()) {
+    return false;
+  }
+
+  auto res_pc = std::from_chars(pc_sv.data(), pc_sv.data() + pc_sv.size(), pc, 16);
+  if (res_pc.ec != std::errc() || res_pc.ptr != pc_sv.data() + pc_sv.size()) {
+    return false;
+  }
+
+  auto res_instr = std::from_chars(instr_sv.data(), instr_sv.data() + instr_sv.size(), instr, 16);
+  if (res_instr.ec != std::errc() || res_instr.ptr != instr_sv.data() + instr_sv.size()) {
+    return false;
+  }
+
+  return true;
+}
+
+RiscvInstructionInfo analyze_instruction(uint32_t instr) {
+  RiscvInstructionInfo info;
+
+  info.isRVC = is_rvc(instr);
+  info.brType = get_br_type(instr, info.isRVC);
+
+  if (info.isRVC) {
+    info.rd = instr >> 12 & 0x1;
+    if (info.brType == BrType::Jal) {
+      info.rs1 = 0;
+    } else {
+      info.rs1 = (instr >> 7) & 0x1F;
+    }
+  } else {
+    info.rd = (instr >> 7) & 0x1F;
+    info.rs1 = (instr >> 15) & 0x1F;
+  }
+
+  bool is_jal_not_rvc = (info.brType == BrType::Jal && !info.isRVC);
+  bool is_jalr = (info.brType == BrType::Jalr);
+
+  info.isCall = (is_jal_not_rvc || is_jalr) && is_link_register(info.rd);
+  info.isRet = (info.brType == BrType::Jalr) && is_link_register(info.rs1) && !info.isCall;
+
+  return info;
+}
+
+#include <type_traits>
+template <typename T> void set_bit_field(T &data, T value, int position, int width) {
+  static_assert(std::is_unsigned_v<T>, "set_bit_field can only be used with unsigned types.");
+
+  T mask = (static_cast<T>(1) << width) - 1;
+  data &= ~(mask << position);
+  data |= (value & mask) << position;
+}
+
+template <typename T> T get_bit_field(T data, int position, int width) {
+  static_assert(std::is_unsigned_v<T>, "get_bit_field can only be used with unsigned types.");
+
+  T mask = (static_cast<T>(1) << width) - 1;
+  return (data >> position) & mask;
+}
+
+uint32_t pack_trace_data(const RiscvInstructionInfo &info, bool pred_taken, bool is_last_ftq_entry, bool wrap,
+                         uint32_t queue_id, uint32_t offset) {
+  uint32_t packed_value = 0;
+
+  const uint32_t val_is_rvc = static_cast<uint32_t>(info.isRVC);
+  const uint32_t val_br_type = static_cast<uint32_t>(info.brType);
+  const uint32_t val_is_call = static_cast<uint32_t>(info.isCall);
+  const uint32_t val_is_ret = static_cast<uint32_t>(info.isRet);
+  const uint32_t val_pred_taken = static_cast<uint32_t>(pred_taken);
+  const uint32_t val_queue_id = static_cast<uint32_t>(queue_id);
+  const uint32_t val_queue_wrap = static_cast<uint32_t>(wrap);
+  const uint32_t val_offset = static_cast<uint32_t>(offset);
+  const uint32_t val_is_last_entr = static_cast<uint32_t>(is_last_ftq_entry);
+
+  packed_value |= (1ULL << POS_CONST);
+  packed_value |= (val_is_rvc << POS_IS_RVC);
+  packed_value |= (val_br_type << POS_BR_TYPE);
+  packed_value |= (val_is_call << POS_IS_CALL);
+  packed_value |= (val_is_ret << POS_IS_RET);
+  packed_value |= (val_pred_taken << POS_PRED_TAKEN);
+  packed_value |= (val_queue_id << POS_QUEUE_ID);
+  packed_value |= (val_queue_wrap << POS_QUEUE_ID_WRAP);
+  packed_value |= (val_is_last_entr << POS_IS_LAST_ENTRY);
+  packed_value |= (val_offset << POS_OFFSET);
+
+  return packed_value;
+}
+
+UnpackedTraceData unpack_trace_data(uint32_t packed_data) {
+  UnpackedTraceData unpacked;
+
+  unpacked.isRVC = get_bit_field(packed_data, POS_IS_RVC, WIDTH_IS_RVC);
+  unpacked.brType = static_cast<BrType>(get_bit_field(packed_data, POS_BR_TYPE, WIDTH_BR_TYPE));
+  unpacked.isCall = get_bit_field(packed_data, POS_IS_CALL, WIDTH_IS_CALL);
+  unpacked.isRet = get_bit_field(packed_data, POS_IS_RET, WIDTH_IS_RET);
+  unpacked.pred_taken = get_bit_field(packed_data, POS_PRED_TAKEN, WIDTH_PRED_TAKEN);
+  unpacked.queue_id = get_bit_field(packed_data, POS_QUEUE_ID, WIDTH_QUEUE_ID);
+  unpacked.queue_wrap = get_bit_field(packed_data, POS_QUEUE_ID_WRAP, WIDTH_QUEUE_ID_WRAP);
+  unpacked.is_last_ftq_entry = get_bit_field(packed_data, POS_IS_LAST_ENTRY, WIDTH_IS_LAST_ENTRY);
+  unpacked.offset = get_bit_field(packed_data, POS_OFFSET, WIDTH_OFFSET);
+
+  return unpacked;
+}
+
+static std::string br_type_to_string_tb(BrType type) {
+  switch (type) {
+    case BrType::NotCfi: return "NotCfi";
+    case BrType::Branch: return "Branch";
+    case BrType::Jal: return "Jal";
+    case BrType::Jalr: return "Jalr";
+    default: return "Unknown";
+  }
+}
+
+bool out_is_discontinuous(uint64_t current_pc, bool current_instr_isrvc, uint64_t next_pc) {
+  uint64_t expected_pc = current_pc + (current_instr_isrvc ? 2 : 4);
+  bool discontinuous = (next_pc != expected_pc);
+
+  return discontinuous;
+}
+
+ContinuityChecker::ContinuityChecker() : last_pc(0), last_instr_was_rvc(false), is_first_call(true) {}
+
+bool ContinuityChecker::is_discontinuous(uint64_t current_pc, uint32_t current_instr) {
+  if (is_first_call) {
+    is_first_call = false;
+    update_state(current_pc, current_instr);
+    return true;
+  }
+
+  uint64_t expected_pc = last_pc + (last_instr_was_rvc ? 2 : 4);
+
+  bool discontinuous = (current_pc != expected_pc);
+
+  update_state(current_pc, current_instr);
+
+  return discontinuous;
+}
+
+bool ContinuityChecker::is_discontinuous(uint64_t current_pc, bool current_instr_isrvc, uint64_t next_pc) {
+  uint64_t expected_pc = current_pc + (current_instr_isrvc ? 2 : 4);
+  bool discontinuous = (next_pc != expected_pc);
+
+  return discontinuous;
+}
+
+void ContinuityChecker::update_state(uint64_t pc, uint32_t instr) {
+  last_pc = pc;
+  last_instr_was_rvc = is_rvc(instr);
+}
+
+// ***************************
+// FTQ
+// ***************************
+
+FetchTargetQueue::FetchTargetQueue()
+    : enq_ptr(0), read_ptr(0), commit_ptr(0), id_head(0), id_tail(0), id_read_ptr(0), id_head_wrap(false),
+      id_tail_wrap(false), id_read_wrap(false), accumulated_bytes(0) {}
+
+bool FetchTargetQueue::will_start_new_group(bool is_discontinuous, uint32_t next_bytes) const {
+  return is_discontinuous || accumulated_bytes + next_bytes > 32;
+}
+
+void FetchTargetQueue::set_final() {
+  if (final)
+    return;
+  if ((id_tail + 1) % ID_QUEUE_SIZE == id_head)
+    return;
+  if (id_tail == ID_QUEUE_SIZE - 1)
+    id_tail_wrap = !id_tail_wrap;
+  id_tail = (id_tail + 1) % ID_QUEUE_SIZE;
+  final = true;
+  return;
+};
+
+bool FetchTargetQueue::is_full() const {
+  if ((id_tail + 1) % ID_QUEUE_SIZE == id_head)
+    return true;
+  return false;
+}
+
+extern uint64_t debug_line_number;
+bool FetchTargetQueue::enqueue(uint64_t pc, uint32_t instr, uint64_t next_pc, uint32_t next_instr,
+                               bool is_discontinuous) {
+  if (is_full())
+    return false;
+  bool offset_init = false;
+  if (!id_queue[id_tail].is_valid) {
+    id_queue[id_tail] = {true, enq_ptr, 0, id_tail_wrap};
+    accumulated_bytes = 0;
+    offset_init = true;
+  }
+
+  uint32_t next_bytes = is_rvc(instr) ? 2 : 4;
+  bool starts_new_group = will_start_new_group(is_discontinuous, next_bytes);
+
+  if (starts_new_group && id_queue[id_tail].instr_count > 0) {
+    if ((id_tail + 1) % ID_QUEUE_SIZE == id_head)
+      return false;
+
+    if (id_tail == ID_QUEUE_SIZE - 1) {
+      id_tail_wrap = !id_tail_wrap;
+    }
+
+    id_tail = (id_tail + 1) % ID_QUEUE_SIZE;
+
+    id_queue[id_tail] = {true, enq_ptr, 0, id_tail_wrap};
+    accumulated_bytes = 0;
+    offset_init = true;
+  } else if (id_queue[id_tail].instr_count >= MAX_INSTRS_PER_GROUP) {
+
+    if ((id_tail + 1) % ID_QUEUE_SIZE == id_head)
+      return false;
+    if (id_tail == ID_QUEUE_SIZE - 1)
+      id_tail_wrap = !id_tail_wrap;
+    id_tail = (id_tail + 1) % ID_QUEUE_SIZE;
+    id_queue[id_tail] = {true, enq_ptr, 0, id_tail_wrap};
+    accumulated_bytes = 0;
+    offset_init = true;
+  }
+
+  size_t current_group_id = id_tail;
+  size_t current_group_wrap = id_tail_wrap;
+  RiscvInstructionInfo riscv_info = analyze_instruction(instr);
+  // uint32_t offset = offset_init ? 0 : (pc - target_queue[id_queue[current_group_id].start_index].pc) >> 1; // frist
+  uint32_t offset = offset_init
+                        ? (is_rvc(instr) ? 0 : 1)
+                        : (pc - target_queue[id_queue[current_group_id].start_index].pc + (is_rvc(instr) ? 0 : 2)) >> 1;
+
+  bool next_is_discontinuous = out_is_discontinuous(pc, is_rvc(instr), next_pc);
+  bool br_taken = next_is_discontinuous;
+
+  uint32_t self_and_next_bytes = (is_rvc(instr) ? 2 : 4) + (is_rvc(next_instr) ? 2 : 4);
+  bool is_last_ftq_entry = will_start_new_group(next_is_discontinuous, self_and_next_bytes);
+
+  uint64_t packed_data =
+      pack_trace_data(riscv_info, br_taken, is_last_ftq_entry, current_group_wrap, current_group_id, offset);
+
+  auto unpacked_data = unpack_trace_data(packed_data);
+
+  accumulated_bytes += next_bytes;
+  target_queue[enq_ptr] = {pc, instr, packed_data, current_group_id, current_group_wrap, debug_line_number};
+  enq_ptr = (enq_ptr + 1) % INSTR_QUEUE_SIZE;
+  id_queue[current_group_id].instr_count++;
+
+  return true;
+}
+
+std::optional<FTQEntry> FetchTargetQueue::read() {
+  if (read_ptr == enq_ptr)
+    return std::nullopt;
+  FTQEntry entry = target_queue[read_ptr];
+  read_ptr = (read_ptr + 1) % INSTR_QUEUE_SIZE;
+  return entry;
+}
+
+std::optional<FTQEntry> FetchTargetQueue::read_offset(uint32_t offset) {
+  if (offset >= readable_size()) {
+    return std::nullopt;
+  }
+  size_t physical_index = (read_ptr + offset) % INSTR_QUEUE_SIZE;
+  FTQEntry entry = target_queue[physical_index];
+  read_ptr = (physical_index + 1) % INSTR_QUEUE_SIZE;
+
+  return entry;
+}
+
+std::optional<FTQEntry> FetchTargetQueue::peek() const {
+  if (read_ptr == enq_ptr)
+    return std::nullopt;
+  return target_queue[read_ptr];
+}
+
+std::optional<FTQEntry> FetchTargetQueue::peek_offset(size_t offset) const {
+  if (offset >= readable_size()) {
+    return std::nullopt;
+  }
+
+  size_t physical_index = (read_ptr + offset) % INSTR_QUEUE_SIZE;
+
+  return target_queue[physical_index];
+}
+
+bool FetchTargetQueue::set_read_ptr_offset(size_t offset) {
+  if (offset > readable_size()) {
+    return false;
+  }
+
+  read_ptr = (read_ptr + offset) % INSTR_QUEUE_SIZE;
+
+  return true;
+}
+
+bool FetchTargetQueue::set_read_ptr(size_t index) {
+  if (index > uncommitted_size()) {
+    return false;
+  }
+
+  read_ptr = (commit_ptr + index) % INSTR_QUEUE_SIZE;
+
+  return true;
+}
+
+size_t FetchTargetQueue::uncommitted_size() const {
+  if (enq_ptr >= commit_ptr)
+    return enq_ptr - commit_ptr;
+  return INSTR_QUEUE_SIZE - (commit_ptr - enq_ptr);
+}
+size_t FetchTargetQueue::readable_size() const {
+  if (enq_ptr >= read_ptr)
+    return enq_ptr - read_ptr;
+  return INSTR_QUEUE_SIZE - (read_ptr - enq_ptr);
+}
+
+std::optional<FTQEntry> FetchTargetQueue::get_entry(size_t index) const {
+  if (index >= uncommitted_size())
+    return std::nullopt;
+  size_t physical_index = (commit_ptr + index) % INSTR_QUEUE_SIZE;
+  return target_queue[physical_index];
+}
+
+std::optional<FTQEntry> FetchTargetQueue::get_physical_entry(size_t index) const {
+  if (index >= INSTR_QUEUE_SIZE)
+    return std::nullopt;
+  return target_queue[index];
+}
+
+size_t FetchTargetQueue::id_queue_committed_size() const {
+  if (id_tail == id_head) {
+    return (id_tail_wrap == id_head_wrap) ? 0 : ID_QUEUE_SIZE;
+  } else if (id_tail > id_head) {
+    return id_tail - id_head;
+  } else {
+    return ID_QUEUE_SIZE - (id_head - id_tail);
+  }
+}
+
+size_t FetchTargetQueue::id_queue_readable_size() const {
+  if (id_tail == id_read_ptr) {
+    return (id_tail_wrap == id_read_wrap) ? 0 : ID_QUEUE_SIZE;
+  } else if (id_tail > id_read_ptr) {
+    return id_tail - id_read_ptr;
+  } else {
+    return ID_QUEUE_SIZE - (id_read_ptr - id_tail);
+  }
+}
+
+std::optional<FetchGroupInfo> FetchTargetQueue::peek_id_group(size_t offset) const {
+  if (offset >= id_queue_readable_size()) {
+    return std::nullopt;
+  }
+  size_t physical_index = (id_read_ptr + offset) % ID_QUEUE_SIZE;
+  return id_queue[physical_index];
+}
+
+std::optional<FetchGroupInfo> FetchTargetQueue::read_id_group() {
+  if (id_queue_readable_size() == 0) {
+    return std::nullopt;
+  }
+
+  FetchGroupInfo group_info = id_queue[id_read_ptr];
+
+  if (id_read_ptr == ID_QUEUE_SIZE - 1) {
+    id_read_wrap = !id_read_wrap;
+  }
+  id_read_ptr = (id_read_ptr + 1) % ID_QUEUE_SIZE;
+
+  return group_info;
+}
+
+bool FetchTargetQueue::commit_to(size_t target_group_id, bool target_wrap_bit) {
+  if (target_group_id >= ID_QUEUE_SIZE || !id_queue[target_group_id].is_valid) {
+    std::cout << "commit_to failed: target_group_id " << target_group_id << " is invalid or does not exist.\n";
+    return false;
+  }
+  if (id_queue[target_group_id].wrap_bit != target_wrap_bit) {
+    std::cout << "commit_to failed: target_group_id " << target_group_id << " wrap bit mismatch.\n";
+    return false;
+  }
+
+  while (true) {
+    FetchGroupInfo &group_to_commit = id_queue[id_head];
+
+    if (id_head == id_tail && id_head_wrap == id_tail_wrap) {
+      return false;
+    }
+
+    if (!group_to_commit.is_valid) {
+      return false;
+    }
+
+    commit_ptr = (group_to_commit.start_index + group_to_commit.instr_count) % INSTR_QUEUE_SIZE;
+
+    bool was_target = (id_head == target_group_id && id_head_wrap == target_wrap_bit);
+
+    advance_id_head();
+
+    if (was_target) {
+      break;
+    }
+  }
+
+  if (uncommitted_size() < readable_size()) {
+    read_ptr = commit_ptr;
+  }
+
+  return true;
+}
+
+bool FetchTargetQueue::commit_to_right_open(size_t target_group_id, bool target_wrap_bit) {
+  if (target_group_id >= ID_QUEUE_SIZE || !id_queue[target_group_id].is_valid) {
+    return false;
+  }
+  if (id_queue[target_group_id].wrap_bit != target_wrap_bit) {
+    return false;
+  }
+
+  while (id_head != target_group_id || id_head_wrap != target_wrap_bit) {
+
+    if (id_head == id_tail && id_head_wrap == id_tail_wrap) {
+      return false;
+    }
+
+    FetchGroupInfo &group_to_commit = id_queue[id_head];
+    if (!group_to_commit.is_valid) {
+      return false;
+    }
+
+    commit_ptr = (group_to_commit.start_index + group_to_commit.instr_count) % INSTR_QUEUE_SIZE;
+
+    advance_id_head();
+  }
+
+  if (uncommitted_size() < readable_size() || (read_ptr == commit_ptr && readable_size() > 0)) {
+    bool commit_is_ahead = (commit_ptr > read_ptr && id_head_wrap == id_read_wrap) || (id_head_wrap != id_read_wrap);
+    if (uncommitted_size() < readable_size()) {
+      read_ptr = commit_ptr;
+    }
+  }
+
+  return true;
+}
+
+#define PC_MASK 0x3FFFFFFFFFFFF
+bool FetchTargetQueue::redirect(size_t target_group_id, bool target_wrap_bit, uint64_t target_pc) {
+
+  if (target_group_id >= ID_QUEUE_SIZE || !id_queue[target_group_id].is_valid ||
+      id_queue[target_group_id].wrap_bit != target_wrap_bit) {
+    return false;
+  }
+  const FetchGroupInfo &target_group = id_queue[target_group_id];
+
+  for (size_t i = 0; i < target_group.instr_count; ++i) {
+    size_t physical_index = (target_group.start_index + i) % INSTR_QUEUE_SIZE;
+    uint64_t entry_pc = target_queue[physical_index].pc & PC_MASK;
+    if (entry_pc == target_pc) {
+
+      id_read_ptr = target_group_id;
+      id_read_wrap = target_wrap_bit;
+      read_ptr = physical_index;
+      return true;
+    }
+  }
+
+  //exception & prediction failure
+  size_t next_group_id = (target_group_id + 1) % ID_QUEUE_SIZE;
+  bool next_wrap_bit = (target_group_id == ID_QUEUE_SIZE - 1) ? !target_wrap_bit : target_wrap_bit;
+
+  if (next_group_id == id_tail && next_wrap_bit == id_tail_wrap && !id_queue[next_group_id].is_valid) {
+
+    DEBUG_INFO(std::cout << std::hex << "Redirect Failed: ftq empty " << "next ftq: 0x" << next_group_id << ", "
+                         << next_wrap_bit << " " << "tail idx: 0x" << id_tail << " tail wrap: " << id_tail_wrap
+                         << std::dec << std::endl;)
+
+    return false;
+  }
+  if (!id_queue[next_group_id].is_valid || id_queue[next_group_id].wrap_bit != next_wrap_bit) {
+
+    DEBUG_INFO(std::cout << std::hex << "Redirect Failed: next not valid or wrap mismatch " << "next valid "
+                         << id_queue[next_group_id].is_valid << "next ftq: 0x" << next_group_id << ", " << next_wrap_bit
+                         << " " << "need wrap: " << id_queue[next_group_id].wrap_bit << std::dec << std::endl;)
+
+    return false;
+  }
+
+  const FetchGroupInfo &next_group = id_queue[next_group_id];
+  uint64_t next_start_pc = target_queue[next_group.start_index].pc & PC_MASK;
+  if (next_start_pc == target_pc) {
+    id_read_ptr = next_group_id;
+    id_read_wrap = next_wrap_bit;
+    read_ptr = next_group.start_index;
+    return true;
+  }
+
+  DEBUG_INFO(std::cout << std::hex << "Redirect Failed: " << " next ftq: 0x" << next_group_id << " next start pc: 0x"
+                       << target_queue[next_group.start_index].pc << " next line: 0x"
+                       << target_queue[next_group.start_index].line_number << std::dec << std::endl;)
+
+  return false;
+}
+
+void FetchTargetQueue::advance_id_head() {
+  if (id_queue_committed_size() == 0)
+    return;
+
+  id_queue[id_head].is_valid = false;
+  if (id_head == ID_QUEUE_SIZE - 1) {
+    id_head_wrap = !id_head_wrap;
+  }
+  id_head = (id_head + 1) % ID_QUEUE_SIZE;
+}
+
+void FetchTargetQueue::print_ftq_state(size_t idx) {
+  if (idx >= INSTR_QUEUE_SIZE) {
+    std::cout << "Index out of bounds\n";
+    return;
+  }
+  auto ftq = id_queue[idx];
+  std::cout << "FTQ Entry at index " << idx << std::hex << " Valid: " << ftq.is_valid
+            << " Start Pc: " << target_queue[ftq.start_index].pc << " Instruction Count: " << ftq.instr_count
+            << " Wrap Bit: " << ftq.wrap_bit << std::dec << std::endl;
+}

--- a/src/test/csrc/plugin/simfrontend/ftq.h
+++ b/src/test/csrc/plugin/simfrontend/ftq.h
@@ -1,0 +1,229 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef FTQ_H
+#define FTQ_H
+
+#include <array>
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <vector>
+
+enum class BrType {
+  NotCfi,
+  Branch,
+  Jal,
+  Jalr
+};
+
+enum TraceBitPositions {
+  POS_CONST = 0,
+  POS_IS_RVC = 1,
+  POS_BR_TYPE = 2,
+  POS_IS_CALL = 4,
+  POS_IS_RET = 5,
+  POS_PRED_TAKEN = 6,
+  POS_QUEUE_ID = 7,
+  POS_QUEUE_ID_WRAP = 13,
+  POS_IS_LAST_ENTRY = 14,
+  POS_OFFSET = 15
+};
+
+enum TraceBitWidths {
+  WIDTH_CONST = 1,
+  WIDTH_IS_RVC = 1,
+  WIDTH_BR_TYPE = 2,
+  WIDTH_IS_CALL = 1,
+  WIDTH_IS_RET = 1,
+  WIDTH_PRED_TAKEN = 1,
+  WIDTH_QUEUE_ID = 6,
+  WIDTH_QUEUE_ID_WRAP = 1,
+  WIDTH_IS_LAST_ENTRY = 1,
+  WIDTH_OFFSET = 5,
+};
+
+struct UnpackedTraceData {
+  bool isRVC;
+  BrType brType;
+  bool isCall;
+  bool isRet;
+  bool pred_taken;
+  bool is_last_ftq_entry;
+  bool queue_wrap;
+  uint32_t queue_id;
+  uint32_t offset;
+};
+
+struct RiscvInstructionInfo {
+  bool isRVC;
+  BrType brType;
+  bool isCall;
+  bool isRet;
+
+  uint32_t rd;
+  uint32_t rs1;
+};
+
+static inline bool is_rvc(uint32_t instr) {
+  return (instr & 0x3) != 0x3;
+}
+
+bool parse_line(std::string_view line, uint64_t &pc, uint32_t &instr);
+RiscvInstructionInfo analyze_instruction(uint32_t instr);
+uint32_t pack_trace_data(const RiscvInstructionInfo &info, bool pred_taken, bool is_last_ftq_entry, bool wrap,
+                         uint32_t queue_id, uint32_t offset);
+UnpackedTraceData unpack_trace_data(uint32_t packed_data);
+
+class ContinuityChecker {
+public:
+  ContinuityChecker();
+
+  bool is_discontinuous(uint64_t current_pc, uint32_t current_instr);
+
+  bool is_discontinuous(uint64_t current_pc, bool current_instr_isrvc, uint64_t next_pc);
+
+private:
+  void update_state(uint64_t pc, uint32_t instr);
+
+  uint64_t last_pc;
+  bool last_instr_was_rvc;
+  bool is_first_call;
+};
+
+struct FTQEntry {
+  uint64_t pc;
+  uint32_t instr;
+  uint64_t packed_data;
+  size_t fetch_group_id;
+  bool fetch_group_id_wrap;
+  uint64_t line_number;
+};
+
+struct FetchGroupInfo {
+  bool is_valid = false;
+  size_t start_index = 0;
+  size_t instr_count = 0;
+  bool wrap_bit = false;
+};
+
+class FetchTargetQueue {
+public:
+  static constexpr size_t ID_QUEUE_SIZE = 64;
+  static constexpr size_t INSTR_QUEUE_SIZE = 1024;
+  static constexpr size_t MAX_INSTRS_PER_GROUP = 16;
+
+  FetchTargetQueue();
+
+  void set_final();
+  bool is_full() const;
+
+  bool enqueue(uint64_t pc, uint32_t instr, uint64_t next_pc, uint32_t next_instr, bool is_discontinuous);
+
+  std::optional<FTQEntry> read();
+  std::optional<FTQEntry> read_offset(uint32_t offset);
+  std::optional<FTQEntry> peek() const;
+  std::optional<FTQEntry> peek_offset(size_t offset) const;
+
+  bool set_read_ptr(size_t index);
+  bool set_read_ptr_offset(size_t index);
+
+  size_t uncommitted_size() const;
+  size_t readable_size() const;
+
+  std::optional<FTQEntry> get_entry(size_t index) const;
+  std::optional<FTQEntry> get_physical_entry(size_t index) const;
+
+  size_t id_queue_committed_size() const;
+  size_t id_queue_readable_size() const;
+
+  std::optional<FetchGroupInfo> peek_id_group(size_t offset = 0) const;
+  std::optional<FetchGroupInfo> read_id_group();
+
+  size_t get_read_entry_ptr() {
+    return read_ptr;
+  }
+
+  size_t get_read_ftq_id() {
+    return id_read_ptr;
+  }
+  size_t get_read_wrap() {
+    return id_read_wrap;
+  }
+
+  bool commit_to(size_t target_group_id, bool target_wrap_bit);
+  bool commit_to_right_open(size_t target_group_id, bool target_wrap_bit);
+
+  bool redirect(size_t target_group_id, bool target_wrap_bit, uint64_t target_pc);
+
+  bool will_start_new_group(bool is_discontinuous, uint32_t next_bytes) const;
+
+  void print_ftq_state(size_t idx);
+
+  size_t get_enq_ptr() {
+    return enq_ptr;
+  }
+  size_t get_read_ptr() {
+    return read_ptr;
+  }
+  size_t get_commit_ptr() {
+    return commit_ptr;
+  }
+  size_t get_id_head_ptr() {
+    return id_head;
+  }
+  size_t get_id_tail_ptr() {
+    return id_tail;
+  }
+  size_t get_id_read_ptr() {
+    return id_read_ptr;
+  }
+  bool get_id_head_wrap() {
+    return id_head_wrap;
+  }
+  bool get_id_tail_wrap() {
+    return id_tail_wrap;
+  }
+  bool get_id_read_wrap() {
+    return id_read_wrap;
+  }
+
+  // private:
+  bool final;
+
+  void advance_id_head();
+
+  std::array<FetchGroupInfo, ID_QUEUE_SIZE> id_queue;
+  std::array<FTQEntry, INSTR_QUEUE_SIZE> target_queue;
+
+  size_t enq_ptr;
+  size_t read_ptr;
+  size_t commit_ptr;
+
+  size_t id_head;
+  size_t id_tail;
+  size_t id_read_ptr;
+
+  bool id_head_wrap;
+  bool id_tail_wrap;
+  bool id_read_wrap;
+  int accumulated_bytes;
+};
+#endif // FTQ_H

--- a/src/test/csrc/plugin/simfrontend/simfrontend.cpp
+++ b/src/test/csrc/plugin/simfrontend/simfrontend.cpp
@@ -1,0 +1,220 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#include "simfrontend.h"
+#include "debug.h"
+#include "ftq.h"
+#include "tracereader.h"
+#include <assert.h>
+#include <cstddef>
+#include <cstdio>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <queue>
+#include <stdio.h>
+#include <sys/types.h>
+#include <vector>
+
+bool get_debug_flag() {
+  return true;
+}
+
+uint64_t debug_line_number = 0;
+std::vector<std::string_view> debug_read_line_vector;
+
+MmapLineReader trace_fetch;
+ContinuityChecker PcChecker;
+FetchTargetQueue ftq;
+uint32_t tick_fetch_count = 0;
+
+bool TryFetchNextLine(uint32_t read_count) {
+  if (trace_fetch.is_final)
+    return false;
+
+  std::string_view line;
+  for (uint32_t i = 0; i < read_count; ++i) {
+    if (ftq.is_full())
+      return false;
+    if (!trace_fetch.get_next_line(line)) {
+      ftq.set_final();
+      return false;
+    }
+    debug_line_number = trace_fetch.get_line_read_count();
+
+    uint64_t current_pc;
+    uint32_t current_instr;
+
+    parse_line(line, current_pc, current_instr);
+
+    bool is_discontinuous = PcChecker.is_discontinuous(current_pc, current_instr);
+    uint64_t next_pc = current_pc;
+    uint32_t next_instr = current_instr;
+    std::string_view next_line;
+
+    if (trace_fetch.probe_next_line(next_line)) {
+      parse_line(next_line, next_pc, next_instr);
+    };
+
+    if (!ftq.enqueue(current_pc, current_instr, next_pc, next_instr, is_discontinuous))
+      assert(false && "ftq full");
+  }
+
+  return false;
+}
+
+void SimFrontFetch(int offset, uint64_t *pc, uint32_t *instr, uint32_t *preDecode) {
+  auto entry_option = ftq.peek_offset(offset);
+  bool allow_fetch = false;
+  if (entry_option.has_value()) {
+    allow_fetch = (entry_option->fetch_group_id < ftq.get_id_read_ptr()) ^
+                  (entry_option->fetch_group_id_wrap ^ ftq.get_id_read_wrap());
+  }
+
+  if (allow_fetch) {
+    auto data = unpack_trace_data(entry_option->packed_data);
+    auto entry = entry_option.value();
+    *pc = entry.pc;
+    *instr = entry.instr;
+    *preDecode = entry.packed_data;
+
+    DEBUG_INFO(std::cout << std::hex << "Fetch Line: 0x" << entry.line_number << ", 0x" << entry.pc << ": 0x"
+                         << entry.instr << " ftq: 0x" << entry.fetch_group_id << ", " << entry.fetch_group_id_wrap
+                         << std::dec << std::endl;)
+
+    tick_fetch_count++;
+  } else {
+    *pc = 0;
+    *instr = 0;
+    *preDecode = 0;
+  }
+
+  return;
+}
+
+void SimFrontUpdatePtr(uint32_t updateCount) {
+  if (updateCount != 0) {
+    ftq.set_read_ptr_offset(tick_fetch_count);
+  }
+  tick_fetch_count = 0;
+}
+
+void SimFrontRedirect(uint32_t redirect_valid, uint32_t redirect_ftq_flag, uint32_t redirect_ftq_value,
+                      uint64_t traget_pc) {
+  if (redirect_valid) {
+
+    DEBUG_INFO(std::cout << std::hex << "Redirect start: ftq: 0x" << redirect_ftq_value << ", " << redirect_ftq_value
+                         << " pc: 0x" << traget_pc << std::dec << std::endl;)
+
+    // std::cout << "redirect to ftq id: " << redirect_ftq_value << " wrap: " << redirect_ftq_flag << " pc: 0x" << std::hex << traget_pc << std::dec << std::endl;
+    bool rx = ftq.redirect(redirect_ftq_value, redirect_ftq_flag, traget_pc);
+    if (rx) {
+
+      DEBUG_INFO(std::cout << std::hex << "Redirect finish: ftq: 0x" << ftq.get_read_ftq_id() << ", "
+                           << ftq.get_read_wrap() << std::dec << std::endl;)
+
+    } else {
+      DEBUG_INFO(std::cout << std::hex << "Redirect failed ftq: 0x" << ftq.get_read_ftq_id() << std::dec << std::endl;)
+    }
+  }
+}
+
+void SimFrontGetFtqToBackEnd(uint64_t *pc, uint32_t *pack_data, uint64_t *newest_pc, uint32_t *newest_pack_data) {
+  *pc = 0;
+  *pack_data = 0;
+
+  *newest_pc = 0;
+  *newest_pack_data = 0;
+  size_t ftq_id = ftq.get_read_ftq_id();
+  auto ftq_info = ftq.read_id_group();
+  bool ftq_read_empty = ftq_info.has_value() == false;
+  bool ftq_full = ftq.is_full();
+
+  if (ftq_read_empty) {
+    if (trace_fetch.is_final) {
+      ftq.set_final();
+    }
+    if (trace_fetch.is_final || ftq_full) {
+      return;
+    }
+
+    TryFetchNextLine(32);
+    ftq_info = ftq.read_id_group();
+  }
+
+  auto entry_opt = ftq.get_physical_entry(ftq_info->start_index);
+
+  DEBUG_INFO(std::cout << std::hex << "Ftq to backend current pc: 0x" << entry_opt->pc << " ftq: 0x" << ftq_id
+                       << std::dec << std::endl;)
+
+  *pc = entry_opt->pc;
+  *pack_data = (1ULL << 6) | ftq_id;
+
+  size_t next_id = ftq.get_read_ftq_id();
+  auto newest_ftq_info = ftq.peek_id_group(0);
+  if (!newest_ftq_info.has_value()) {
+    if (trace_fetch.is_final) {
+      return;
+    }
+
+    std::string_view line;
+    uint64_t current_pc;
+    uint32_t current_instr;
+
+    if (!trace_fetch.probe_next_line(line))
+      return;
+    parse_line(line, current_pc, current_instr);
+
+    *newest_pc = current_pc;
+    *newest_pack_data = (1ULL << 6) | ftq_id;
+  } else {
+
+    auto newest_entry_opt = ftq.get_physical_entry(newest_ftq_info->start_index);
+
+    *newest_pc = newest_entry_opt->pc;
+    *newest_pack_data = (1ULL << 6) | ftq_id;
+  }
+
+  DEBUG_INFO(std::cout << std::hex << "Ftq to backend next pc: 0x" << newest_pc << " ftq: 0x"
+                       << ftq.get_physical_entry(newest_ftq_info->start_index)->fetch_group_id << std::dec
+                       << std::endl;)
+}
+
+void SimFrontRobCommit(uint32_t valid, uint32_t ftqIdxFlag, uint32_t ftqIdxValue) {
+  if (valid) {
+
+    DEBUG_INFO(std::cout << std::hex << "Commit start: ftqidexValue: 0x" << ftqIdxValue << ", " << ftqIdxFlag
+                         << " current ftq: 0x" << ftq.get_read_ftq_id() << ", " << ftq.get_read_wrap() << std::dec
+                         << std::endl;)
+
+    ftq.commit_to_right_open(ftqIdxValue, ftqIdxFlag);
+
+    DEBUG_INFO(std::cout << std::hex << "Commit finish: " << " current ftq: 0x" << ftq.get_read_ftq_id() << ", "
+                         << ftq.get_read_wrap() << std::dec << std::endl;)
+  }
+}
+
+bool init_sim_frontend(const std::string &file) {
+  trace_fetch.init(file);
+  if (!trace_fetch.is_open) {
+    std::cerr << "Failed to open file." << std::endl;
+    assert(false && "Failed to open file.");
+    return 1;
+  }
+  std::cout << "Open instrction trace: " << file << std::endl;
+
+  return true;
+}

--- a/src/test/csrc/plugin/simfrontend/simfrontend.h
+++ b/src/test/csrc/plugin/simfrontend/simfrontend.h
@@ -1,0 +1,33 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef SIMFRONTEND_H
+#define SIMFRONTEND_H
+
+#include <cstdint>
+#include <string>
+
+// Align with the functions defined in the blackbox within chisel.
+extern "C" void SimFrontFetch(int offset, uint64_t *pc, uint32_t *instr, uint32_t *preDecode);
+extern "C" void SimFrontUpdatePtr(uint32_t updateCount);
+extern "C" void SimFrontRedirect(uint32_t redirect_valid, uint32_t redirect_ftq_flag, uint32_t redirect_ftq_value,
+                                 uint64_t traget_pc);
+extern "C" void SimFrontGetFtqToBackEnd(uint64_t *pc, uint32_t *pack_data, uint64_t *newest_pc,
+                                        uint32_t *newest_pack_data);
+extern "C" void SimFrontRobCommit(uint32_t valid, uint32_t ftqIdxFlag, uint32_t ftqIdxValue);
+
+bool init_sim_frontend(const std::string &file);
+#endif // SIMFRONTEND_H

--- a/src/test/csrc/plugin/simfrontend/tracereader.cpp
+++ b/src/test/csrc/plugin/simfrontend/tracereader.cpp
@@ -1,0 +1,134 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#include "tracereader.h"
+#include "debug.h"
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+MmapLineReader::MmapLineReader(const std::string &filename) {
+  if (init(filename)) {
+    is_open = true;
+  }
+}
+
+MmapLineReader::~MmapLineReader() {
+  if (mapped_data) {
+    munmap(mapped_data, file_size);
+  }
+  if (fd != -1) {
+    close(fd);
+  }
+}
+
+bool MmapLineReader::init(const std::string &filename) {
+  fd = open(filename.c_str(), O_RDONLY);
+  if (fd == -1) {
+    perror("Error opening file");
+    return false;
+  }
+
+  struct stat sb;
+  if (fstat(fd, &sb) == -1) {
+    perror("Error getting file size");
+    close(fd);
+    fd = -1;
+    return false;
+  }
+  file_size = sb.st_size;
+
+  if (file_size == 0) {
+    is_final = true;
+    is_open = true;
+    read_ptr = nullptr;
+    end_of_file = nullptr;
+    return true;
+  }
+
+  mapped_data = static_cast<char *>(mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0));
+  if (mapped_data == MAP_FAILED) {
+    perror("Error mapping file to memory");
+    close(fd);
+    fd = -1;
+    mapped_data = nullptr;
+    return false;
+  }
+
+  read_ptr = mapped_data;
+  end_of_file = mapped_data + file_size;
+  is_open = true;
+  is_final = false;
+
+  return true;
+}
+
+bool MmapLineReader::get_next_line(std::string_view &line) {
+  if (read_ptr == nullptr || read_ptr >= end_of_file) {
+    is_final = true;
+    return false;
+  }
+
+  const void *newline_ptr_void = memchr(read_ptr, '\n', end_of_file - read_ptr);
+
+  const char *line_start = read_ptr;
+  const char *line_end;
+
+  if (newline_ptr_void != nullptr) {
+
+    line_end = static_cast<const char *>(newline_ptr_void);
+    read_ptr = line_end + 1;
+  } else {
+    line_end = end_of_file;
+    read_ptr = end_of_file;
+  }
+  line = std::string_view(line_start, line_end - line_start);
+
+  DEBUG_INFO(std::cout << std::hex << "Read Line: 0x" << lines_read << ", 0x" << line << std::dec << std::endl;)
+
+  lines_read++;
+
+  return true;
+}
+
+bool MmapLineReader::probe_next_line(std::string_view &line) {
+  if (read_ptr == nullptr || read_ptr >= end_of_file) {
+    return false;
+  }
+
+  const void *newline_ptr_void = memchr(read_ptr, '\n', end_of_file - read_ptr);
+
+  const char *line_start = read_ptr;
+  const char *line_end;
+
+  if (newline_ptr_void != nullptr) {
+    line_end = static_cast<const char *>(newline_ptr_void);
+  } else {
+    line_end = end_of_file;
+  }
+
+  line = std::string_view(line_start, line_end - line_start);
+
+  DEBUG_INFO(std::cout << std::hex << "Probe Line: 0x" << lines_read + 1 << ", 0x" << line << std::dec << std::endl;)
+  return true;
+}
+
+size_t MmapLineReader::get_line_read_count() const {
+  return lines_read;
+}

--- a/src/test/csrc/plugin/simfrontend/tracereader.h
+++ b/src/test/csrc/plugin/simfrontend/tracereader.h
@@ -1,0 +1,58 @@
+/***************************************************************************************
+* Copyright (c) 2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef TRACEREADER_H
+#define TRACEREADER_H
+
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <vector>
+
+class MmapLineReader {
+public:
+  explicit MmapLineReader() = default;
+  explicit MmapLineReader(const std::string &filename);
+
+  bool is_final = false;
+
+  bool is_open = false;
+
+  ~MmapLineReader();
+
+  bool init(const std::string &filename);
+
+  bool get_next_line(std::string_view &line);
+
+  bool probe_next_line(std::string_view &line);
+
+  size_t get_line_read_count() const;
+
+private:
+  MmapLineReader(const MmapLineReader &) = delete;
+  MmapLineReader &operator=(const MmapLineReader &) = delete;
+
+  int fd = -1;
+  char *mapped_data = nullptr;
+  size_t file_size = 0;
+
+  const char *read_ptr = nullptr;
+  const char *end_of_file = nullptr;
+
+  size_t lines_read = 0;
+};
+
+#endif // TRACEREADER_H

--- a/src/test/csrc/verilator/emu.cpp
+++ b/src/test/csrc/verilator/emu.cpp
@@ -39,6 +39,9 @@
 #ifdef ENABLE_IPC
 #include <sys/stat.h>
 #endif
+#ifdef PLUGIN_SIMFRONTEND
+#include "simfrontend.h"
+#endif // PLUGIN_SIMFRONTEND
 
 extern remote_bitbang_t *jtag;
 
@@ -87,6 +90,9 @@ static inline void print_help(const char *file) {
   printf("  -X, --fork-interval=NUM    LightSSS snapshot interval (in seconds), default: 10\n");
   printf("      --overwrite-nbytes=N   set valid bytes, but less than 0xf00, default: 0xe00\n");
   printf("      --overwrite-auto       overwrite size is automatically set of the new gcpt\n");
+#ifdef PLUGIN_SIMFRONTEND
+  printf("      --instr-trace          Setting the trace of instructions for SimFrontEnd\n");
+#endif // PLUGIN_SIMFRONTEND
   printf("      --force-dump-result    force dump performance counter result in the end\n");
   printf("      --load-snapshot=PATH   load snapshot from PATH\n");
   printf("      --enable-snapshot      enable simulation snapshots\n");
@@ -161,6 +167,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
     { "dramsim3-ini",      1, NULL,  0  },
     { "dramsim3-outdir",   1, NULL,  0  },
     { "overwrite-auto",    1, NULL,  0  },
+    { "instr-trace",       1, NULL,  0  },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "fork-interval",     1, NULL, 'X' },
@@ -268,6 +275,7 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
             break;
 #endif
           case 27: args.overwrite_nbytes_autoset = true; continue;
+          case 28: args.instr_trace = optarg; continue;
         }
         // fall through
       default: print_help(argv[0]); exit(0);
@@ -388,6 +396,10 @@ Emulator::Emulator(int argc, const char *argv[])
       dut_ptr->waveform_init(waveform_clock);
     }
   }
+
+#ifdef PLUGIN_SIMFRONTEND
+  init_sim_frontend(args.instr_trace);
+#endif // PLUGIN_SIMFRONTEND
 
   // init core
   reset_ncycles(args.reset_cycles);

--- a/src/test/csrc/verilator/emu.h
+++ b/src/test/csrc/verilator/emu.h
@@ -46,6 +46,7 @@ struct EmuArgs {
   uint64_t ipc_times;
 #endif
   const char *image = nullptr;
+  const char *instr_trace = nullptr;
   const char *gcpt_restore = nullptr;
   const char *snapshot_path = nullptr;
   const char *wave_path = nullptr;


### PR DESCRIPTION
Currently, I have implemented an ideal decoupled frontend for Xiangshan to prepare for performance debugging of the backend and memory access.

These modifications have been verified to work on my local machine, and they have achieved the desired results.

However, I'm still unsure about how to organize my code.
I'm uncertain whether it should be placed directly in the difftest repository. Therefore, this PR also serves as a request for advice: Does Mr. Xu @poemonsense have any suggestions on where to place this code?

---

This commit(https://github.com/OpenXiangShan/difftest/commit/a55a474e5dce06010190bc52d619251ca64c174e) enables normal generation of skip instruction traces in NEMU, regardless of whether changes are made, and will not affect the normal operation of difftest.