### PR TITLE
fix(delta): explicitly set width for delta queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,10 +274,10 @@ jobs:
             ./build/simv +workload=$WORKLOAD +diff=$REF_SO
             make clean
 
-      - name: Verilator Build with VCS Top (with Batch InternalStep Delta PerfCnt)
+      - name: Verilator Build with VCS Top (with Batch InternalStep Squash Delta PerfCnt)
         run: |
             cd $NOOP_HOME
-            make simv MILL_ARGS="--difftest-config BIDP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
+            make simv MILL_ARGS="--difftest-config BISDP" DIFFTEST_PERFCNT=1 VCS=verilator -j2
             ./build/simv +workload=$WORKLOAD +no-diff +max-cycles=100000
             ./build/simv +workload=$WORKLOAD +diff=$REF_SO
             make clean

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -101,9 +101,9 @@ class DeltaQueue(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) ext
   val inPending = IO(Input(Bool()))
   val out = IO(Output(MixedVec(bundles)))
   val mem = Mem(config.deltaQueueDepth, MixedVec(bundles))
-  val cnt = RegInit(0.U)
-  val head = RegInit(0.U)
-  val tail = RegInit(0.U)
+  val cnt = RegInit(0.U(8.W))
+  val head = RegInit(0.U(8.W))
+  val tail = RegInit(0.U(8.W))
   val enqueue = VecInit(in.map(_.valid)).asUInt.orR
   val dequeue = !RegNext(inPending) && cnt =/= 0.U
   when(enqueue && !dequeue) {


### PR DESCRIPTION
Previously when width is not specified, it will be set to width 1 by default, which cause queue overflow but not assert for delta queue.