### PR TITLE
fix(difftest): generate and call update_archreg inside DPI-C

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -389,7 +389,7 @@ object DPIC {
     deltaInstances ++= template.filter(_.supportsDelta)
   }
 
-  def collect(config: GatewayConfig): GatewayResult = {
+  def collect(config: GatewayConfig, instances: Seq[DifftestBundle]): GatewayResult = {
     if (interfaces.isEmpty) {
       return GatewayResult()
     }
@@ -408,37 +408,47 @@ object DPIC {
       Delta.collect()
       interfaceCpp += "#include \"difftest-delta.h\""
     }
+    val phyRegs = instances.distinctBy(_.desiredCppName).filter(_.desiredCppName.contains("pregs"))
+    if (phyRegs.nonEmpty) {
+      interfaceCpp += "void diffstate_update_archreg(DiffTestState* dut) {"
+      phyRegs.foreach { p =>
+        val hasRat = instances.exists(_.desiredCppName == p.desiredCppName.replace("pregs", "rat"))
+        interfaceCpp += p.asInstanceOf[DiffPhyRegState].cppUpdateArch(hasRat, "dut")
+      }
+      interfaceCpp += "}"
+    }
     interfaceCpp += ""
     interfaceCpp +=
-      """
-        |class DPICBuffer : public DiffStateBuffer {
-        |private:
-        |  DiffTestState buffer[CONFIG_DIFFTEST_ZONESIZE][CONFIG_DIFFTEST_BUFLEN];
-        |  int read_ptr = 0;
-        |  int zone_ptr = 0;
-        |  bool init = true;
-        |public:
-        |  DPICBuffer() {
-        |    memset(buffer, 0, sizeof(buffer));
-        |  }
-        |  inline DiffTestState* get(int zone, int index) {
-        |    return buffer[zone] + index;
-        |  }
-        |  inline DiffTestState* next() {
-        |    DiffTestState* ret = buffer[zone_ptr] + read_ptr;
-        |    read_ptr = (read_ptr + 1) % CONFIG_DIFFTEST_BUFLEN;
-        |    return ret;
-        |  }
-        |  inline void switch_zone() {
-        |    if (init) {
-        |      init = false;
-        |      return;
-        |    }
-        |    zone_ptr = (zone_ptr + 1) % CONFIG_DIFFTEST_ZONESIZE;
-        |    read_ptr = 0;
-        |  }
-        |};
-        |""".stripMargin
+      s"""
+         |class DPICBuffer : public DiffStateBuffer {
+         |private:
+         |  DiffTestState buffer[CONFIG_DIFFTEST_ZONESIZE][CONFIG_DIFFTEST_BUFLEN];
+         |  int read_ptr = 0;
+         |  int zone_ptr = 0;
+         |  bool init = true;
+         |public:
+         |  DPICBuffer() {
+         |    memset(buffer, 0, sizeof(buffer));
+         |  }
+         |  inline DiffTestState* get(int zone, int index) {
+         |    return buffer[zone] + index;
+         |  }
+         |  inline DiffTestState* next() {
+         |    DiffTestState* ret = buffer[zone_ptr] + read_ptr;
+         |    ${if (phyRegs.nonEmpty) "diffstate_update_archreg(ret);" else ""}
+         |    read_ptr = (read_ptr + 1) % CONFIG_DIFFTEST_BUFLEN;
+         |    return ret;
+         |  }
+         |  inline void switch_zone() {
+         |    if (init) {
+         |      init = false;
+         |      return;
+         |    }
+         |    zone_ptr = (zone_ptr + 1) % CONFIG_DIFFTEST_ZONESIZE;
+         |    read_ptr = 0;
+         |  }
+         |};
+         |""".stripMargin
 
     interfaceCpp += interfaces.map(_._2 + ";").mkString("\n")
     interfaceCpp += ""

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -388,6 +388,11 @@ class DiffArchVecRenameTable(numPhyRegs: Int) extends DiffArchRenameTable(64, nu
 abstract class DiffPhyRegState(val numPhyRegs: Int) extends PhyRegState(numPhyRegs) with DifftestBundle {
   override val supportsDelta: Boolean = true
   override def classArgs: Map[String, Any] = Map("numPhyRegs" -> numPhyRegs)
+  def cppUpdateArch(hasRat: Boolean, ptr: String): String = {
+    val suffix = desiredCppName.replace("pregs_", "")
+    val index = if (hasRat) s"$ptr->rat_$suffix.value[i]" else "i"
+    s"  for (int i = 0; i < ${value.size}; i++) { $ptr->regs_$suffix.value[i] = $ptr->pregs_$suffix.value[$index]; }"
+  }
 }
 
 class DiffPhyIntRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -215,7 +215,7 @@ object Gateway {
         fpgaIO = endpoint.fpgaIO,
       )
     } else {
-      GatewayResult(instances = getInstance(instances)) + GatewaySink.collect(config)
+      GatewayResult(instances = getInstance(instances)) + GatewaySink.collect(config, getInstance(instances))
     }
     sink + GatewayResult(
       cppMacros = config.cppMacros,
@@ -295,7 +295,7 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
     }
   }
 
-  GatewaySink.collect(config)
+  GatewaySink.collect(config, instances)
 
 }
 
