### PR TITLE
feat(refill-check): add mask to refill check

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -315,6 +315,7 @@ class L2TLBEvent extends DifftestBaseBundle with HasValid {
 class RefillEvent extends DifftestBaseBundle with HasValid {
   val addr = UInt(64.W)
   val data = Vec(8, UInt(64.W))
+  val mask = UInt(8.W)
 }
 
 class ScEvent extends DifftestBaseBundle with HasValid {


### PR DESCRIPTION
After https://github.com/OpenXiangShan/XiangShan/pull/3051, we have supported low-power read (read only 5 out of 8 8B-banks) in ICacheDataArray, and in V3, it was further modified to dynamically compute the mask based on the taken branch location.

Though, refill-check in difftest does not support masked comparison, instead it checks entire 512bit, so it will fail if we enable checks on `cacheid >=3` (#712).

https://github.com/OpenXiangShan/XiangShan/pull/5188 have disabled checks on `cacheid >= 3` temporarily. But as we're refactoring ICache recently, we need this check to ensure the refactored code is working properly.

Therefore, this PR tries to introduce masked refill-check, each mask bit controls comparison of 8B data.