### PR TITLE
feat(difftest): use standard names for regs

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -311,7 +311,7 @@ class DiffTriggerCSRState extends TriggerCSRState with DifftestBundle {
 }
 
 class DiffIntWriteback(numRegs: Int = 32) extends DataWriteback(numRegs) with DifftestBundle {
-  override val desiredCppName: String = "wb_int"
+  override val desiredCppName: String = "wb_xrf"
   override protected val needFlatten: Boolean = true
   // It is required for MMIO/Load(only for multi-core) data synchronization, and commit instr trace record
   override def supportsSquashBase: Bool = true.B
@@ -319,11 +319,11 @@ class DiffIntWriteback(numRegs: Int = 32) extends DataWriteback(numRegs) with Di
 }
 
 class DiffFpWriteback(numRegs: Int = 32) extends DiffIntWriteback(numRegs) {
-  override val desiredCppName: String = "wb_fp"
+  override val desiredCppName: String = "wb_frf"
 }
 
 class DiffVecWriteback(numRegs: Int = 32) extends VecDataWriteback(numRegs) with DifftestBundle {
-  override val desiredCppName: String = "wb_vec"
+  override val desiredCppName: String = "wb_vrf"
   override protected val needFlatten: Boolean = true
   override def supportsSquashBase: Bool = true.B
   override def classArgs: Map[String, Any] = Map("numRegs" -> numRegs)
@@ -334,7 +334,7 @@ class DiffVecV0Writeback(numRegs: Int = 32) extends DiffVecWriteback(numRegs) {
 }
 
 class DiffArchIntRegState extends ArchIntRegState with DifftestBundle {
-  override val desiredCppName: String = "regs_int"
+  override val desiredCppName: String = "regs_xrf"
   override val desiredOffset: Int = 0
   override val updateDependency: Seq[String] = Seq("commit", "event")
   override val supportsDelta: Boolean = true
@@ -356,14 +356,14 @@ class DiffArchFpDelayedUpdate extends DiffArchDelayedUpdate(32) {
 }
 
 class DiffArchFpRegState extends DiffArchIntRegState {
-  override val desiredCppName: String = "regs_fp"
+  override val desiredCppName: String = "regs_frf"
   override val desiredOffset: Int = 2
   override val updateDependency: Seq[String] = Seq("commit", "event")
   override val supportsDelta: Boolean = true
 }
 
 class DiffArchVecRegState extends ArchVecRegState with DifftestBundle {
-  override val desiredCppName: String = "regs_vec"
+  override val desiredCppName: String = "regs_vrf"
   override val desiredOffset: Int = 4
   override val updateDependency: Seq[String] = Seq("commit", "event")
   override val supportsDelta: Boolean = true
@@ -378,15 +378,15 @@ abstract class DiffArchRenameTable(numRegs: Int, val numPhyRegs: Int)
 }
 
 class DiffArchIntRenameTable(numPhyRegs: Int) extends DiffArchRenameTable(32, numPhyRegs) {
-  override val desiredCppName: String = "rat_int"
+  override val desiredCppName: String = "rat_xrf"
 }
 
 class DiffArchFpRenameTable(numPhyRegs: Int) extends DiffArchRenameTable(32, numPhyRegs) {
-  override val desiredCppName: String = "rat_fp"
+  override val desiredCppName: String = "rat_frf"
 }
 
 class DiffArchVecRenameTable(numPhyRegs: Int) extends DiffArchRenameTable(64, numPhyRegs) {
-  override val desiredCppName: String = "rat_vec"
+  override val desiredCppName: String = "rat_vrf"
 }
 
 abstract class DiffPhyRegState(val numPhyRegs: Int) extends PhyRegState(numPhyRegs) with DifftestBundle {
@@ -396,15 +396,15 @@ abstract class DiffPhyRegState(val numPhyRegs: Int) extends PhyRegState(numPhyRe
 }
 
 class DiffPhyIntRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {
-  override val desiredCppName: String = "pregs_int"
+  override val desiredCppName: String = "pregs_xrf"
 }
 
 class DiffPhyFpRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {
-  override val desiredCppName: String = "pregs_fp"
+  override val desiredCppName: String = "pregs_frf"
 }
 
 class DiffPhyVecRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {
-  override val desiredCppName: String = "pregs_vec"
+  override val desiredCppName: String = "pregs_vrf"
 }
 
 class DiffVecCSRState extends VecCSRState with DifftestBundle {

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -185,7 +185,7 @@ object Gateway {
   }
 
   def getInstance(bundles: Seq[DifftestBundle]): Seq[DifftestBundle] = {
-    val archRegs = if (!bundles.exists(_.desiredCppName == "regs_int")) {
+    val archRegs = if (!bundles.exists(_.desiredCppName == "regs_xrf")) {
       Preprocess.getArchRegs(bundles, false)
     } else {
       Seq.empty

--- a/src/main/scala/Preprocess.scala
+++ b/src/main/scala/Preprocess.scala
@@ -29,7 +29,7 @@ object Preprocess {
   }
 
   def getArchRegs(bundles: Seq[DifftestBundle], isHardware: Boolean): Seq[ArchRegState with DifftestBundle] = {
-    Seq(("int", new DiffArchIntRegState), ("fp", new DiffArchFpRegState), ("vec", new DiffArchVecRegState)).flatMap {
+    Seq(("xrf", new DiffArchIntRegState), ("frf", new DiffArchFpRegState), ("vrf", new DiffArchVecRegState)).flatMap {
       case (suffix, gen) =>
         val pregs = bundles.filter(_.desiredCppName == "pregs_" + suffix).asInstanceOf[Seq[DiffPhyRegState]]
         if (pregs.nonEmpty) {
@@ -69,9 +69,9 @@ object Preprocess {
     val archRegs = getArchRegs(bundles, true)
 
     val commits = getBundle[DiffInstrCommit]("commit")
-    val phyInts = getBundle[DiffPhyIntRegState]("pregs_int")
-    val phyFps = getBundle[DiffPhyFpRegState]("pregs_fp")
-    val phyVecs = getBundle[DiffPhyVecRegState]("pregs_vec")
+    val phyInts = getBundle[DiffPhyIntRegState]("pregs_xrf")
+    val phyFps = getBundle[DiffPhyFpRegState]("pregs_frf")
+    val phyVecs = getBundle[DiffPhyVecRegState]("pregs_vrf")
     val commitDatas = commits.zipWithIndex.flatMap { case (c, idx) =>
       val coreID = idx / (commits.length / numCores)
       val intData = phyInts(coreID).value(c.wpdest)
@@ -102,7 +102,7 @@ object Preprocess {
 class PreprocessEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
   val in = IO(Input(MixedVec(bundles)))
 
-  val replaceReg = if (!config.softArchUpdate && in.exists(_.desiredCppName == "pregs_int")) {
+  val replaceReg = if (!config.softArchUpdate && in.exists(_.desiredCppName == "pregs_xrf")) {
     // extract ArchReg in Hardware
     Preprocess.replaceRegs(in)
   } else {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -675,7 +675,7 @@ void Difftest::do_vec_load_check(int index, DifftestLoadEvent load_event) {
 #else
       // TODO: support Squash without vec_commit_data (i.e. update ArchReg in software)
       auto vecNextPdest = dut->commit[index].otherwpdest[dataIndex];
-      uint64_t dutRegData = dut->pregs_vec.value[vecPdest];
+      uint64_t dutRegData = dut->pregs_vrf.value[vecPdest];
 #endif // CONFIG_DIFFTEST_VECCOMMITDATA
 
       uint64_t *refRegPtr = proxy->arch_vecreg(VLENE_64 * vecNextLdest + i);
@@ -703,7 +703,7 @@ void Difftest::do_vec_load_check(int index, DifftestLoadEvent load_event) {
 #ifndef CONFIG_DIFFTEST_COMMITDATA
       bool v0Wen = dut->commit[index].v0wen && vdidx == 0;
       auto vecNextPdest = dut->commit[index].otherwpdest[vdidx];
-      uint64_t *dutRegPtr = v0Wen ? dut->wb_v0[vecNextPdest].data : dut->wb_vec[vecNextPdest].data;
+      uint64_t *dutRegPtr = v0Wen ? dut->wb_v0[vecNextPdest].data : dut->wb_vrf[vecNextPdest].data;
 #endif // !CONFIG_DIFFTEST_COMMITDATA
 
       for (int i = 0; i < VLENE_64; i++) {
@@ -731,7 +731,7 @@ void Difftest::do_vec_load_check(int index, DifftestLoadEvent load_event) {
 #ifndef CONFIG_DIFFTEST_COMMITDATA
         bool v0Wen = dut->commit[index].v0wen && vdidx == 0;
         auto vecNextPdest = dut->commit[index].otherwpdest[vdidx];
-        uint64_t *dutRegPtr = v0Wen ? dut->wb_v0[vecNextPdest].data : dut->wb_vec[vecNextPdest].data;
+        uint64_t *dutRegPtr = v0Wen ? dut->wb_v0[vecNextPdest].data : dut->wb_vrf[vecNextPdest].data;
 #endif // !CONFIG_DIFFTEST_COMMITDATA
 
         auto vecNextLdest = vecFirstLdest + vdidx;
@@ -1558,10 +1558,10 @@ int Difftest::apply_delayed_writeback() {
   } while (0);
 
 #ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-  APPLY_DELAYED_WB(delayed_int, regs_int, regs_name_int)
+  APPLY_DELAYED_WB(delayed_int, regs_xrf, regs_name_int)
 #endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
 #ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-  APPLY_DELAYED_WB(delayed_fp, regs_fp, regs_name_fp)
+  APPLY_DELAYED_WB(delayed_fp, regs_frf, regs_name_fp)
 #endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
   return 0;
 }

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -149,14 +149,14 @@ public:
   uint64_t *arch_reg(uint8_t src, bool is_fp = false) {
     return
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-        is_fp ? dut->regs_fp.value + src :
+        is_fp ? dut->regs_frf.value + src :
 #endif
-              dut->regs_int.value + src;
+              dut->regs_xrf.value + src;
   }
 
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
   inline uint64_t *arch_vecreg(uint8_t src) {
-    return dut->regs_vec.value + src;
+    return dut->regs_vrf.value + src;
   }
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 
@@ -272,22 +272,22 @@ protected:
 
   inline uint64_t get_int_data(int i) {
 #if defined(CONFIG_DIFFTEST_PHYINTREGSTATE)
-    return dut->pregs_int.value[dut->commit[i].wpdest];
+    return dut->pregs_xrf.value[dut->commit[i].wpdest];
 #elif defined(CONFIG_DIFFTEST_INTWRITEBACK)
-    return dut->wb_int[dut->commit[i].wpdest].data;
+    return dut->wb_xrf[dut->commit[i].wpdest].data;
 #else
-    return dut->regs_int.value[dut->commit[i].wdest];
+    return dut->regs_xrf.value[dut->commit[i].wdest];
 #endif
   }
 
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
   inline uint64_t get_fp_data(int i) {
 #if defined(CONFIG_DIFFTEST_PHYFPREGSTATE)
-    return dut->pregs_fp.value[dut->commit[i].wpdest];
+    return dut->pregs_frf.value[dut->commit[i].wpdest];
 #elif defined(CONFIG_DIFFTEST_FPWRITEBACK)
-    return dut->wb_fp[dut->commit[i].wpdest].data;
+    return dut->wb_frf[dut->commit[i].wpdest].data;
 #else
-    return dut->regs_fp.value[dut->commit[i].wdest];
+    return dut->regs_frf.value[dut->commit[i].wdest];
 #endif
   }
 #endif

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -148,9 +148,9 @@ RefProxy::~RefProxy() {
 }
 
 void RefProxy::regcpy(DiffTestState *dut) {
-  memcpy(&state.regs_int, dut->regs_int.value, 32 * sizeof(uint64_t));
+  memcpy(&state.regs_xrf, dut->regs_xrf.value, 32 * sizeof(uint64_t));
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-  memcpy(&state.regs_fp, dut->regs_fp.value, 32 * sizeof(uint64_t));
+  memcpy(&state.regs_frf, dut->regs_frf.value, 32 * sizeof(uint64_t));
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
   memcpy(&state.csr, &dut->csr, sizeof(state.csr));
   state.pc = dut->commit[0].pc;
@@ -158,7 +158,7 @@ void RefProxy::regcpy(DiffTestState *dut) {
   memcpy(&state.hcsr, &dut->hcsr, sizeof(state.hcsr));
 #endif // CONFIG_DIFFTEST_HCSRSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-  memcpy(&state.regs_vec, &dut->regs_vec.value, sizeof(state.regs_vec));
+  memcpy(&state.regs_vrf, &dut->regs_vrf.value, sizeof(state.regs_vrf));
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
   memcpy(&state.vcsr, &dut->vcsr, sizeof(state.vcsr));
@@ -175,12 +175,12 @@ void RefProxy::regcpy(DiffTestState *dut) {
 int RefProxy::compare(DiffTestState *dut) {
 #define PROXY_COMPARE(field) memcmp(&(dut->field), &(state.field), sizeof(state.field))
 
-  const int results[] = {PROXY_COMPARE(regs_int),
+  const int results[] = {PROXY_COMPARE(regs_xrf),
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-                         PROXY_COMPARE(regs_fp),
+                         PROXY_COMPARE(regs_frf),
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-                         PROXY_COMPARE(regs_vec),
+                         PROXY_COMPARE(regs_vrf),
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
                          PROXY_COMPARE(vcsr),
@@ -226,16 +226,16 @@ void RefProxy::display(DiffTestState *dut) {
     }                                                                                   \
   } while (0);
 
-    PROXY_COMPARE_AND_DISPLAY(regs_int, regs_name_int)
+    PROXY_COMPARE_AND_DISPLAY(regs_xrf, regs_name_int)
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-    PROXY_COMPARE_AND_DISPLAY(regs_fp, regs_name_fp)
+    PROXY_COMPARE_AND_DISPLAY(regs_frf, regs_name_fp)
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
     PROXY_COMPARE_AND_DISPLAY(csr, regs_name_csr)
 #ifdef CONFIG_DIFFTEST_HCSRSTATE
     PROXY_COMPARE_AND_DISPLAY(hcsr, regs_name_hcsr)
 #endif // CONFIG_DIFFTEST_HCSRSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-    PROXY_COMPARE_AND_DISPLAY(regs_vec, regs_name_vec)
+    PROXY_COMPARE_AND_DISPLAY(regs_vrf, regs_name_vec)
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
     PROXY_COMPARE_AND_DISPLAY(vcsr, regs_name_vec_csr)

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -181,9 +181,9 @@ private:
 };
 
 typedef struct __attribute__((packed)) {
-  DifftestArchIntRegState regs_int;
+  DifftestArchIntRegState regs_xrf;
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-  DifftestArchFpRegState regs_fp;
+  DifftestArchFpRegState regs_frf;
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
   DifftestCSRState csr;
   uint64_t pc;
@@ -191,7 +191,7 @@ typedef struct __attribute__((packed)) {
   DifftestHCSRState hcsr;
 #endif // CONFIG_DIFFTEST_HCSRSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-  DifftestArchVecRegState regs_vec;
+  DifftestArchVecRegState regs_vrf;
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #ifdef CONFIG_DIFFTEST_VECCSRSTATE
   DifftestVecCSRState vcsr;
@@ -216,18 +216,18 @@ public:
   inline uint64_t *arch_reg(uint8_t src, bool is_fp = false) {
     return
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
-        is_fp ? state.regs_fp.value + src :
+        is_fp ? state.regs_frf.value + src :
 #endif
-              state.regs_int.value + src;
+              state.regs_xrf.value + src;
   }
 
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
   inline uint64_t *arch_vecreg(uint8_t src) {
-    return state.regs_vec.value + src;
+    return state.regs_vrf.value + src;
   }
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
   inline void sync(bool is_from_dut = false) {
-    ref_regcpy(&state.regs_int, is_from_dut, is_from_dut);
+    ref_regcpy(&state.regs_xrf, is_from_dut, is_from_dut);
   }
 
   void regcpy(DiffTestState *dut);
@@ -243,10 +243,10 @@ public:
       state.pc += isRVC ? 2 : 4;
 
       if (rfwen)
-        state.regs_int.value[wdest] = wdata;
+        state.regs_xrf.value[wdest] = wdata;
 #ifdef CONFIG_DIFFTEST_ARCHFPREGSTATE
       if (fpwen)
-        state.regs_fp.value[wdest] = wdata;
+        state.regs_frf.value[wdest] = wdata;
 #endif // CONFIG_DIFFTEST_ARCHFPREGSTATE
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
       // TODO: vec skip is not supported at this time.


### PR DESCRIPTION
General-purpose, floating-point, and vector registers in RISC-V are usually referred as XRF, FRF, and VRF.