@@ -314,10 +314,10 @@ object GatewaySink {
     }
   }
 
-  def collect(config: GatewayConfig): GatewayResult = {
+  def collect(config: GatewayConfig, instances: Seq[DifftestBundle]): GatewayResult = {
     config.style match {
-      case "dpic" => DPIC.collect(config)
-      case _      => DPIC.collect(config) // Default: DPI-C
+      case "dpic" => DPIC.collect(config, instances)
+      case _      => DPIC.collect(config, instances) // Default: DPI-C
     }
   }
 }

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -273,23 +273,6 @@ void Difftest::do_replay() {
 }
 #endif // CONFIG_DIFFTEST_REPLAY
 
-void Difftest::update_dut_archreg() {
-#if defined(CONFIG_DIFFTEST_PHYINTREGSTATE) && defined(CONFIG_DIFFTEST_ARCHINTRENAMETABLE)
-  for (int i = 0; i < 32; i++) {
-    dut->regs_int.value[i] = dut->pregs_int.value[dut->rat_int.value[i]];
-  }
-#endif
-#if defined(CONFIG_DIFFTEST_PHYFPREGSTATE) && defined(CONFIG_DIFFTEST_ARCHFPRENAMETABLE)
-  for (int i = 0; i < 32; i++) {
-    dut->regs_fp.value[i] = dut->pregs_fp.value[dut->rat_fp.value[i]];
-  }
-#endif
-#if defined(CONFIG_DIFFTEST_PHYVECREGSTATE) && defined(CONFIG_DIFFTEST_ARCHVECRENAMETABLE)
-  for (int i = 0; i < 64; i++) {
-    dut->regs_vec.value[i] = dut->pregs_vec.value[dut->rat_vec.value[i]];
-  }
-#endif
-}
 int Difftest::step() {
 #ifdef CONFIG_DIFFTEST_REPLAY
   static int replay_step = 0;
@@ -326,7 +309,6 @@ int Difftest::step() {
 
 inline int Difftest::check_all() {
   progress = false;
-  update_dut_archreg();
 
   if (check_timeout()) {
     return 1;

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -383,7 +383,6 @@ protected:
   }
   int check_timeout();
   int check_all();
-  void update_dut_archreg();
   void do_first_instr_commit();
   void do_interrupt();
   void do_exception();


### PR DESCRIPTION
Previously, archReg updates were controlled by macro defines just before checking, leading to complex conditional logic depending on whether PhyReg or RenameTable were defined, and also requiring manual call of the update function.

This change moves both the generation and invocation of update_archreg into dpic. Now, every time the user gets diffstate, the archReg have already been updated automatically, making the update process fully transparent.