### PR TITLE
Preprocess: skip vec_commit_data when single core

### DIFF
--- a/src/main/scala/Preprocess.scala
+++ b/src/main/scala/Preprocess.scala
@@ -81,7 +81,8 @@ object Preprocess {
       cd.index := c.index
       cd.valid := c.valid && (c.rfwen || c.fpwen)
       cd.data := Mux(c.fpwen, fpData, intData)
-      val vcd = Option.when(phyVecs.nonEmpty) {
+      // Also skip vec_commit_data (used in vec_load check) for single core
+      val vcd = Option.when(phyVecs.nonEmpty && numCores > 1) {
         val vreg = phyVecs(coreID).value
         val gen = Wire(new DiffVecCommitData)
         gen.coreid := c.coreid


### PR DESCRIPTION
As vec_commit_data is only used in vec_load_check, which will only be called for multi-core. For less transmitted data, we skip vec_commit_data for single core, same as load event.