### PR TITLE
fix(difftest): fix regSize of update_archreg and add CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,10 +267,10 @@ jobs:
             ./build/simv +workload=$WORKLOAD +diff=$REF_SO
             make clean
 
-      - name: Verilator Build with VCS Top (with GlobalEnable Squash Replay Batch InternalStep Delta NonBlock PerfCnt Query)
+      - name: Verilator Build with VCS Top (with SoftArchUpdate GlobalEnable Squash Replay Batch InternalStep Delta NonBlock PerfCnt Query)
         run: |
             cd $NOOP_HOME
-            make simv MILL_ARGS="--difftest-config ESRBIDNP" DIFFTEST_PERFCNT=1 DIFFTEST_QUERY=1 VCS=verilator -j2
+            make simv MILL_ARGS="--difftest-config UESRBIDNP" DIFFTEST_PERFCNT=1 DIFFTEST_QUERY=1 VCS=verilator -j2
             ./build/simv +workload=$WORKLOAD +no-diff +max-cycles=100000
             ./build/simv +workload=$WORKLOAD +diff=$REF_SO
             make clean

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -191,7 +191,7 @@ class VecDataWriteback(val numElements: Int) extends DifftestBaseBundle with Has
   val data = Vec(2, UInt(64.W))
 }
 
-class ArchRegState(numRegs: Int) extends DifftestBaseBundle {
+class ArchRegState(val numRegs: Int) extends DifftestBaseBundle {
   val value = Vec(numRegs, UInt(64.W))
 
   def apply(i: UInt): UInt = value(i(log2Ceil(numRegs), 0))

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -388,11 +388,6 @@ class DiffArchVecRenameTable(numPhyRegs: Int) extends DiffArchRenameTable(64, nu
 abstract class DiffPhyRegState(val numPhyRegs: Int) extends PhyRegState(numPhyRegs) with DifftestBundle {
   override val supportsDelta: Boolean = true
   override def classArgs: Map[String, Any] = Map("numPhyRegs" -> numPhyRegs)
-  def cppUpdateArch(hasRat: Boolean, ptr: String): String = {
-    val suffix = desiredCppName.replace("pregs_", "")
-    val index = if (hasRat) s"$ptr->rat_$suffix.value[i]" else "i"
-    s"  for (int i = 0; i < ${value.size}; i++) { $ptr->regs_$suffix.value[i] = $ptr->pregs_$suffix.value[$index]; }"
-  }
 }
 
 class DiffPhyIntRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -208,7 +208,7 @@ object Gateway {
       val endpoint = Module(new GatewayEndpoint(instanceWithDelay.toSeq, config))
       endpoint.in := gatewayIn
       GatewayResult(
-        instances = getInstance(endpoint.instances),
+        instances = endpoint.instances,
         structPacked = Some(config.isBatch),
         structAligned = Some(config.isDelta),
         step = Some(endpoint.step),
@@ -258,7 +258,7 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
   } else {
     WireInit(validated)
   }
-  val instances = chiselTypeOf(squashed).map(_.bits).toSeq
+  val instances = Gateway.getInstance(chiselTypeOf(squashed).map(_.bits).toSeq)
   val deltas = if (config.isDelta) {
     WireInit(Delta(squashed, config))
   } else {


### PR DESCRIPTION
Previous in https://github.com/OpenXiangShan/difftest/pull/720 we mistakenly use phyRegSize for update_archreg loop. This change fix the loop size to archRegSize, and add CI for softArchUpdate