### PR TITLE
fix(difftest): use ld as linker for BOLT PGO builds

### DIFF
--- a/gsim.mk
+++ b/gsim.mk
@@ -130,7 +130,7 @@ endif # ifdef LLVM_PROFDATA
 					   PGO_LDFLAGS="-fprofile-use=$(GSIM_EMU_PGO_DIR)"
 else # ifneq ($(PGO_BOLT),1)
 	@echo "Building emu..."
-	@$(MAKE) gsim-build-emu PGO_LDFLAGS="-Wl,--emit-relocs"
+	@$(MAKE) gsim-build-emu PGO_LDFLAGS="-Wl,--emit-relocs -fuse-ld=ld"
 	@mv $(GSIM_EMU_TARGET) $(GSIM_EMU_TARGET).pre-bolt
 	@sync -d $(BUILD_DIR) -d $(GSIM_EMU_BUILD_DIR)
 	@echo "Training emu with PGO Workload..."

--- a/verilator.mk
+++ b/verilator.mk
@@ -193,7 +193,7 @@ endif # ifdef LLVM_PROFDATA
 					   PGO_LDFLAGS="-fprofile-use=$(VERILATOR_PGO_DIR)"
 else # ifneq ($(PGO_BOLT),1)
 	@echo "Building emu..."
-	@$(MAKE) verilator-build-emu OPT_FAST=$(OPT_FAST) PGO_LDFLAGS="-Wl,--emit-relocs"
+	@$(MAKE) verilator-build-emu OPT_FAST=$(OPT_FAST) PGO_LDFLAGS="-Wl,--emit-relocs -fuse-ld=ld"
 	@mv $(VERILATOR_TARGET) $(VERILATOR_TARGET).pre-bolt
 	@sync -d $(BUILD_DIR) -d $(VERILATOR_BUILD_DIR)
 	@echo "Training emu with PGO Workload..."


### PR DESCRIPTION
When building with PGO, use `-fuse-ld=ld` to specify `ld` as the linker, since mold from Ubuntu 22.04 does not support emitting relocations, resulting in build failures if our LLVM is built with mold as the default linker. While ld is still able to link all the objects in 1s on my machine, that's fast enough for our use case.