### PR TITLE
fix(simfrontend): fix decoding of func3 for non-compressed instr

### DIFF
--- a/src/test/csrc/plugin/simfrontend/ftq.cpp
+++ b/src/test/csrc/plugin/simfrontend/ftq.cpp
@@ -43,7 +43,7 @@ static BrType get_br_type(uint32_t instr, bool rvc) {
     }
   } else {
     uint32_t opcode = instr & 0x7F;
-    uint32_t funct3 = (instr >> 13) & 0x7;
+    uint32_t funct3 = (instr >> 12) & 0x7;
     if (opcode == 0b1100011)
       return BrType::Branch; // B-type instructions
     if (opcode == 0b1101111)


### PR DESCRIPTION
Only the func3 for C compression instructions starts at bit 13.
The func3 for non-compression instructions starts at bit 12.