### PR TITLE
feat(mem): support multi-ported memories

### DIFF
--- a/src/main/scala/common/Mem.scala
+++ b/src/main/scala/common/Mem.scala
@@ -63,326 +63,302 @@ private trait HasMemInitializer { this: ExtModule =>
        |""".stripMargin
 }
 
-private trait HasReadPort { this: ExtModule =>
-  val r = IO(new Bundle {
-    val enable = Input(Bool())
-    val index = Input(UInt(64.W))
-    val data = Output(UInt(64.W))
-    val async = Output(Bool())
-  })
+private trait HasMemReadHelper { this: ExtModule =>
+  private def r(i: Int): String = s"r_$i"
 
-  val r_dpic =
-    """
-      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
-      |import "DPI-C" function longint difftest_ram_read(input longint rIdx);
-      |`endif // DISABLE_DIFFTEST_RAM_DPIC
-      |""".stripMargin
-
-  val r_if =
-    """
-      |input             r_enable,
-      |input      [63:0] r_index,
-      |output reg [63:0] r_data,
-      |output            r_async,
-      |""".stripMargin
-
-  val r_func =
-    """
-      |`ifdef GSIM
-      |  assign r_async = 1'b1;
-      |always @(*) begin
-      |  r_data = 0;
-      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
-      |  if (r_enable) begin
-      |    r_data = difftest_ram_read(r_index);
-      |  end
-      |`else
-      |  if (r_enable) begin
-      |    r_data = `MEM_TARGET[r_index];
-      |  end
-      |`endif // DISABLE_DIFFTEST_RAM_DPIC
-      |end
-      |`else // GSIM
-      |  assign r_async = 1'b0;
-      |always @(posedge clock) begin
-      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
-      |  if (r_enable) begin
-      |    r_data <= difftest_ram_read(r_index);
-      |  end
-      |`else
-      |  if (r_enable) begin
-      |    r_data <= `MEM_TARGET[r_index];
-      |  end
-      |`endif // DISABLE_DIFFTEST_RAM_DPIC
-      |end
-      |`endif // GSIM
-      |""".stripMargin
-
-  val r_cpp_arg =
-    """
-      |uint8_t   r_enable,
-      |uint64_t  r_index,
-      |uint64_t& r_data,
-      |uint8_t&  r_async""".stripMargin
-
-  val r_cpp_func =
+  private def sv_interface(i: Int): String =
     s"""
-       |  r_async = 1;
-       |  if (r_enable) r_data = difftest_ram_read(r_index);""".stripMargin
+       |input             ${r(i)}_enable,
+       |input      [63:0] ${r(i)}_index,
+       |output reg [63:0] ${r(i)}_data,
+       |output            ${r(i)}_async
+       |""".stripMargin
+  def r_sv_interface(n: Int): String = (0 until n).map(sv_interface).mkString(",\n")
 
-  def read(enable: Bool, index: UInt): UInt = {
-    r.enable := enable
-    r.index := index
-    Mux(r.async, RegEnable(r.data, r.enable), r.data)
-  }
+  private def sv_body(i: Int): String =
+    s"""
+       |`ifdef GSIM
+       |  assign ${r(i)}_async = 1'b1;
+       |always @(*) begin
+       |  ${r(i)}_data = 0;
+       |`ifndef DISABLE_DIFFTEST_RAM_DPIC
+       |  if (${r(i)}_enable) begin
+       |    ${r(i)}_data = difftest_ram_read(${r(i)}_index);
+       |  end
+       |`else
+       |  if (${r(i)}_enable) begin
+       |    ${r(i)}_data = `MEM_TARGET[${r(i)}_index];
+       |  end
+       |`endif // DISABLE_DIFFTEST_RAM_DPIC
+       |end
+       |`else // GSIM
+       |  assign ${r(i)}_async = 1'b0;
+       |always @(posedge clock) begin
+       |`ifndef DISABLE_DIFFTEST_RAM_DPIC
+       |  if (${r(i)}_enable) begin
+       |    ${r(i)}_data <= difftest_ram_read(${r(i)}_index);
+       |  end
+       |`else
+       |  if (${r(i)}_enable) begin
+       |    ${r(i)}_data <= `MEM_TARGET[${r(i)}_index];
+       |  end
+       |`endif // DISABLE_DIFFTEST_RAM_DPIC
+       |end
+       |`endif // GSIM
+       |""".stripMargin
+  def r_sv_body(n: Int): String = (0 until n).map(sv_body).mkString
+
+  private def cpp_arg(i: Int): String =
+    s"""
+       |uint8_t   ${r(i)}_enable,
+       |uint64_t  ${r(i)}_index,
+       |uint64_t& ${r(i)}_data,
+       |uint8_t&  ${r(i)}_async
+       |""".stripMargin
+  def r_cpp_arg(n: Int): String = (0 until n).map(cpp_arg).mkString(",\n")
+
+  private def cpp_body(i: Int): String =
+    s"""
+       |  ${r(i)}_async = 1;
+       |  if (${r(i)}_enable) ${r(i)}_data = difftest_ram_read(${r(i)}_index);
+       |""".stripMargin
+  def r_cpp_body(n: Int): String = (0 until n).map(cpp_body).mkString
 }
 
