### PR TITLE
fix(SimJTAG): remove wire delays for newer version of verilator

### DIFF
--- a/src/test/vsrc/common/SimJTAG.v
+++ b/src/test/vsrc/common/SimJTAG.v
@@ -49,7 +49,7 @@ module SimJTAG #(
 
    logic [31:0] random_bits = $random;
 
-   wire         #0.1 __jtag_TDO = jtag_TDO_driven ?
+   wire         __jtag_TDO = jtag_TDO_driven ?
                 jtag_TDO_data : random_bits[0];
 
    bit          __jtag_TCK;
@@ -60,12 +60,12 @@ module SimJTAG #(
 
    reg          init_done_sticky;
 
-   assign #0.1 jtag_TCK   = __jtag_TCK;
-   assign #0.1 jtag_TMS   = __jtag_TMS;
-   assign #0.1 jtag_TDI   = __jtag_TDI;
-   assign #0.1 jtag_TRSTn = __jtag_TRSTn;
+   assign       jtag_TCK   = __jtag_TCK;
+   assign       jtag_TMS   = __jtag_TMS;
+   assign       jtag_TDI   = __jtag_TDI;
+   assign       jtag_TRSTn = __jtag_TRSTn;
 
-   assign #0.1 exit = __exit;
+   assign       exit = __exit;
 
    always @(posedge clock) begin
       r_reset <= reset;


### PR DESCRIPTION
In newer versions of Verilator, functions with delays are not legal, which causes a compile error:

```
%Error: /path-to-difftest/src/test/vsrc/common/SimJTAG.v:52:17: Delays are not legal in functions. Suggest use a task (IEEE 1800-2023 13.4.4)
                                                                                           : ... note: In instance 'SimTop'
   52 |    wire         #0.1 __jtag_TDO = jtag_TDO_driven ?
      |                 ^
        ... See the manual at https://verilator.org/verilator_doc.html?v=5.041 for more assistance.
%Error: Exiting due to 1 error(s)
```

As the delay not be useful in verilator, thus remove it.