### PR TITLE
fix(difftest): fix InstrCommit.otherwpdest for vecPhyReg splitting

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -72,8 +72,7 @@ class InstrCommit(val numPhyRegs: Int = 32) extends DifftestBaseBundle with HasV
   val v0wen = Bool()
   val wpdest = UInt(log2Ceil(numPhyRegs).W)
   val wdest = UInt(8.W)
-  val otherwpdest = Vec(8, UInt(8.W))
-  val otherV0Wen = Vec(8, Bool())
+  val otherwpdest = Vec(16, UInt(log2Ceil(numPhyRegs).W))
 
   val pc = UInt(64.W)
   val instr = UInt(32.W)

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -388,6 +388,7 @@ class DiffArchVecRenameTable(numPhyRegs: Int) extends DiffArchRenameTable(64, nu
 abstract class DiffPhyRegState(val numPhyRegs: Int) extends PhyRegState(numPhyRegs) with DifftestBundle {
   override val supportsDelta: Boolean = true
   override def classArgs: Map[String, Any] = Map("numPhyRegs" -> numPhyRegs)
+  override val updateDependency: Seq[String] = Seq("commit", "event")
 }
 
 class DiffPhyIntRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {


### PR DESCRIPTION
This commit updates instrCommit.otherwpdest to align with vecCommitData, PhyVecReg, ArchVecRenameTable for vecPhyReg splitting.

Since 128-bit vecPhyRegs are splitted to 2 64-bit regs, both otherwpdest and RenameTable now follow the same DUT-side index conversion to (2*index, 2*index+1).

We also accordingly fix the indexing in vector_load_checking.

Note that Squash without vec_commit_data (i.e., updating ArchReg and CommitData in software with PhyReg) is not yet supported. This will be added in a future update.