### PR TITLE
fix(difftest): move DiffState to separate files

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -21,7 +21,7 @@
 #define NUM_CORES 1
 #endif
 
-#include "diffstate.h"
+#include "difftest-state.h"
 
 #if defined(CPU_NUTSHELL)
 #elif defined(CPU_XIANGSHAN)

--- a/pdb.mk
+++ b/pdb.mk
@@ -28,7 +28,7 @@ $(PDB_OBJ_DIR)/python.i:
 	mkdir -p $(PYTHON_DIR)
 	cp $(PDB_SWIG_DIR)/swig.i $(PDB_OBJ_DIR)/python.i
 	echo "%extend DiffTestState {" >> $(PDB_OBJ_DIR)/python.i
-	cat $(BUILD_DIR)/generated-src/diffstate.h|grep Difftest|grep "\["|sed "s/\[/\ /g"|sed "s/\]/\ /g"|awk '{print $$1 " *get_"$$2"(int index){if(index<"$$3"){return &(self->"$$2"[index]);} return NULL;}"}' >> $(PDB_OBJ_DIR)/python.i
+	cat $(BUILD_DIR)/generated-src/difftest-state.h|grep Difftest|grep "\["|sed "s/\[/\ /g"|sed "s/\]/\ /g"|awk '{print $$1 " *get_"$$2"(int index){if(index<"$$3"){return &(self->"$$2"[index]);} return NULL;}"}' >> $(PDB_OBJ_DIR)/python.i
 	echo "}" >> $(PDB_OBJ_DIR)/python.i
 
 $(PDB_OBJ_DIR)/difftest_wrap.cpp: $(PDB_OBJ_DIR)/python.i

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -400,7 +400,7 @@ object DPIC {
     interfaceCpp += "#define __DIFFTEST_DPIC_H__"
     interfaceCpp += ""
     interfaceCpp += "#include <cstdint>"
-    interfaceCpp += "#include \"diffstate.h\""
+    interfaceCpp += "#include \"difftest-state.h\""
     interfaceCpp += "#if defined(CONFIG_DIFFTEST_BATCH) && !defined(CONFIG_DIFFTEST_FPGA)"
     interfaceCpp += "#include \"svdpi.h\""
     interfaceCpp += "#endif // CONFIG_DIFFTEST_BATCH && !CONFIG_DIFFTEST_FPGA"

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -43,7 +43,7 @@ object Delta {
 
     deltaCpp += "#ifndef __DIFFTEST_DELTA_H__"
     deltaCpp += "#define __DIFFTEST_DELTA_H__"
-    deltaCpp += "#include \"diffstate.h\""
+    deltaCpp += "#include \"difftest-state.h\""
     deltaCpp +=
       s"""
          |typedef struct {

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -671,8 +671,8 @@ object DifftestModule {
     structAligned: Boolean,
   ): Unit = {
     val difftestCpp = ListBuffer.empty[String]
-    difftestCpp += "#ifndef __DIFFSTATE_H__"
-    difftestCpp += "#define __DIFFSTATE_H__"
+    difftestCpp += "#ifndef __DIFFTEST_STATE_H__"
+    difftestCpp += "#define __DIFFTEST_STATE_H__"
     difftestCpp += ""
     difftestCpp += "#include <cstdint>"
     difftestCpp += ""
@@ -760,9 +760,9 @@ object DifftestModule {
          |void difftest_query_finish();
          |#endif // CONFIG_DIFFTEST_QUERY
          |""".stripMargin
-    difftestCpp += "#endif // __DIFFSTATE_H__"
+    difftestCpp += "#endif // __DIFFTEST_STATE_H__"
     difftestCpp += ""
-    FileControl.write(difftestCpp, "diffstate.h")
+    FileControl.write(difftestCpp, "difftest-state.h")
   }
 
   def createCppExtModule(name: String, func: String, header: Option[String]): Unit = {

--- a/src/main/scala/util/Query.scala
+++ b/src/main/scala/util/Query.scala
@@ -40,7 +40,7 @@ object Query {
          |#define __DIFFTEST_QUERY_H__
          |
          |#include <cstdint>
-         |#include "diffstate.h"
+         |#include "difftest-state.h"
          |#include "query.h"
          |
          |#ifdef CONFIG_DIFFTEST_QUERY

--- a/src/test/csrc/common/mpool.h
+++ b/src/test/csrc/common/mpool.h
@@ -17,7 +17,6 @@
 #define __MPOOL_H__
 
 #include "common.h"
-#include "diffstate.h"
 #include <atomic>
 #include <condition_variable>
 #include <functional>

--- a/src/test/csrc/difftest/diffstate.cpp
+++ b/src/test/csrc/difftest/diffstate.cpp
@@ -1,0 +1,45 @@
+/***************************************************************************************
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#include "diffstate.h"
+#include "spikedasm.h"
+
+void DiffState::display() {
+  Info("\n============== Commit Group Trace (Core %d) ==============\n", coreid);
+  int group_index = 0;
+  while (!retire_group_queue.empty()) {
+    auto retire_group = retire_group_queue.front();
+    auto pc = retire_group.first;
+    auto cnt = retire_group.second;
+    retire_group_queue.pop();
+    Info("commit group [%02d]: pc %010lx cmtcnt %d%s\n", group_index, pc, cnt,
+         retire_group_queue.empty() ? " <--" : "");
+    group_index++;
+  }
+
+  Info("\n============== Commit Instr Trace ==============\n");
+  int commit_index = 0;
+  while (!commit_trace.empty()) {
+    CommitTrace *trace = commit_trace.front();
+    commit_trace.pop();
+    trace->display_line(commit_index, use_spike, commit_trace.empty());
+    commit_index++;
+  }
+
+  fflush(stdout);
+}
+
+DiffState::DiffState(int coreid) : use_spike(spike_valid()), coreid(coreid) {}

--- a/src/test/csrc/difftest/diffstate.h
+++ b/src/test/csrc/difftest/diffstate.h
@@ -1,0 +1,158 @@
+/***************************************************************************************
+* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025 Beijing Institute of Open Source Chip
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef __DIFFSTATE_H__
+#define __DIFFSTATE_H__
+
+#include "common.h"
+#include <queue>
+
+class CommitTrace {
+public:
+  uint64_t pc;
+  uint32_t inst;
+
+  CommitTrace(uint64_t pc, uint32_t inst) : pc(pc), inst(inst) {}
+  virtual ~CommitTrace() {}
+  virtual const char *get_type() = 0;
+  virtual void display(bool use_spike = false);
+  void display_line(int index, bool use_spike, bool is_retire);
+
+protected:
+  virtual void display_custom() = 0;
+};
+
+class InstrTrace : public CommitTrace {
+public:
+  uint8_t wen;
+  uint8_t dest;
+  uint64_t data;
+  char tag;
+
+  uint16_t robidx;
+  uint8_t isLoad;
+  uint8_t lqidx;
+  uint8_t isStore;
+  uint8_t sqidx;
+
+  InstrTrace(uint64_t pc, uint32_t inst, uint8_t wen, uint8_t dest, uint64_t data, uint8_t lqidx, uint8_t sqidx,
+             uint16_t robidx, uint8_t isLoad, uint8_t isStore, bool skip = false, bool delayed = false)
+      : CommitTrace(pc, inst), robidx(robidx), isLoad(isLoad), lqidx(lqidx), isStore(isStore), sqidx(sqidx), wen(wen),
+        dest(dest), data(data), tag(get_tag(skip, delayed)) {}
+  virtual inline const char *get_type() {
+    return "commit";
+  };
+
+protected:
+  void display_custom() {
+    Info(" wen %d dst %02d data %016lx idx %03x", wen, dest, data, robidx);
+    if (isLoad) {
+      Info(" (%02x)", lqidx);
+    }
+    if (isStore) {
+      Info(" (%02x)", sqidx);
+    }
+    if (tag) {
+      Info(" (%c)", tag);
+    }
+  }
+
+private:
+  char get_tag(bool skip, bool delayed) {
+    char t = '\0';
+    if (skip)
+      t |= 'S';
+    if (delayed)
+      t |= 'D';
+    return t;
+  }
+};
+
+class ExceptionTrace : public CommitTrace {
+public:
+  uint64_t cause;
+  ExceptionTrace(uint64_t pc, uint32_t inst, uint64_t cause) : CommitTrace(pc, inst), cause(cause) {}
+  virtual inline const char *get_type() {
+    return "exception";
+  };
+
+protected:
+  void display_custom() {
+    Info(" cause %016lx", cause);
+  }
+};
+
+class InterruptTrace : public ExceptionTrace {
+public:
+  InterruptTrace(uint64_t pc, uint32_t inst, uint64_t cause) : ExceptionTrace(pc, inst, cause) {}
+  virtual inline const char *get_type() {
+    return "interrupt";
+  }
+};
+
+class DiffState {
+public:
+  bool dump_commit_trace = false;
+
+  DiffState(int coreid);
+  void record_group(uint64_t pc, uint32_t count) {
+    if (retire_group_queue.size() >= DEBUG_GROUP_TRACE_SIZE) {
+      retire_group_queue.pop();
+    }
+    retire_group_queue.push(std::make_pair(pc, count));
+  }
+  void record_inst(uint64_t pc, uint32_t inst, uint8_t en, uint8_t dest, uint64_t data, bool skip, bool delayed,
+                   uint8_t lqidx, uint8_t sqidx, uint16_t robidx, uint8_t isLoad, uint8_t isStore) {
+    push_back_trace(new InstrTrace(pc, inst, en, dest, data, lqidx, sqidx, robidx, isLoad, isStore, skip, delayed));
+  };
+  void record_exception(uint64_t pc, uint32_t inst, uint64_t cause) {
+    push_back_trace(new ExceptionTrace(pc, inst, cause));
+  };
+  void record_interrupt(uint64_t pc, uint32_t inst, uint64_t cause) {
+    push_back_trace(new InterruptTrace(pc, inst, cause));
+  };
+  void display();
+
+private:
+  int coreid;
+  const bool use_spike;
+
+  static const int DEBUG_GROUP_TRACE_SIZE = 16;
+  std::queue<std::pair<uint64_t, uint32_t>> retire_group_queue;
+
+  static const int DEBUG_INST_TRACE_SIZE = 32;
+  std::queue<CommitTrace *> commit_trace;
+
+  uint64_t commit_counter = 0;
+  void push_back_trace(CommitTrace *trace) {
+    if (commit_trace.size() >= DEBUG_INST_TRACE_SIZE) {
+      delete commit_trace.front();
+      commit_trace.pop();
+    }
+    commit_trace.push(trace);
+    if (dump_commit_trace) {
+      // Traces from multiple cores may mix together. Use coreid to distinguish them.
+      if (NUM_CORES > 1) {
+        printf("[%d]", coreid);
+      }
+      trace->display_line(commit_counter, use_spike, false);
+      commit_counter++;
+      fflush(stdout);
+    }
+  }
+};
+
+#endif // __DIFFSTATE_H__

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -1684,30 +1684,3 @@ void Difftest::warmup_display_stats() {
                           ", IPC = %lf\n" ANSI_COLOR_RESET,
        this->id, instrCnt, cycleCnt, ipc);
 }
-
-void DiffState::display() {
-  Info("\n============== Commit Group Trace (Core %d) ==============\n", coreid);
-  int group_index = 0;
-  while (!retire_group_queue.empty()) {
-    auto retire_group = retire_group_queue.front();
-    auto pc = retire_group.first;
-    auto cnt = retire_group.second;
-    retire_group_queue.pop();
-    Info("commit group [%02d]: pc %010lx cmtcnt %d%s\n", group_index, pc, cnt,
-         retire_group_queue.empty() ? " <--" : "");
-    group_index++;
-  }
-
-  Info("\n============== Commit Instr Trace ==============\n");
-  int commit_index = 0;
-  while (!commit_trace.empty()) {
-    CommitTrace *trace = commit_trace.front();
-    commit_trace.pop();
-    trace->display_line(commit_index, use_spike, commit_trace.empty());
-    commit_index++;
-  }
-
-  fflush(stdout);
-}
-
-DiffState::DiffState(int coreid) : use_spike(spike_valid()), coreid(coreid) {}

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -18,6 +18,7 @@
 #define __DIFFTEST_H__
 
 #include "common.h"
+#include "diffstate.h"
 #include "difftrace.h"
 #include "dut.h"
 #include "golden.h"
@@ -87,147 +88,10 @@ public:
   uint8_t mask;
 };
 
-class CommitTrace {
-public:
-  uint64_t pc;
-  uint32_t inst;
-
-  CommitTrace(uint64_t pc, uint32_t inst) : pc(pc), inst(inst) {}
-  virtual ~CommitTrace() {}
-  virtual const char *get_type() = 0;
-  virtual void display(bool use_spike = false);
-  void display_line(int index, bool use_spike, bool is_retire);
-
-protected:
-  virtual void display_custom() = 0;
-};
-
-class InstrTrace : public CommitTrace {
-public:
-  uint8_t wen;
-  uint8_t dest;
-  uint64_t data;
-  char tag;
-
-  uint16_t robidx;
-  uint8_t isLoad;
-  uint8_t lqidx;
-  uint8_t isStore;
-  uint8_t sqidx;
-
-  InstrTrace(uint64_t pc, uint32_t inst, uint8_t wen, uint8_t dest, uint64_t data, uint8_t lqidx, uint8_t sqidx,
-             uint16_t robidx, uint8_t isLoad, uint8_t isStore, bool skip = false, bool delayed = false)
-      : CommitTrace(pc, inst), robidx(robidx), isLoad(isLoad), lqidx(lqidx), isStore(isStore), sqidx(sqidx), wen(wen),
-        dest(dest), data(data), tag(get_tag(skip, delayed)) {}
-  virtual inline const char *get_type() {
-    return "commit";
-  };
-
-protected:
-  void display_custom() {
-    Info(" wen %d dst %02d data %016lx idx %03x", wen, dest, data, robidx);
-    if (isLoad) {
-      Info(" (%02x)", lqidx);
-    }
-    if (isStore) {
-      Info(" (%02x)", sqidx);
-    }
-    if (tag) {
-      Info(" (%c)", tag);
-    }
-  }
-
-private:
-  char get_tag(bool skip, bool delayed) {
-    char t = '\0';
-    if (skip)
-      t |= 'S';
-    if (delayed)
-      t |= 'D';
-    return t;
-  }
-};
-
-class ExceptionTrace : public CommitTrace {
-public:
-  uint64_t cause;
-  ExceptionTrace(uint64_t pc, uint32_t inst, uint64_t cause) : CommitTrace(pc, inst), cause(cause) {}
-  virtual inline const char *get_type() {
-    return "exception";
-  };
-
-protected:
-  void display_custom() {
-    Info(" cause %016lx", cause);
-  }
-};
-
-class InterruptTrace : public ExceptionTrace {
-public:
-  InterruptTrace(uint64_t pc, uint32_t inst, uint64_t cause) : ExceptionTrace(pc, inst, cause) {}
-  virtual inline const char *get_type() {
-    return "interrupt";
-  }
-};
-
 typedef struct {
   uint64_t instrCnt;
   uint64_t cycleCnt;
 } WarmupInfo;
-
-class DiffState {
-public:
-  bool dump_commit_trace = false;
-
-  DiffState(int coreid);
-  void record_group(uint64_t pc, uint32_t count) {
-    if (retire_group_queue.size() >= DEBUG_GROUP_TRACE_SIZE) {
-      retire_group_queue.pop();
-    }
-    retire_group_queue.push(std::make_pair(pc, count));
-  }
-  void record_inst(uint64_t pc, uint32_t inst, uint8_t en, uint8_t dest, uint64_t data, bool skip, bool delayed,
-                   uint8_t lqidx, uint8_t sqidx, uint16_t robidx, uint8_t isLoad, uint8_t isStore) {
-    push_back_trace(new InstrTrace(pc, inst, en, dest, data, lqidx, sqidx, robidx, isLoad, isStore, skip, delayed));
-  };
-  void record_exception(uint64_t pc, uint32_t inst, uint64_t cause) {
-    push_back_trace(new ExceptionTrace(pc, inst, cause));
-  };
-  void record_interrupt(uint64_t pc, uint32_t inst, uint64_t cause) {
-    push_back_trace(new InterruptTrace(pc, inst, cause));
-  };
-  void display();
-
-private:
-  int coreid;
-  const bool use_spike;
-
-  static const int DEBUG_GROUP_TRACE_SIZE = 16;
-  std::queue<std::pair<uint64_t, uint32_t>> retire_group_queue;
-
-  static const int DEBUG_INST_TRACE_SIZE = 32;
-  std::queue<CommitTrace *> commit_trace;
-
-  uint64_t commit_counter = 0;
-  void push_back_trace(CommitTrace *trace) {
-    if (commit_trace.size() >= DEBUG_INST_TRACE_SIZE) {
-      delete commit_trace.front();
-      commit_trace.pop();
-    }
-    commit_trace.push(trace);
-    if (dump_commit_trace) {
-      // Traces from multiple cores may mix together. Use coreid to distinguish them.
-      if (NUM_CORES > 1) {
-        printf("[%d]", coreid);
-      }
-      trace->display_line(commit_counter, use_spike, false);
-      commit_counter++;
-      fflush(stdout);
-    }
-  }
-  void display_commit_count(int i);
-  void display_commit_instr(int index, CommitTrace *trace, bool is_retire);
-};
 
 class Difftest {
 public:

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -16,7 +16,6 @@
 
 #include "args.h"
 #include "device.h"
-#include "diffstate.h"
 #include "difftest.h"
 #include "flash.h"
 #include "goldenmem.h"

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -17,7 +17,6 @@
 #define __XDMA_H__
 
 #include "common.h"
-#include "diffstate.h"
 #include "mpool.h"
 #include <atomic>
 #include <queue>

--- a/src/test/csrc/plugin/xspdb/swig.i
+++ b/src/test/csrc/plugin/xspdb/swig.i
@@ -6,7 +6,7 @@
 #include "ram.h"
 #include "flash.h"
 #include "device.h"
-#include "diffstate.h"
+#include "difftest-state.h"
 #include "difftrace.h"
 #include "refproxy.h"
 %}
@@ -50,7 +50,7 @@
 %include "ram.h"
 %include "flash.h"
 %include "device.h"
-%include "diffstate.h"
+%include "difftest-state.h"
 %include "difftrace.h"
 %include "refproxy.h"
 
@@ -76,4 +76,3 @@ GAL_METHODS(DifftestInstrCommit, instr)
 GAL_METHODS(DifftestTrapEvent, pc)
 GAL_METHODS(DifftestTrapEvent, code)
 GAL_METHODS(DifftestTrapEvent, hasTrap)
-


### PR DESCRIPTION
This improves the code readability.

We also rename the generated DiffTestState filename to avoid naming conflicts. We understand the current names are confusing, but we will leave the naming issues to a future commit.

`display_commit_count` and `display_commit_instr` are never defined. They are removed as well.