### PR TITLE
Fix out-of-range access in gzread & zstdread processing loop

### DIFF
--- a/src/test/csrc/common/compress.cpp
+++ b/src/test/csrc/common/compress.cpp
@@ -141,7 +141,7 @@ long readFromGz(void *ptr, const char *file_name, long buf_size, uint8_t load_ty
     if (bytes_read == 0) {
       break;
     }
-    for (uint32_t x = 0; x < bytes_read / sizeof(long) + 1; x++) {
+    for (uint32_t x = 0; x < bytes_read / sizeof(long); x++) {
       if (*(temp_page + x) != 0) {
         long *pmem_current = (long *)((uint8_t *)ptr + curr_size + x * sizeof(long));
         *pmem_current = *(temp_page + x);
@@ -263,7 +263,7 @@ long readFromZstd(void *ptr, const char *file_name, long buf_size, uint8_t load_
       break;
     }
 
-    for (uint32_t x = 0; x < output_buffer.pos / sizeof(long) + 1; x++) {
+    for (uint32_t x = 0; x < output_buffer.pos / sizeof(long); x++) {
       if (*(temp_page + x) != 0) {
         long *pmem_current = (long *)((uint8_t *)ptr + curr_size + x * sizeof(long));
         *pmem_current = *(temp_page + x);


### PR DESCRIPTION
### Background
This PR fixes an out-of-bounds memory access in the loop that processes data returned by `gzread()`.

### Root Cause
The loop bound was written as `bytes_read / sizeof(long) + 1`, which causes the loop to iterate one element past the valid range. When `bytes_read` is an exact multiple of `sizeof(long)`, the last iteration dereferences `temp_page[x]` beyond the buffer returned by `gzread()`, and may also write past the end of the destination buffer.

### Fix
- Remove the extra `+ 1` from the loop bound.
- Iterate strictly within `bytes_read / sizeof(long)` elements to ensure all reads and writes stay within valid memory.

### Impact
This change prevents potential out-of-bounds reads and writes, which could otherwise lead to memory corruption or crashes.

### Verification
- Code review
- Built and tested locally

As discussed with @zhangjian in chat, this PR submits the fix.