### PR TITLE
fix(emu.mk): add emu-mk for verilator-emu-mk

### DIFF
--- a/emu.mk
+++ b/emu.mk
@@ -77,4 +77,6 @@ else
 	@$(MAKE) emu-verilator
 endif
 
+emu-mk: verilator-emu-mk
+
 clean-obj: verilator-clean-obj gsim-clean-obj


### PR DESCRIPTION
XiangShan call emu-mk for docker, this change add emu-mk for verilator-emu-mk by default.