### PR TITLE
feat(delta): support multi-cycle Delta transmission

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -375,3 +375,7 @@ class AIAEvent extends DifftestBaseBundle with HasValid {
 class SyncCustomMflushpwrEvent extends DifftestBaseBundle with HasValid {
   val l2FlushDone = Bool()
 }
+
+class DeltaInfo extends DifftestBaseBundle {
+  val inPending = UInt(8.W)
+}

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -549,6 +549,10 @@ class DiffTraceInfo(config: GatewayConfig) extends TraceInfo with DifftestBundle
   }
 }
 
+class DiffDeltaInfo extends DeltaInfo with DifftestBundle {
+  override val desiredCppName: String = "delta_info"
+}
+
 trait DifftestModule[T <: DifftestBundle] {
   val io: T
 }

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -60,6 +60,8 @@ case class GatewayConfig(
   def batchArgByteLen: (Int, Int) = if (isFPGA) (1900, 100) else if (isNonBlock) (3600, 400) else (7200, 800)
   def batchBitWidth: Int = batchArgByteLen match { case (len1, len2) => (len1 + len2) * 8 }
   def batchSplit: Boolean = !isFPGA // Disable split for FPGA to reduce gates
+  def deltaLimit: Int = 8
+  def deltaQueueDepth: Int = 3
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
   def needEndpoint: Boolean =

--- a/src/main/scala/util/Query.scala
+++ b/src/main/scala/util/Query.scala
@@ -42,6 +42,9 @@ object Query {
          |#include <cstdint>
          |#include "difftest-state.h"
          |#include "query.h"
+         |#ifdef CONFIG_DIFFTEST_DELTA
+         |#include "difftest-delta.h"
+         |#endif // CONFIG_DIFFTEST_DELTA
          |
          |#ifdef CONFIG_DIFFTEST_QUERY
          |


### PR DESCRIPTION
This update adds multi-cycle transmission support to the Delta, named as Delta Splitting.

Previously, Delta allowed splitting a register file of size N into N bundles, sending only the bundles that changed. This change further splits those N bundles across multiple cycles, reducing the number of elems Batch processing per cycle and thereby lowering hardware area.

Key details:
1. The N bundles are grouped into chunks of size DeltaLimit. A chunk is transmitted only when it contains valid updates. As a result, a single-cycle Delta input may require up to N / DeltaLimit cycles to complete transmission.
2. A new DeltaQueue is introduced. When the previous cycle's data is still in pending, new Delta inputs are buffered in the queue. The queue depth is currently set to 3, which is sufficient under Squash, where data is compressed and multi-ycycle produces only a single Delta input.
3. In DPI-C, a set of Delta data may require multi steps to process. To support this behavior, we move the checking logic (xx_nstep) after each step instead of the end of DPI-C. When the current step is pending, it means incoming data is temporarily stored in delta_buffer; if not pending, we will copy delta_buffer to difftest_state and call xx_nstep for check.