### PR TITLE
fix(difftest): remove unused vector logic from get_commit_data

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -411,26 +411,6 @@ protected:
 #endif // CONFIG_DIFFTEST_FPWRITEBACK
     } else
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
-#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-        if (dut->commit[i].vecwen) {
-      return
-#ifdef CONFIG_DIFFTEST_VECWRITEBACK
-          dut->wb_vec[dut->commit[i].wpdest].data[0];
-#else
-          dut->regs_vec.value[dut->commit[i].wdest];
-#endif // CONFIG_DIFFTEST_VECWRITEBACK
-    } else
-#endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
-#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-        if (dut->commit[i].v0wen) {
-      return
-#ifdef CONFIG_DIFFTEST_VECWRITEBACK
-          dut->wb_v0[dut->commit[i].wpdest].data[0];
-#else
-          dut->regs_vec.value[dut->commit[i].wdest];
-#endif // CONFIG_DIFFTEST_VECWRITEBACK
-    } else
-#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
       return
 #ifdef CONFIG_DIFFTEST_INTWRITEBACK
           dut->wb_int[dut->commit[i].wpdest].data;


### PR DESCRIPTION
The get_commit_data function serves two main purposes: (1) synchronizing MMIO operations to NEMU, and
(2) recording per-instruction writeback values into the trace for debugging.

Since vector instructions do not involve MMIO and their writeback widths are incompatible with the existing trace format, the unused vector-related logic has been removed from this function.