### PR TITLE
fix(difftest): add missing void for sv functions

### DIFF
--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -109,7 +109,7 @@ class ReplayControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |
        |// For the C/C++ interface
        |export "DPI-C" function set_replay_head;
-       |function set_replay_head(int head);
+       |function void set_replay_head(int head);
        |  replay = 1'b1;
        |  replay_head = head;
        |endfunction

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -245,7 +245,7 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |
        |// For the C/C++ interface
        |export "DPI-C" function set_squash_enable;
-       |function set_squash_enable(int en);
+       |function void set_squash_enable(int en);
        |  _enable = en;
        |endfunction
        |


### PR DESCRIPTION
The missing `void` return type causes errors in Verilator 5.042.