### PR TITLE
feat(difftest): separate load checkers for squash

### DIFF
--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -260,10 +260,16 @@ protected:
   void do_interrupt();
   void do_exception();
   int do_instr_commit(int index);
-#if defined(CONFIG_DIFFTEST_LOADEVENT) && defined(CONFIG_DIFFTEST_ARCHVECREGSTATE)
-  void do_vec_load_check(int index, DifftestLoadEvent load_event);
-#endif // CONFIG_DIFFTEST_LOADEVENT && CONFIG_DIFFTEST_ARCHVECREGSTATE
+#ifdef CONFIG_DIFFTEST_LOADEVENT
   void do_load_check(int index);
+  void do_load_check(DifftestLoadEvent load_event, bool regWen, uint64_t *refRegPtr, uint64_t commitData);
+#ifdef CONFIG_DIFFTEST_SQUASH
+  void do_load_check_squash();
+#endif // CONFIG_DIFFTEST_SQUASH
+#ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
+  void do_vec_load_check(int index, DifftestLoadEvent load_event);
+#endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
+#endif // CONFIG_DIFFTEST_LOADEVENT
   int do_store_check();
   int do_refill_check(int cacheid);
   int do_l1tlb_check();


### PR DESCRIPTION
There're macros to distinguish between squash and non-squash mode for load check. It's not readable and should be separated.