### PR TITLE
fix(log): check log ranges and support log-status query

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -316,6 +316,10 @@ public:
     state->dump_commit_trace = enable;
   }
 
+  bool get_commit_trace() {
+    return state->dump_commit_trace;
+  }
+
   void warmup_record() {
     auto trap = get_trap_event();
     warmup_info.instrCnt = trap->instrCnt;

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -355,6 +355,10 @@ public:
     sync_config();
   }
 
+  inline bool get_debug() {
+    return config.debug_difftest;
+  }
+
   inline void set_illegal_mem_access(bool ignored = false) {
     config.ignore_illegal_mem_access = ignored;
     sync_config();

--- a/src/test/csrc/emu/emu.cpp
+++ b/src/test/csrc/emu/emu.cpp
@@ -774,18 +774,20 @@ int Emulator::tick() {
     }
 #endif
     if (args.enable_ref_trace) {
-      if (trap->cycleCnt == args.log_begin) {
+      bool is_debug = difftest[i]->proxy->get_debug();
+      if (trap->cycleCnt >= args.log_begin && !is_debug) {
         difftest[i]->proxy->set_debug(true);
       }
-      if (trap->cycleCnt == args.log_end) {
+      if (trap->cycleCnt >= args.log_end && is_debug) {
         difftest[i]->proxy->set_debug(false);
       }
     }
     if (args.enable_commit_trace) {
-      if (trap->cycleCnt == args.log_begin) {
+      bool is_commit_trace = difftest[i]->get_commit_trace();
+      if (trap->cycleCnt >= args.log_begin && !is_commit_trace) {
         difftest[i]->set_commit_trace(true);
       }
-      if (trap->cycleCnt == args.log_end) {
+      if (trap->cycleCnt >= args.log_end && is_commit_trace) {
         difftest[i]->set_commit_trace(false);
       }
     }


### PR DESCRIPTION
Since Squash mode does not transmit trapEvent every cycle, trap->cycleCnt can no longer be matched using exact equality. This change updates the check to use a range-based condition instead.

We also add an API to query whether logging is enabled, preventing redundant or repeated log setup.