### PR TITLE
fix(difftest): fix vec_load declaration and pass param reference

### DIFF
--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -647,7 +647,7 @@ void Difftest::do_first_instr_commit() {
 }
 
 #if defined(CONFIG_DIFFTEST_LOADEVENT) && defined(CONFIG_DIFFTEST_ARCHVECREGSTATE)
-void Difftest::do_vec_load_check(DifftestLoadEvent load_event, uint8_t vecFirstLdest, uint64_t vecCommitData[]) {
+void Difftest::do_vec_load_check(DifftestLoadEvent &load_event, uint8_t vecFirstLdest, uint64_t vecCommitData[]) {
   if (!enable_vec_load_goldenmem_check) {
     return;
   }
@@ -777,7 +777,7 @@ void Difftest::do_load_check_squash() {
 #endif // CONFIG_DIFFTEST_LOADEVENT && CONFIG_DIFFTEST_SQUASH
 
 #ifdef CONFIG_DIFFTEST_LOADEVENT
-void Difftest::do_load_check(DifftestLoadEvent load_event, bool regWen, uint64_t *refRegPtr, uint64_t commitData) {
+void Difftest::do_load_check(DifftestLoadEvent &load_event, bool regWen, uint64_t *refRegPtr, uint64_t commitData) {
   if (load_event.isLoad || load_event.isAtomic) {
     proxy->sync();
     if (regWen && *refRegPtr != commitData) {

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -262,12 +262,12 @@ protected:
   int do_instr_commit(int index);
 #ifdef CONFIG_DIFFTEST_LOADEVENT
   void do_load_check(int index);
-  void do_load_check(DifftestLoadEvent load_event, bool regWen, uint64_t *refRegPtr, uint64_t commitData);
+  void do_load_check(DifftestLoadEvent &load_event, bool regWen, uint64_t *refRegPtr, uint64_t commitData);
 #ifdef CONFIG_DIFFTEST_SQUASH
   void do_load_check_squash();
 #endif // CONFIG_DIFFTEST_SQUASH
 #ifdef CONFIG_DIFFTEST_ARCHVECREGSTATE
-  void do_vec_load_check(int index, DifftestLoadEvent load_event);
+  void do_vec_load_check(DifftestLoadEvent &load_event, uint8_t vecFirstLdest, uint64_t vecCommitData[]);
 #endif // CONFIG_DIFFTEST_ARCHVECREGSTATE
 #endif // CONFIG_DIFFTEST_LOADEVENT
   int do_store_check();


### PR DESCRIPTION
This change fix the declaration of do_vec_load_check for #744 and #751. We also pass parameters by reference (&) to avoid unnecessary copies.