### PR TITLE
fix(difftest): always assume a correct reset vector

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -616,11 +616,6 @@ int Difftest::do_instr_commit(int i) {
 
 void Difftest::do_first_instr_commit() {
   if (!has_commit && dut->commit[0].valid) {
-#ifndef BASIC_DIFFTEST_ONLY
-    if (dut->commit[0].pc != FIRST_INST_ADDRESS) {
-      return;
-    }
-#endif
     Info("The first instruction of core %d has commited. Difftest enabled. \n", id);
     has_commit = 1;
     nemu_this_pc = FIRST_INST_ADDRESS;


### PR DESCRIPTION
This commit removes the checker for first instruction commit PC (reset
vector of the CPU) due to several reasons.

1) The unchecked instructions may have store instructions that pollute
   the memory. These writes won't be captured by DiffTest and may cause
   future mismatches.

2) If the CPU is wrong in the first instruction, DiffTest cannot detect
   it. NEMU may also have unexpeceted behaviors that are hard to debug.