### PR TITLE
fix(difftest): only check existed refill events

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -338,9 +338,13 @@ inline int Difftest::check_all() {
 #endif // CONFIG_DIFFTEST_CMOINVALEVENT
 
 #ifdef DEBUG_REFILL
-  if (do_irefill_check() || do_drefill_check() || do_ptwrefill_check()) {
-    return 1;
+#ifdef CONFIG_DIFFTEST_REFILLEVENT
+  for (int i = 0; i < CONFIG_DIFF_REFILL_WIDTH; i++) {
+    if (do_refill_check(i)) {
+      return 1;
+    }
   }
+#endif // CONFIG_DIFFTEST_REFILLEVENT
 #endif
 
 #ifdef DEBUG_L2TLB
@@ -1047,26 +1051,6 @@ int Difftest::do_refill_check(int cacheid) {
   }
 #endif // CONFIG_DIFFTEST_REFILLEVENT
   return 0;
-}
-
-int Difftest::do_irefill_check() {
-  int r = 0;
-  r |= do_refill_check(ICACHEID);
-  // r |= do_refill_check(3);
-  // r |= do_refill_check(4);
-  // r |= do_refill_check(5);
-  // r |= do_refill_check(6);
-  // r |= do_refill_check(7);
-  // r |= do_refill_check(8);
-  return r;
-}
-
-int Difftest::do_drefill_check() {
-  return do_refill_check(DCACHEID);
-}
-
-int Difftest::do_ptwrefill_check() {
-  return do_refill_check(PAGECACHEID);
 }
 
 typedef struct {

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -55,17 +55,6 @@ enum {
   EX_SGPF       // store/amo guest-page fault, H-extention
 };
 
-enum {
-  ICACHEID,
-  DCACHEID,
-  PAGECACHEID
-};
-enum {
-  ITLBID,
-  LDTLBID,
-  STTLBID
-};
-
 #define DEBUG_MEM_REGION(v, f) (f <= (DEBUG_MEM_BASE + 0x1000) && f >= DEBUG_MEM_BASE && v)
 #define IS_LOAD_STORE(instr)   (((instr & 0x7f) == 0x03) || ((instr & 0x7f) == 0x23))
 #define IS_TRIGGERCSR(instr)   (((instr & 0x7f) == 0x73) && ((instr & (0xff0 << 20)) == (0x7a0 << 20)))
@@ -404,9 +393,6 @@ protected:
   void do_load_check(int index);
   int do_store_check();
   int do_refill_check(int cacheid);
-  int do_irefill_check();
-  int do_drefill_check();
-  int do_ptwrefill_check();
   int do_l1tlb_check();
   int do_l2tlb_check();
   int do_golden_memory_update();


### PR DESCRIPTION
This commit fixes the wrong refill checkers that may not exist. We should use the CONFIG_DIFF_REFILL_WIDTH macro to get the number of existed refill events.