### PR TITLE
feat(top): allow extra CPU IO with connectTopIOs

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -572,7 +572,7 @@ object DifftestModule {
     gateway
   }
 
-  def top[T <: Module with HasDiffTestInterfaces](cpuGen: => T): SimTop[T] = new SimTop(cpuGen)
+  def top[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T): SimTop[T] = new SimTop(cpuGen)
 
   def generateSvhInterface(instances: Seq[DifftestBundle], numCores: Int): Unit = {
     // generate interface by jsonProfile, single-core interface will be copied numCore times


### PR DESCRIPTION
This change allows passing some extra CPU IOs as return value of connectTopIOs, and then DiffTest will also expose this IOs to outer SimTop.