### PR TITLE
fix(preprocess): fix vec_commit_data indexing

### DIFF
--- a/src/main/scala/Preprocess.scala
+++ b/src/main/scala/Preprocess.scala
@@ -83,15 +83,13 @@ object Preprocess {
       cd.data := Mux(c.fpwen, fpData, intData)
       // Also skip vec_commit_data (used in vec_load check) for single core
       val vcd = Option.when(phyVecs.nonEmpty && numCores > 1) {
-        val vreg = phyVecs(coreID).value
         val gen = Wire(new DiffVecCommitData)
         gen.coreid := c.coreid
         gen.index := c.index
         gen.valid := c.valid && (c.v0wen || c.vecwen)
-        gen.data := VecInit(c.otherwpdest.flatMap { wpdest =>
-          val splitDest = (wpdest << 1).asUInt
-          Seq(vreg(splitDest), vreg(splitDest + 1.U))
-        })
+        gen.data := c.otherwpdest.map { wpdest =>
+          phyVecs(coreID).value(wpdest)
+        }
         gen
       }
       Seq(cd) ++ vcd.toSeq


### PR DESCRIPTION
In #724, we updates InstrCommit.otherwpdest from index to (2\*index, 2\*index+1) for splitting each 128-bit vecReg to 2 64-bit vecReg. The index conversion is entirely done inside DUT itself.

This change fixs vec_commit_data by using correct otherwpdest to index 64-bit split vecReg indexed from PhyVecReg.