### PR TITLE
feat(difftest): support explicit register states

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -90,9 +90,9 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
     val dut_zone = if (config.hasDutZone) "dut_zone" else "0"
     val dut_index = if (config.isBatch) "dut_index" else "0"
     val packet = if (config.isDelta && gen.isDeltaElem) {
-      s"DELTA_BUF(${prefix}coreid)->${gen.desiredCppName}"
+      s"DELTA_BUF(${prefix}coreid)->${gen.actualCppName}"
     } else {
-      s"DUT_BUF(${prefix}coreid, $dut_zone, $dut_index)->${gen.desiredCppName}"
+      s"DUT_BUF(${prefix}coreid, $dut_zone, $dut_index)->${gen.actualCppName}"
     }
     val index = if (gen.isIndexed) s"[${prefix}index]" else if (gen.isFlatten) s"[${prefix}address]" else ""
     s"auto packet = &($packet$index);"
@@ -413,8 +413,8 @@ object DPIC {
       interfaceCpp += "void diffstate_update_archreg(DiffTestState* dut) {"
       phyRegs.foreach { p =>
         val suffix = p.desiredCppName.replace("pregs_", "")
-        val (regName, pregName, ratName) = (s"regs_$suffix", s"pregs_$suffix", s"rat_$suffix")
-        val regSize = instances.find(_.desiredCppName == regName).get.bits.asInstanceOf[ArchRegState].numRegs
+        val (regName, pregName, ratName) = (s"regs.$suffix", s"pregs_$suffix", s"rat_$suffix")
+        val regSize = instances.find(_.desiredCppName == suffix).get.bits.asInstanceOf[ArchRegState].numRegs
         val index = if (instances.exists(_.desiredCppName == ratName)) {
           s"dut->$ratName.value[i]"
         } else {

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -53,8 +53,9 @@ object Delta {
 
     def deltaSync(dst: String, src: String): Seq[String] = {
       deltaInsts.map { inst =>
-        val name = inst.desiredCppName
-        s"memcpy(&($dst->$name), $src->${name}_elem, sizeof(${inst.desiredModuleName}));"
+        val destName = inst.actualCppName
+        val srcName = inst.desiredCppName
+        s"memcpy(&($dst->$destName), $src->${srcName}_elem, sizeof(${inst.desiredModuleName}));"
       }.toSeq
     }
     deltaCpp +=

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -185,7 +185,7 @@ object Gateway {
   }
 
   def getInstance(bundles: Seq[DifftestBundle]): Seq[DifftestBundle] = {
-    val archRegs = if (!bundles.exists(_.desiredCppName == "regs_xrf")) {
+    val archRegs = if (!bundles.exists(_.desiredCppName == "xrf")) {
       Preprocess.getArchRegs(bundles, false)
     } else {
       Seq.empty

--- a/src/main/scala/Preprocess.scala
+++ b/src/main/scala/Preprocess.scala
@@ -33,7 +33,7 @@ object Preprocess {
       case (suffix, gen) =>
         val pregs = bundles.filter(_.desiredCppName == "pregs_" + suffix).asInstanceOf[Seq[DiffPhyRegState]]
         if (pregs.nonEmpty) {
-          require(!bundles.exists(_.desiredCppName == "regs_" + suffix))
+          require(!bundles.exists(_.desiredCppName == suffix))
           if (isHardware) {
             val needRat = pregs.head.numPhyRegs != gen.value.size
             val rats = bundles.filter(_.desiredCppName == "rat_" + suffix).asInstanceOf[Seq[DiffArchRenameTable]]

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -490,12 +490,12 @@ void Difftest::do_exception() {
     struct ExecutionGuide guide;
     guide.force_raise_exception = true;
     guide.exception_num = dut->event.exception;
-    guide.mtval = dut->csr.mtval;
-    guide.stval = dut->csr.stval;
+    guide.mtval = dut->regs.csr.mtval;
+    guide.stval = dut->regs.csr.stval;
 #ifdef CONFIG_DIFFTEST_HCSRSTATE
-    guide.mtval2 = dut->hcsr.mtval2;
-    guide.htval = dut->hcsr.htval;
-    guide.vstval = dut->hcsr.vstval;
+    guide.mtval2 = dut->regs.hcsr.mtval2;
+    guide.htval = dut->regs.hcsr.htval;
+    guide.vstval = dut->regs.hcsr.vstval;
 #endif // CONFIG_DIFFTEST_HCSRSTATE
     guide.force_set_jump_target = false;
     proxy->guided_exec(guide);
@@ -1541,7 +1541,7 @@ int Difftest::update_delayed_writeback() {
 }
 
 int Difftest::apply_delayed_writeback() {
-#define APPLY_DELAYED_WB(delayed, regs, regs_name)                           \
+#define APPLY_DELAYED_WB(delayed, reg_type, regs_name)                       \
   do {                                                                       \
     static const int m = delay_wb_limit;                                     \
     for (int i = 0; i < 32; i++) {                                           \
@@ -1553,16 +1553,16 @@ int Difftest::apply_delayed_writeback() {
           return 1;                                                          \
         }                                                                    \
         delayed[i]++;                                                        \
-        dut->regs.value[i] = proxy->state.regs.value[i];                     \
+        dut->regs.reg_type.value[i] = proxy->state.reg_type.value[i];        \
       }                                                                      \
     }                                                                        \
   } while (0);
 
 #ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-  APPLY_DELAYED_WB(delayed_int, regs_xrf, regs_name_int)
+  APPLY_DELAYED_WB(delayed_int, xrf, regs_name_int)
 #endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
 #ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-  APPLY_DELAYED_WB(delayed_fp, regs_frf, regs_name_fp)
+  APPLY_DELAYED_WB(delayed_fp, frf, regs_name_fp)
 #endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
   return 0;
 }
@@ -1649,7 +1649,7 @@ void Difftest::display() {
   Info("\n==============  REF Regs  ==============\n");
   fflush(stdout);
   proxy->ref_reg_display();
-  Info("privilegeMode: %lu\n", dut->csr.privilegeMode);
+  Info("privilegeMode: %lu\n", dut->regs.csr.privilegeMode);
 }
 
 void CommitTrace::display(bool use_spike) {

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -149,14 +149,14 @@ public:
   uint64_t *arch_reg(uint8_t src, bool is_fp = false) {
     return
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-        is_fp ? dut->regs_frf.value + src :
+        is_fp ? dut->regs.frf.value + src :
 #endif
-              dut->regs_xrf.value + src;
+              dut->regs.xrf.value + src;
   }
 
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
   inline uint64_t *arch_vecreg(uint8_t src) {
-    return dut->regs_vrf.value + src;
+    return dut->regs.vrf.value + src;
   }
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 
@@ -276,7 +276,7 @@ protected:
 #elif defined(CONFIG_DIFFTEST_INTWRITEBACK)
     return dut->wb_xrf[dut->commit[i].wpdest].data;
 #else
-    return dut->regs_xrf.value[dut->commit[i].wdest];
+    return dut->regs.xrf.value[dut->commit[i].wdest];
 #endif
   }
 
@@ -287,7 +287,7 @@ protected:
 #elif defined(CONFIG_DIFFTEST_FPWRITEBACK)
     return dut->wb_frf[dut->commit[i].wpdest].data;
 #else
-    return dut->regs_frf.value[dut->commit[i].wdest];
+    return dut->regs.frf.value[dut->commit[i].wdest];
 #endif
   }
 #endif

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -148,39 +148,39 @@ RefProxy::~RefProxy() {
 }
 
 void RefProxy::regcpy(DiffTestState *dut) {
-  memcpy(&state.regs_xrf, dut->regs_xrf.value, 32 * sizeof(uint64_t));
+  memcpy(&state.xrf, dut->regs.xrf.value, sizeof(state.xrf));
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-  memcpy(&state.regs_frf, dut->regs_frf.value, 32 * sizeof(uint64_t));
+  memcpy(&state.frf, dut->regs.frf.value, sizeof(state.frf));
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
-  memcpy(&state.csr, &dut->csr, sizeof(state.csr));
+  memcpy(&state.csr, &dut->regs.csr, sizeof(state.csr));
   state.pc = dut->commit[0].pc;
 #ifdef CONFIG_DIFFTEST_HCSRSTATE
-  memcpy(&state.hcsr, &dut->hcsr, sizeof(state.hcsr));
+  memcpy(&state.hcsr, &dut->regs.hcsr, sizeof(state.hcsr));
 #endif // CONFIG_DIFFTEST_HCSRSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-  memcpy(&state.regs_vrf, &dut->regs_vrf.value, sizeof(state.regs_vrf));
+  memcpy(&state.vrf, &dut->regs.vrf.value, sizeof(state.vrf));
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
-  memcpy(&state.vcsr, &dut->vcsr, sizeof(state.vcsr));
+  memcpy(&state.vcsr, &dut->regs.vcsr, sizeof(state.vcsr));
 #endif // CONFIG_DIFFTEST_VECCSRSTATE
 #ifdef CONFIG_DIFFTEST_FPCSRSTATE
-  memcpy(&state.fcsr, &dut->fcsr, sizeof(state.fcsr));
+  memcpy(&state.fcsr, &dut->regs.fcsr, sizeof(state.fcsr));
 #endif // CONFIG_DIFFTEST_FPCSRSTATE
 #ifdef CONFIG_DIFFTEST_TRIGGERCSRSTATE
-  memcpy(&state.triggercsr, &dut->triggercsr, sizeof(state.triggercsr));
+  memcpy(&state.triggercsr, &dut->regs.triggercsr, sizeof(state.triggercsr));
 #endif //CONFIG_DIFFTEST_TRIGGERCSRSTATE
   ref_regcpy(&state, DUT_TO_REF, false);
 };
 
 int RefProxy::compare(DiffTestState *dut) {
-#define PROXY_COMPARE(field) memcmp(&(dut->field), &(state.field), sizeof(state.field))
+#define PROXY_COMPARE(field) memcmp(&(dut->regs.field), &(state.field), sizeof(state.field))
 
-  const int results[] = {PROXY_COMPARE(regs_xrf),
+  const int results[] = {PROXY_COMPARE(xrf),
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-                         PROXY_COMPARE(regs_frf),
+                         PROXY_COMPARE(frf),
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-                         PROXY_COMPARE(regs_vrf),
+                         PROXY_COMPARE(vrf),
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
                          PROXY_COMPARE(vcsr),
@@ -217,7 +217,7 @@ void RefProxy::display(DiffTestState *dut) {
   if (dut) {
 #define PROXY_COMPARE_AND_DISPLAY(field, field_names)                                   \
   do {                                                                                  \
-    uint64_t *_ptr_dut = (uint64_t *)(&((dut)->field));                                 \
+    uint64_t *_ptr_dut = (uint64_t *)(&((dut)->regs.field));                            \
     uint64_t *_ptr_ref = (uint64_t *)(&(state.field));                                  \
     for (int i = 0; i < sizeof(state.field) / sizeof(uint64_t); i++) {                  \
       if (_ptr_dut[i] != _ptr_ref[i]) {                                                 \
@@ -226,16 +226,16 @@ void RefProxy::display(DiffTestState *dut) {
     }                                                                                   \
   } while (0);
 
-    PROXY_COMPARE_AND_DISPLAY(regs_xrf, regs_name_int)
+    PROXY_COMPARE_AND_DISPLAY(xrf, regs_name_int)
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-    PROXY_COMPARE_AND_DISPLAY(regs_frf, regs_name_fp)
+    PROXY_COMPARE_AND_DISPLAY(frf, regs_name_fp)
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
     PROXY_COMPARE_AND_DISPLAY(csr, regs_name_csr)
 #ifdef CONFIG_DIFFTEST_HCSRSTATE
     PROXY_COMPARE_AND_DISPLAY(hcsr, regs_name_hcsr)
 #endif // CONFIG_DIFFTEST_HCSRSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-    PROXY_COMPARE_AND_DISPLAY(regs_vrf, regs_name_vec)
+    PROXY_COMPARE_AND_DISPLAY(vrf, regs_name_vec)
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
     PROXY_COMPARE_AND_DISPLAY(vcsr, regs_name_vec_csr)
@@ -294,13 +294,13 @@ static uint64_t read_mtvec(uint64_t paddr) {
 #endif // CPU_ROCKET_CHIP
 
 bool RefProxy::do_csr_waive(DiffTestState *dut) {
-#define CSR_WAIVE(field, mapping)                                   \
-  do {                                                              \
-    uint64_t v = mapping(state.csr.field);                          \
-    if (state.csr.field != dut->csr.field && dut->csr.field == v) { \
-      state.csr.field = v;                                          \
-      has_waive = true;                                             \
-    }                                                               \
+#define CSR_WAIVE(field, mapping)                                             \
+  do {                                                                        \
+    uint64_t v = mapping(state.csr.field);                                    \
+    if (state.csr.field != dut->regs.csr.field && dut->regs.csr.field == v) { \
+      state.csr.field = v;                                                    \
+      has_waive = true;                                                       \
+    }                                                                         \
   } while (0);
 
   bool has_waive = false;

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -181,9 +181,9 @@ private:
 };
 
 typedef struct __attribute__((packed)) {
-  DifftestArchIntRegState regs_xrf;
+  DifftestArchIntRegState xrf;
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-  DifftestArchFpRegState regs_frf;
+  DifftestArchFpRegState frf;
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
   DifftestCSRState csr;
   uint64_t pc;
@@ -191,7 +191,7 @@ typedef struct __attribute__((packed)) {
   DifftestHCSRState hcsr;
 #endif // CONFIG_DIFFTEST_HCSRSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-  DifftestArchVecRegState regs_vrf;
+  DifftestArchVecRegState vrf;
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
   DifftestVecCSRState vcsr;
@@ -216,18 +216,18 @@ public:
   inline uint64_t *arch_reg(uint8_t src, bool is_fp = false) {
     return
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-        is_fp ? state.regs_frf.value + src :
+        is_fp ? state.frf.value + src :
 #endif
-              state.regs_xrf.value + src;
+              state.xrf.value + src;
   }
 
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
   inline uint64_t *arch_vecreg(uint8_t src) {
-    return state.regs_vrf.value + src;
+    return state.vrf.value + src;
   }
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
   inline void sync(bool is_from_dut = false) {
-    ref_regcpy(&state.regs_xrf, is_from_dut, is_from_dut);
+    ref_regcpy(&state.xrf, is_from_dut, is_from_dut);
   }
 
   void regcpy(DiffTestState *dut);
@@ -243,10 +243,10 @@ public:
       state.pc += isRVC ? 2 : 4;
 
       if (rfwen)
-        state.regs_xrf.value[wdest] = wdata;
+        state.xrf.value[wdest] = wdata;
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
       if (fpwen)
-        state.regs_frf.value[wdest] = wdata;
+        state.frf.value[wdest] = wdata;
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
       // TODO: vec skip is not supported at this time.


### PR DESCRIPTION
This commit moves register states in DifftestBundles to a separate C++ struct definition to improve code readability and allow future optimizations for DUT-REF interfaces.

Only these states are compared with the REF.