### PR TITLE
fix(refproxy): wrap missing pc in struct

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -536,7 +536,7 @@ int Difftest::do_instr_commit(int i) {
 
   // store the writeback info to debug array
 #ifdef BASIC_DIFFTEST_ONLY
-  uint64_t commit_pc = proxy->pc;
+  uint64_t commit_pc = proxy->state.pc;
 #else
   uint64_t commit_pc = dut->commit[i].pc;
 #endif


### PR DESCRIPTION
In #728, we wrap all states of refproxy into a struct. This change fix the missing unwrapper pc, avoid undefined pc when BASIC_DIFF.