### PR TITLE
feat(ci): check private interface and softArchUpdate config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Generate EMU using Profile-Generated RTL
         run: |
           make emu WITH_CHISELDB=0 WITH_CONSTANTIN=0 -j2
+          make clean
+
+      - name: Generate EMU with SoftArchUpdate
+        run: |
+          make PROFILE=./difftest_profile.json NUM_CORES=4 CONFIG=U
+          make emu WITH_CHISELDB=0 WITH_CONSTANTIN=0 -j2
+          make clean
 
       - name: Clean the Profile File
         run: |

--- a/src/test/scala/DifftestMain.scala
+++ b/src/test/scala/DifftestMain.scala
@@ -18,6 +18,7 @@ package difftest
 
 import chisel3.stage.ChiselGeneratorAnnotation
 import circt.stage._
+import app.DifftestApp
 
 object DifftestMain extends DifftestApp {
   (new ChiselStage).execute(firrtlOpts, Seq(ChiselGeneratorAnnotation(gen)) ++ firtoolOptions)

--- a/src/test/scala/DifftestTop.scala
+++ b/src/test/scala/DifftestTop.scala
@@ -14,9 +14,10 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-package difftest
+package app
 
 import chisel3._
+import difftest._
 import difftest.util.DifftestProfile
 
 import scala.annotation.tailrec


### PR DESCRIPTION
DifftestInterface has been moved to an external package to avoid usage of private interfaces and to ensure that emu compilation CI can test it correctly.

Additionally, this change enable for compilation check under SoftArchUpdate config, which is used for DUT release flows (e.g., XiangShan)