### PR TITLE
fix(dpic): add !reset to DPI-C enable condition

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -344,7 +344,7 @@ private class DummyDPICWrapper(gen: Valid[DifftestBundle], config: GatewayConfig
   val io = IO(Input(gen))
   val dpic = Module(new DPIC(gen.bits, config))
   dpic.clock := clock
-  dpic.enable := io.valid && control.enable
+  dpic.enable := io.valid && control.enable && !reset.asBool
   if (config.hasDutZone) dpic.dut_zone.get := control.dut_zone.get
   dpic.io := io.bits
 }
@@ -358,7 +358,7 @@ private class DummyDPICBatchWrapper(
   val io = IO(Input(batchIO))
   val dpic = Module(new DPICBatch(template, batchIO, config))
   dpic.clock := clock
-  dpic.enable := control.enable
+  dpic.enable := control.enable && !reset.asBool
   if (config.hasDutZone) dpic.dut_zone.get := control.dut_zone.get
   dpic.io := io.asUInt
 }


### PR DESCRIPTION
This change add !reset to the DPI-C trigger conditions, preventing calling DPI-C functions when Hardware is still in reset.

Without this guard, diffstate_buffer may already be initialized while the previous dpic enable condition is reseted as true, leading to execution errors.