-private trait HasWritePort { this: ExtModule =>
-  val w = IO(new Bundle {
-    val enable = Input(Bool())
-    val index = Input(UInt(64.W))
-    val data = Input(UInt(64.W))
-    val mask = Input(UInt(64.W))
-  })
+private trait HasMemWriteHelper {
+  private def w(i: Int): String = s"w_$i"
 
-  val w_dpic =
-    """
-      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
-      |import "DPI-C" function void difftest_ram_write
-      |(
-      |  input  longint index,
-      |  input  longint data,
-      |  input  longint mask
-      |);
-      |`endif // DISABLE_DIFFTEST_RAM_DPIC
-      |""".stripMargin
+  private def sv_interface(i: Int): String =
+    s"""
+       |input         ${w(i)}_enable,
+       |input  [63:0] ${w(i)}_index,
+       |input  [63:0] ${w(i)}_data,
+       |input  [63:0] ${w(i)}_mask
+       |""".stripMargin
+  def w_sv_interface(n: Int): String = (0 until n).map(sv_interface).mkString(",\n")
 
-  val w_if =
-    """
-      |input         w_enable,
-      |input  [63:0] w_index,
-      |input  [63:0] w_data,
-      |input  [63:0] w_mask,
-      |""".stripMargin
+  private def sv_body(i: Int): String =
+    s"""
+       |`ifndef DISABLE_DIFFTEST_RAM_DPIC
+       |if (${w(i)}_enable) begin
+       |  difftest_ram_write(${w(i)}_index, ${w(i)}_data, ${w(i)}_mask);
+       |end
+       |`else
+       |if (${w(i)}_enable) begin
+       |  `MEM_TARGET[${w(i)}_index] <= (${w(i)}_data & ${w(i)}_mask) | (`MEM_TARGET[${w(i)}_index] & ~${w(i)}_mask);
+       |end
+       |`endif // DISABLE_DIFFTEST_RAM_DPIC
+       |""".stripMargin
+  def w_sv_body(n: Int): String =
+    s"""
+       |always @(posedge clock) begin
+       |${(0 until n).map(sv_body).mkString}
+       |end
+       |""".stripMargin
 
-  val w_func =
-    """
-      |always @(posedge clock) begin
-      |`ifndef DISABLE_DIFFTEST_RAM_DPIC
-      |  if (w_enable) begin
-      |    difftest_ram_write(w_index, w_data, w_mask);
-      |  end
-      |`else
-      |  if (w_enable) begin
-      |    `MEM_TARGET[w_index] <= (w_data & w_mask) | (`MEM_TARGET[w_index] & ~w_mask);
-      |  end
-      |`endif // DISABLE_DIFFTEST_RAM_DPIC
-      |end
-      |""".stripMargin
+  private def cpp_arg(i: Int): String =
+    s"""
+       |uint8_t  ${w(i)}_enable,
+       |uint64_t ${w(i)}_index,
+       |uint64_t ${w(i)}_data,
+       |uint64_t ${w(i)}_mask""".stripMargin
+  def w_cpp_arg(n: Int): String = (0 until n).map(cpp_arg).mkString(",\n")
 
-  val w_cpp_arg =
-    """
-      |uint8_t  w_enable,
-      |uint64_t w_index,
-      |uint64_t w_data,
-      |uint64_t w_mask""".stripMargin
-
-  val w_cpp_func = "if(w_enable) difftest_ram_write(w_index, w_data, w_mask);"
-
-  def write(enable: Bool, index: UInt, data: UInt, mask: UInt): HasWritePort = {
-    w.enable := enable
-    w.index := index
-    w.data := data
-    w.mask := mask
-    this
-  }
+  private def cpp_body(i: Int): String =
+    s"""
+       |  if (${w(i)}_enable) {
+       |    difftest_ram_write(${w(i)}_index, ${w(i)}_data, ${w(i)}_mask);
+       |  }
+       |""".stripMargin
+  def w_cpp_body(n: Int): String = (0 until n).map(cpp_body).mkString
 }
 
-abstract private class MemHelper extends ExtModule with HasExtModuleInline with HasMemInitializer
+private class CppMemReadIO extends Bundle {
+  val enable = Input(Bool())
+  val index = Input(UInt(64.W))
+  val data = Output(UInt(64.W))
+  val async = Output(Bool())
+}
 
-private class MemRWHelper extends MemHelper with HasReadPort with HasWritePort {
+private class CppMemWriteIO extends Bundle {
+  val enable = Input(Bool())
+  val index = Input(UInt(64.W))
+  val data = Input(UInt(64.W))
+  val mask = Input(UInt(64.W))
+}
+
+private class MemRWHelper(size: BigInt, val nr: Int, val nw: Int)
+  extends ExtModule(Map("RAM_SIZE" -> size))
+  with HasExtModuleInline
+  with HasMemInitializer
+  with HasMemReadHelper
+  with HasMemWriteHelper {
+
+  val r = IO(Vec(nr, new CppMemReadIO))
+  val w = IO(Vec(nw, new CppMemWriteIO))
   val clock = IO(Input(Clock()))
+
+  def read(i: Int, enable: Bool, index: UInt): UInt = {
+    r(i).enable := enable
+    r(i).index := index
+    Mux(r(i).async, RegEnable(r(i).data, r(i).enable), r(i).data)
+  }
+  def write(i: Int, enable: Bool, index: UInt, data: UInt, mask: UInt): Unit = {
+    w(i).enable := enable
+    w(i).index := index
+    w(i).data := data
+    w(i).mask := mask
+  }
 
   def mem_decl: String =
     """
-      |// 1536MB memory
-      |`define RAM_SIZE (1536 * 1024 * 1024)
-      |reg [63:0] memory [0 : `RAM_SIZE / 8 - 1];
+      |reg [63:0] memory [0 : RAM_SIZE / 8 - 1];
       |""".stripMargin
 
   def mem_target: String = "memory"
 
+  override def desiredName: String = s"Mem${nr}R${nw}WHelper"
+
   val cppExtModule =
     s"""
-       |void MemRWHelper(
-       |$r_cpp_arg,
-       |$w_cpp_arg
+       |static void $desiredName(
+       |${r_cpp_arg(nr)},
+       |${w_cpp_arg(nw)}
        |) {
-       |  $r_cpp_func
-       |  $w_cpp_func
+       |  ${r_cpp_body(nr)}
+       |  ${w_cpp_body(nw)}
        |}
        |""".stripMargin
-  difftest.DifftestModule.createCppExtModule("MemRWHelper", cppExtModule, Some("\"ram.h\""))
+  difftest.DifftestModule.createCppExtModule(desiredName, cppExtModule, Some("\"ram.h\""))
 
   setInline(
-    "MemRWHelper.v",
+    s"$desiredName.v",
     s"""
        |`ifdef SYNTHESIS
        |  `define DISABLE_DIFFTEST_RAM_DPIC
        |`endif
-       |$r_dpic
-       |$w_dpic
-       |module MemRWHelper(
-       |  $r_if
-       |  $w_if
-       |  input clock
+       |module $desiredName #(
+       |  parameter RAM_SIZE
+       |)(
+       |  input clock,
+       |  ${r_sv_interface(nr)},
+       |  ${w_sv_interface(nw)}
        |);
        |  $mem_init
-       |  $r_func
-       |  $w_func
+       |  ${r_sv_body(nr)}
+       |  ${w_sv_body(nw)}
        |endmodule
      """.stripMargin,
   )
 }
 
-abstract class DifftestMem(size: BigInt, lanes: Int, bits: Int) extends Module {
+class DifftestMemReadIO(nWord: Int) extends Bundle {
+  val valid = Input(Bool())
+  val index = Input(UInt(64.W))
+  val data = Output(Vec(nWord, UInt(64.W)))
+}
+
+class DifftestMemWriteIO(nWord: Int) extends Bundle {
+  val valid = Input(Bool())
+  val index = Input(UInt(64.W))
+  val data = Input(Vec(nWord, UInt(64.W)))
+  val mask = Input(Vec(nWord, UInt(64.W)))
+}
+
+class DifftestMem(size: BigInt, lanes: Int, bits: Int, nr: Int, nw: Int) extends Module {
+  override def desiredName: String = s"DifftestMem${nr}R${nw}W"
+
   require(bits == 8 && lanes % 8 == 0, "supports 64-bits aligned byte access only")
-  protected val n_helper = lanes / 8
-  private val helper = Seq.fill(n_helper)(Module(new MemRWHelper))
+  private val n_helper = lanes / 8
 
-  val read = IO(new Bundle {
-    val valid = Input(Bool())
-    val index = Input(UInt(64.W))
-    val data = Output(Vec(n_helper, UInt(64.W)))
-  })
-  val write = IO(Input(new Bundle {
-    val valid = Bool()
-    val index = UInt(64.W)
-    val data = Vec(n_helper, UInt(64.W))
-    val mask = Vec(n_helper, UInt(64.W))
-  }))
+  val read = IO(Vec(nr, new DifftestMemReadIO(n_helper)))
+  val write = IO(Vec(nw, new DifftestMemWriteIO(n_helper)))
 
-  read.data := helper.zipWithIndex.map { case (h, i) =>
-    h.clock := clock
-    h.read(
-      enable = !reset.asBool && read.valid,
-      index = read.index * n_helper.U + i.U,
-    )
+  private val helper = Seq.fill(n_helper)(Module(new MemRWHelper(size, nr, nw)))
+  read.zipWithIndex.foreach { case (r, i) =>
+    r.data := helper.zipWithIndex.map { case (h, j) =>
+      h.clock := clock
+      h.read(i, enable = !reset.asBool && r.valid, index = r.index * n_helper.U + j.U)
+    }
   }
+  write.foreach(w =>
+    helper.zipWithIndex.foreach { case (h, i) =>
+      h.clock := clock
+      h.write(
+        i,
+        enable = !reset.asBool && w.valid,
+        index = w.index * n_helper.U + i.U,
+        data = w.data(i),
+        mask = w.mask(i),
+      )
+    }
+  )
 
-  helper.zipWithIndex.foreach { case (h, i) =>
-    h.clock := clock
-    h.write(
-      enable = !reset.asBool && write.valid,
-      index = write.index * n_helper.U + i.U,
-      data = write.data(i),
-      mask = write.mask(i),
-    )
-  }
-
-  def read(addr: UInt): Vec[UInt] = {
-    read.valid := !write.valid
-    read.index := addr
-    read.data
+  private var r_index = 0
+  def read(addr: UInt, en: Bool): Vec[UInt] = {
+    val port = read(r_index)
+    r_index += 1
+    port.valid := en
+    port.index := addr
+    port.data
   }
 
   def readAndHold(addr: UInt, en: Bool): Vec[UInt] = {
-    read.valid := en
-    read.index := addr
-    Mux(RegNext(en), read.data, RegEnable(read.data, RegNext(en))).asTypeOf(Vec(lanes, UInt(bits.W)))
+    val port = read(r_index)
+    r_index += 1
+    port.valid := en
+    port.index := addr
+    Mux(RegNext(en), port.data, RegEnable(port.data, RegNext(en))).asTypeOf(Vec(lanes, UInt(bits.W)))
   }
 
+  private var w_index = 0
   def write(addr: UInt, data: Seq[UInt], mask: Seq[Bool]): Unit = {
-    write.valid := true.B
-    write.index := addr
-    write.data := VecInit(data).asTypeOf(write.data)
+    val port = write(w_index)
+    w_index += 1
+    port.valid := true.B
+    port.index := addr
+    port.data := VecInit(data).asTypeOf(port.data)
     require(data.length == lanes, s"data Vec[UInt] should have the length of $lanes")
     require(mask.length == lanes, s"mask Vec[Bool] should have the length of $lanes")
     require(data.head.getWidth == bits, s"data should have the width of $bits")
-    write.mask := VecInit(mask.map(m => Fill(bits, m))).asTypeOf(write.mask)
+    port.mask := VecInit(mask.map(m => Fill(bits, m))).asTypeOf(port.mask)
   }
 }
 
-private class DifftestMemReadOnly(size: BigInt, lanes: Int, bits: Int) extends DifftestMem(size, lanes, bits) {
-  assert(!write.valid, "no write allowed in read-only mem")
+private class DifftestMem1P(size: BigInt, lanes: Int, bits: Int) extends DifftestMem(size, lanes, bits, 1, 1) {
+  assert(!read.head.valid || !write.head.valid, "read and write come at the same cycle")
 }
 
-private class DifftestMemWriteOnly(size: BigInt, lanes: Int, bits: Int) extends DifftestMem(size, lanes, bits) {
-  assert(!read.valid, "no read allowed in write-only mem")
-}
-
-private class DifftestMem2P(size: BigInt, lanes: Int, bits: Int) extends DifftestMem(size, lanes, bits)
-
-private class DifftestMem1P(size: BigInt, lanes: Int, bits: Int) extends DifftestMem2P(size, lanes, bits) {
-  assert(!read.valid || !write.valid, "read and write come at the same cycle")
-}
-
-private class SynthesizableDifftestMem(size: BigInt, lanes: Int, bits: Int) extends DifftestMem(size, lanes, bits) {
-  val mem = Mem(size / 8, UInt(64.W))
-
-  for (i <- 0 until n_helper) {
-    val r_index = read.index * n_helper.U + i.U
-    read.data(i) := RegEnable(mem(r_index), read.valid)
-
-    val w_index = write.index * n_helper.U + i.U
-    when(write.valid) {
-      mem(w_index) := (write.data(i) & write.mask(i)) | (mem(w_index) & (~write.mask(i)).asUInt)
-    }
-  }
-
-  Module(new MemInitializer(s"$desiredName.mem"))
-}
-
-private class MemInitializer(mem: String) extends MemHelper {
-  override def mem_decl: String = ""
-  override def mem_target: String = mem
-
-  setInline(
-    s"$desiredName.v",
-    s"""
-       |module $desiredName();
-       |$mem_init
-       |endmodule
-      """.stripMargin,
-  )
+private class DifftestMemMP(size: BigInt, lanes: Int, bits: Int, nr: Int, nw: Int)
+  extends DifftestMem(size, lanes, bits, nr, nw) {
+  override def desiredName: String = s"DifftestMem${nr}R${nw}W"
 }
 
 object DifftestMem {
   private def setDefaultIOs(mod: DifftestMem): DifftestMem = {
     mod.read := DontCare
-    mod.read.valid := false.B
+    mod.read.foreach(_.valid := false.B)
     mod.write := DontCare
-    mod.write.valid := false.B
+    mod.write.foreach(_.valid := false.B)
     mod
   }
 
-  def apply(size: BigInt, beatBytes: Int): DifftestMem = {
-    apply(size, beatBytes, 8)
-  }
+  def apply(size: BigInt, beatBytes: Int): DifftestMem = apply(size, beatBytes, 8)
 
-  def apply(size: BigInt, beatBytes: Int, synthesizable: Boolean): DifftestMem = {
-    apply(size, beatBytes, 8, synthesizable = synthesizable)
-  }
-
+  // only for compatibility
   def apply(
     size: BigInt,
     lanes: Int,
     bits: Int,
     synthesizable: Boolean = false,
     singlePort: Boolean = true,
-  ): DifftestMem = {
-    setDefaultIOs((synthesizable, singlePort) match {
-      case (true, _)      => Module(new SynthesizableDifftestMem(size, lanes, bits))
-      case (false, true)  => Module(new DifftestMem1P(size, lanes, bits))
-      case (false, false) => Module(new DifftestMem2P(size, lanes, bits))
-    })
-  }
+  ): DifftestMem = apply(size, lanes, bits, 1, 1)
 
-  def readOnly(size: BigInt, beatBytes: Int): DifftestMem = {
-    setDefaultIOs(Module(new DifftestMemReadOnly(size, beatBytes, 8)))
-  }
-
-  def writeOnly(size: BigInt, beatBytes: Int): DifftestMem = {
-    setDefaultIOs(Module(new DifftestMemWriteOnly(size, beatBytes, 8)))
-  }
+  def apply(
+    size: BigInt,
+    lanes: Int,
+    bits: Int,
+    nr: Int,
+    nw: Int,
+  ): DifftestMem = setDefaultIOs(Module(new DifftestMemMP(size, lanes, bits, nr, nw)))
 }

--- a/src/test/vsrc/common/ram.v
+++ b/src/test/vsrc/common/ram.v
@@ -1,0 +1,20 @@
+`ifdef SYNTHESIS
+  `define DISABLE_DIFFTEST_RAM_DPIC
+`endif
+
+`ifndef DISABLE_DIFFTEST_RAM_DPIC
+
+import "DPI-C" function longint difftest_ram_read
+(
+  input longint index
+);
+
+
+import "DPI-C" function void difftest_ram_write
+(
+  input longint index,
+  input longint data,
+  input longint mask
+);
+
+`endif // DISABLE_DIFFTEST_RAM_DPIC


### PR DESCRIPTION
Some designs may read/write multiple blocks in one clock cycle, such as in a multi-channel DRAM system. To support this, this commit adds the multi-ported feature for DifftestMem.

Note this changes the naming for blackbox and may break GSIM support.

We also move the DPI-C functions to src/test/vsrc because they should not be declared multiple times, which may occur if multiple RWHelper's are called.