### PR TITLE
feat(verilator,gsim): add PGO_BOLT option

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-difftest-main:
     runs-on: ubuntu-latest
-    container: ghcr.io/openxiangshan/xs-env:ubuntu-22.04
+    container: ghcr.io/openxiangshan/xs-env:ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
 
   test-verilator-nutshell:
     runs-on: ubuntu-latest
-    container: ghcr.io/openxiangshan/xs-env:ubuntu-22.04
+    container: ghcr.io/openxiangshan/xs-env:ubuntu-24.04
 
     needs: test-difftest-main
 
@@ -71,10 +71,17 @@ jobs:
             ./build/emu --no-diff -C 10000
             make clean
 
-      - name: Basic Difftest with PGO build
+      - name: Basic Difftest with PGO build using compiler instrumentation
         run: |
             cd $NOOP_HOME
-            make emu PGO_WORKLOAD=$WORKLOAD LLVM_PROFDATA=llvm-profdata PGO_EMU_ARGS="--diff $REF_SO 2>/dev/null" -j2
+            make emu PGO_WORKLOAD=$WORKLOAD LLVM_PROFDATA=llvm-profdata PGO_EMU_ARGS="--diff $REF_SO 2>/dev/null" PGO_BOLT=0 -j2
+            ./build/emu -i $WORKLOAD --diff $REF_SO
+            make clean
+
+      - name: Basic Difftest with PGO build using BOLT
+        run: |
+            cd $NOOP_HOME
+            make emu PGO_WORKLOAD=$WORKLOAD PGO_EMU_ARGS="--diff $REF_SO 2>/dev/null" PGO_BOLT=1 -j2
             ./build/emu -i $WORKLOAD --diff $REF_SO
             make clean
 

--- a/emu.mk
+++ b/emu.mk
@@ -58,6 +58,18 @@ EMU_COVERAGE ?=
 # optimization level for RTL simulators
 EMU_OPTIMIZE ?= -O3
 
+PGO_MAX_CYCLE ?= 100000
+PGO_EMU_ARGS ?= --no-diff
+
+LLVM_BOLT ?= $(shell readlink -f `command -v llvm-bolt 2> /dev/null`)
+# We use readlink -f to get the absolute path of llvm-bolt, it's
+# needed since we use argv[0]/../lib/libbolt_rt_instr.a as the path
+# to find the runtime library inside llvm-bolt. It's a workaround
+# for LLVM before commit abc2eae682("[BOLT] Enable standalone build (llvm#97130)").
+# Ref: https://github.com/llvm/llvm-project/blob/release/18.x/bolt/lib/RuntimeLibs/RuntimeLibrary.cpp#L33
+# Ref: https://github.com/llvm/llvm-project/blob/release/18.x/bolt/tools/driver/llvm-bolt.cpp#L187
+PGO_BOLT ?= $(shell if [ -x "$(LLVM_BOLT)" ]; then echo 1; else echo 0; fi)
+
 include verilator.mk
 include gsim.mk
 


### PR DESCRIPTION
The PGO data generated by hardware branch tracing directly with nearly zero runtime overhead to the already compiled binary, thus making the PGO build really quick (~1min), also avoiding the need for a full recompilation. This results in a much faster build process while still benefiting from the performance improvements provided by PGO.

The results show that it only takes 1:27 with  `PGO_BOLT=1` and `PGO_MAX_CYCLE=100000` to build the Verilator emulator with PGO, compared to 10+ minutes traditionally, and the performance is nearly the same, both finished CoreMark in ~26s on my 13900K with LLVM 22, while the non-PGO build takes 84s.

This process requires Linux-perf to collect the profile data, and BOLT to apply the optimizations. When profiling with Linux-perf, please ensure that the system has set `sysctl -w kernel.perf_event_paranoid=-1` to allow perf to collect the necessary data.