### PR TITLE
fix(difftest): update the  error message for pc_mismatch

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -456,6 +456,9 @@ inline int Difftest::check_all() {
 #endif
     display();
     proxy->display(dut);
+    if (pc_mismatch) {
+      REPORT_DIFFERENCE("pc", ref_commit_first_pc, ref_commit_first_pc, dut_commit_first_pc);
+    }
 #ifdef FUZZER_LIB
     stats.exit_code = SimExitCode::difftest;
 #endif // FUZZER_LIB
@@ -1642,10 +1645,6 @@ void Difftest::do_sync_custom_mflushpwr() {
 #endif
 
 void Difftest::display() {
-  Info("\n==============  In the last commit group  ==============\n");
-  Info("the first commit instr pc of DUT is 0x%016lx\nthe first commit instr pc of REF is 0x%016lx\n",
-       dut_commit_first_pc, ref_commit_first_pc);
-
   state->display();
 
   Info("\n==============  REF Regs  ==============\n");

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -211,18 +211,15 @@ int RefProxy::compare(DiffTestState *dut) {
 
 void RefProxy::display(DiffTestState *dut) {
   if (dut) {
-#define PROXY_COMPARE_AND_DISPLAY(field, field_names)                     \
-  do {                                                                    \
-    uint64_t *_ptr_dut = (uint64_t *)(&((dut)->field));                   \
-    uint64_t *_ptr_ref = (uint64_t *)(&(field));                          \
-    for (int i = 0; i < sizeof(field) / sizeof(uint64_t); i++) {          \
-      if (_ptr_dut[i] != _ptr_ref[i]) {                                   \
-        Info(                                                             \
-            "%7s different at pc = 0x%010lx, right= 0x%016lx, "           \
-            "wrong = 0x%016lx\n",                                         \
-            field_names[i], dut->commit[0].pc, _ptr_ref[i], _ptr_dut[i]); \
-      }                                                                   \
-    }                                                                     \
+#define PROXY_COMPARE_AND_DISPLAY(field, field_names)                                   \
+  do {                                                                                  \
+    uint64_t *_ptr_dut = (uint64_t *)(&((dut)->field));                                 \
+    uint64_t *_ptr_ref = (uint64_t *)(&(field));                                        \
+    for (int i = 0; i < sizeof(field) / sizeof(uint64_t); i++) {                        \
+      if (_ptr_dut[i] != _ptr_ref[i]) {                                                 \
+        REPORT_DIFFERENCE(field_names[i], dut->commit[0].pc, _ptr_ref[i], _ptr_dut[i]); \
+      }                                                                                 \
+    }                                                                                   \
   } while (0);
 
     PROXY_COMPARE_AND_DISPLAY(regs_int, regs_name_int)

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -484,4 +484,7 @@ struct InterruptDelegate {
 extern const char *difftest_ref_so;
 extern uint8_t *ref_golden_mem;
 
+#define REPORT_DIFFERENCE(name, pc_val, right_val, wrong_val) \
+  Info("%7s different at pc = 0x%010lx, right= 0x%016lx, wrong = 0x%016lx\n", name, pc_val, right_val, wrong_val);
+
 #endif


### PR DESCRIPTION
This commit fixes the error message for pc_mismatch, which is previously implemented as a standalone display "In the last commit group" and hard to find.

The message was introduced in https://github.com/OpenXiangShan/difftest/pull/434