### PR TITLE
fix(difftest): initialize ref_proxy during init

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -33,7 +33,7 @@
 
 Difftest **difftest = NULL;
 
-int difftest_init() {
+int difftest_init(bool enabled, size_t ramsize) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_perfcnt_init();
 #endif // CONFIG_DIFFTEST_PERFCNT
@@ -48,13 +48,12 @@ int difftest_init() {
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i] = new Difftest(i);
     difftest[i]->dut = diffstate_buffer[i]->get(0, 0);
+    if (enabled) {
+      difftest[i]->update_nemuproxy(i, ramsize);
+    }
   }
-  return 0;
-}
-
-int init_nemuproxy(size_t ramsize = 0) {
-  for (int i = 0; i < NUM_CORES; i++) {
-    difftest[i]->update_nemuproxy(i, ramsize);
+  if (enabled) {
+    init_goldenmem();
   }
   return 0;
 }

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -502,7 +502,7 @@ protected:
 };
 
 extern Difftest **difftest;
-int difftest_init();
+int difftest_init(bool enabled, size_t ramsize);
 
 int difftest_nstep(int step, bool enable_diff);
 void difftest_switch_zone();
@@ -513,8 +513,6 @@ void difftest_finish();
 
 void difftest_trace_read();
 void difftest_trace_write(int step);
-
-int init_nemuproxy(size_t);
 
 #ifdef CONFIG_DIFFTEST_SQUASH
 extern "C" void set_squash_scope();

--- a/src/test/csrc/emu/emu.cpp
+++ b/src/test/csrc/emu/emu.cpp
@@ -165,7 +165,8 @@ Emulator::Emulator(int argc, const char *argv[])
 
 #ifndef CONFIG_NO_DIFFTEST
   // init difftest
-  difftest_init();
+  auto ref_ramsize = args.ram_size ? simMemory->get_size() : 0;
+  difftest_init(args.enable_diff, ref_ramsize);
 
   // init difftest traces
   if (args.trace_name) {
@@ -177,13 +178,6 @@ Emulator::Emulator(int argc, const char *argv[])
 
   init_device();
 
-#ifndef CONFIG_NO_DIFFTEST
-  if (args.enable_diff) {
-    init_goldenmem();
-    size_t ref_ramsize = args.ram_size ? simMemory->get_size() : 0;
-    init_nemuproxy(ref_ramsize);
-  }
-#endif // CONFIG_NO_DIFFTEST
 #ifdef ENABLE_RUNAHEAD
   if (args.enable_runahead) {
     runahead_init();

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -83,11 +83,9 @@ void fpga_init() {
   init_ram(args.image, DEFAULT_EMU_RAM_SIZE);
   init_flash(args.flash_bin);
 
-  difftest_init();
+  difftest_init(true, DEFAULT_EMU_RAM_SIZE);
 
   init_device();
-  init_goldenmem();
-  init_nemuproxy(DEFAULT_EMU_RAM_SIZE);
 
 #ifndef FPGA_SIM
 #ifdef USE_XDMA_DDR_LOAD

--- a/src/test/csrc/plugin/xspdb/cpp/export.cpp
+++ b/src/test/csrc/plugin/xspdb/cpp/export.cpp
@@ -66,10 +66,6 @@ void GoldenMemFinish() {
   goldenmem_finish();
 }
 
-int NemuProxyInit(uint64_t size) {
-  return init_nemuproxy((size_t)size);
-}
-
 void SetProxyRefSo(uint64_t addr) {
   difftest_ref_so = (const char *)addr;
 }

--- a/src/test/csrc/plugin/xspdb/cpp/export.h
+++ b/src/test/csrc/plugin/xspdb/cpp/export.h
@@ -24,7 +24,6 @@ int GetDifftestStat();
 
 void GoldenMemInit();
 void GoldenMemFinish();
-int NemuProxyInit(uint64_t size);
 void SetProxyRefSo(uint64_t addr);
 uint64_t GetProxyRefSo();
 

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -200,17 +200,10 @@ extern "C" uint8_t simv_init() {
   init_flash(args.flash_bin);
 
 #ifndef CONFIG_NO_DIFFTEST
-  difftest_init();
+  difftest_init(args.enable_diff, ram_size);
 #endif // CONFIG_NO_DIFFTEST
 
   init_device();
-
-#ifndef CONFIG_NO_DIFFTEST
-  if (args.enable_diff) {
-    init_goldenmem();
-    init_nemuproxy(ram_size);
-  }
-#endif // CONFIG_NO_DIFFTEST
 
 #ifdef FPGA_SIM
   xdma_sim_open(0, false);


### PR DESCRIPTION
This is one of the steps toward refactoring the framework using OOP. We need to avoid using global variables and functions.