### PR TITLE
feat(top): support extra Clock and Reset for RawModule

### DIFF
--- a/src/main/scala/SimTop.scala
+++ b/src/main/scala/SimTop.scala
@@ -58,15 +58,19 @@ class UARTIO extends Bundle {
   }
 }
 
-trait HasDiffTestInterfaces {
+trait HasDiffTestInterfaces extends ImplicitClock with ImplicitReset { this: RawModule =>
   def cpuName: Option[String] = None
 
+  private[difftest] def dutClock = implicitClock
+  private[difftest] def dutReset = implicitReset
   def connectTopIOs(difftest: DifftestTopIO): Seq[Data] = Seq.empty
 }
 
 // Top-level module for DiffTest simulation. Will be created by DifftestModule.top
 class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T) extends Module {
   val cpu = Module(cpuGen)
+  cpu.dutClock := clock
+  cpu.dutReset := reset.asTypeOf(cpu.dutReset)
 
   val cpuName = cpu.cpuName.getOrElse(cpu.getClass.getName.split("\\.").last)
   val gateway = DifftestModule.collect(cpuName)


### PR DESCRIPTION
This change enforces that RawModules explicitly define both clock and
reset signals, and we also introduce connectTopIOsWithName, allowing
modules to specify explicit IO names when wiring top-level interfaces.
The original connectTopIOs API remains supported for backward compatibility.

Example Usage:
override protected def implicitClock: Clock = io.clock
override protected def implicitReset: Reset = io.reset
override def connectTopIOsWithName(difftest: DifftestTopIO): Seq[(Data, String)] = {
  io.elements.toSeq.collect { case (name, elem)
    if !Seq("clock", "reset").contains(name) => (elem, "io_" + name)
  }
}