### PR TITLE
fix(pdb): fix SWIG parse error on packed typedef in refproxy.h

### DIFF
--- a/src/test/csrc/plugin/xspdb/swig.i
+++ b/src/test/csrc/plugin/xspdb/swig.i
@@ -1,5 +1,19 @@
 %module difftest
 
+/*
+ * Make SWIG ignore GCC-style attributes like __attribute__((packed))
+ * for parsing only. Do NOT redefine it in the generated wrapper code
+ * to avoid ABI/layout mismatches with the compiled library.
+ */
+%define __attribute__(x)
+%enddef
+
+/* Also ignore common attribute aliases used in headers */
+%define __packed
+%enddef
+%define __aligned(x)
+%enddef
+
 %{
 #include "difftest.h"
 #include "export.h"


### PR DESCRIPTION
This PR updates swig.i to make SWIG ignore GCC-style attributes` (__attribute__(...), __packed, __aligned(x)) `used in the difftest headers. These macros are now swallowed at SWIG parse time only, so Python bindings generate cleanly without syntax errors. The change does not alter compiled C/C++ layout or ABI and is safe for existing code. It fixes SWIG parsing failures on annotated typedef struct declarations.