### PR TITLE
fix(vcs): vcs/pldm prints the IPC after warmup as before

### DIFF
--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -305,7 +305,6 @@ int simv_get_result(uint8_t step) {
     for (int i = 0; i < NUM_CORES; i++) {
       auto trap = difftest[i]->get_trap_event();
       if (trap->instrCnt >= args.warmup_instr) {
-        args.warmup_instr = -1; // maxium of uint64_t
         finish = true;
         break;
       }


### PR DESCRIPTION
In this pr(https://github.com/OpenXiangShan/difftest/pull/732), we introduced a unified arguments mechanism.
This is good, but it resulted in the loss of the warmup print after the pldm terminates.

---
This is because, previously, we would set warmup_instr to 20000000 and max_instr to 40000000 at runtime. When the simulation ends, if trap_instr >= warmup_instr, we then reset warmup_instr to -1, as follows:
https://github.com/OpenXiangShan/difftest/blob/0dff19d520abe9c595cd60fe2aa6972701daee2c/src/test/csrc/vcs/vcs_main.cpp#L307-L315

Subsequently, if the value of `warmup_instr != 0`, the warmup data is printed. Since it was set to -1 above, it prints normally:
https://github.com/OpenXiangShan/difftest/blob/0dff19d520abe9c595cd60fe2aa6972701daee2c/src/test/csrc/vcs/vcs_main.cpp#L347-L348

---
In this pr(https://github.com/OpenXiangShan/difftest/pull/732), the default value of `warmup_instr` has been set to -1. Consequently, the condition for determining whether to print the warmup has changed to `warmup_instr != -1`:
https://github.com/OpenXiangShan/difftest/blob/d62250c6f6708f2128963fd54293c4cc8dc58399/src/test/csrc/vcs/vcs_main.cpp#L367-L369

However, the code that sets warmup_instr to -1 when this simulation segment ends remains unchanged, so the warmup information will not be printed:
https://github.com/OpenXiangShan/difftest/blob/d62250c6f6708f2128963fd54293c4cc8dc58399/src/test/csrc/vcs/vcs_main.cpp#L303-L310

---

I'm not sure why the default value needs to be changed, **but I chose to remove the statement that sets the value to -1.**
Perhaps we should ensure the parameter's default value remains unchanged?