### PR TITLE
chore(args): set default args.image to "/dev/zero"

### DIFF
--- a/src/test/csrc/emu/emu.cpp
+++ b/src/test/csrc/emu/emu.cpp
@@ -307,11 +307,6 @@ inline EmuArgs parse_args(int argc, const char *argv[]) {
     }
   }
 
-  if (args.image == NULL) {
-    Info("Hint: --image=IMAGE_FILE is not specified. Use /dev/zero instead.\n");
-    args.image = "/dev/zero";
-  }
-
   args.enable_waveform = args.enable_waveform && !args.enable_fork;
 
 #ifdef ENABLE_IPC

--- a/src/test/csrc/emu/emu.h
+++ b/src/test/csrc/emu/emu.h
@@ -46,7 +46,7 @@ struct EmuArgs {
   uint64_t ipc_last_cycle;
   uint64_t ipc_times;
 #endif
-  const char *image = nullptr;
+  const char *image = "/dev/zero";
   const char *instr_trace = nullptr;
   const char *gcpt_restore = nullptr;
   const char *snapshot_path = nullptr;


### PR DESCRIPTION
This change sets the default value of args.image to "/dev/zero" directly in the structure instead of arg_parser.

This makes it easier to maintain consistent args initialization across different envs (Verilator, VCS, FPGA).