### PR TITLE
fix(Preprocess): `vecdata` should use `DiffVecCommitData`

### DIFF
--- a/src/main/scala/Preprocess.scala
+++ b/src/main/scala/Preprocess.scala
@@ -144,7 +144,7 @@ class PreprocessEndpoint(bundles: Seq[DifftestBundle]) extends Module {
   val withVecCommitData = if (bundles.exists(_.desiredCppName == "wb_vec")) {
     val vecData = Preprocess.getVecCommitData(in, commits)
     val vecCommitData = commits.zip(vecData).map { case (c, v) =>
-      val vcd = WireInit(0.U.asTypeOf(new DiffCommitData))
+      val vcd = WireInit(0.U.asTypeOf(new DiffVecCommitData))
       vcd.coreid := c.coreid
       vcd.index := c.index
       vcd.valid := c.valid


### PR DESCRIPTION
vecdata should use DiffVecCommitData instead of DiffCommitData.
Using DiffCommitData causes multi-core compilation errors.
See:
https://github.com/OpenXiangShan/XiangShan/actions/runs/17786462508/job/50555731500#step:17:33

Sorry, I didn't check this PR(https://github.com/OpenXiangShan/difftest/pull/650) thoroughly.
Perhaps we should add additional multi-core CI tests for difftest?