### PR TITLE
fix(zstd): fix compress_file_buffer_size for #710

### DIFF
--- a/src/test/csrc/common/compress.cpp
+++ b/src/test/csrc/common/compress.cpp
@@ -214,7 +214,8 @@ long readFromZstd(void *ptr, const char *file_name, long buf_size, uint8_t load_
     }
     read_cnt += read_now;
   }
-  if (read_cnt != file_size) {
+  compress_file_buffer_size = read_cnt;
+  if (compress_file_buffer_size != file_size) {
     close(fd);
     free(compress_file_buffer);
     printf("Zstd compressed file read failed, file size: %zd, read size: %zd\n", file_size, compress_file_buffer_size);


### PR DESCRIPTION
This patch fixes an issue introduced in #710 where compress_file_buffer_size was left unassigned after updating the ZSTD read logic. The variable is required by subsequent processing, and failing to assign it could lead to incorrect DUT behavior (e.g. CriticalError) or uninitialized memory access.