### PR TITLE
fix(vcs/fpga): mark warmup_finish by static flag instead of args

### DIFF
--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -149,17 +149,16 @@ int fpga_get_result(uint8_t step) {
     }
   }
   // Warmup Check
-  if (args.warmup_instr != -1) {
-    bool finish = false;
+  static bool warmup_finish = false;
+  if (args.warmup_instr != -1 && !warmup_finish) {
     for (int i = 0; i < NUM_CORES; i++) {
       auto trap = difftest[i]->get_trap_event();
       if (trap->instrCnt >= args.warmup_instr) {
-        args.warmup_instr = -1; // maxium of uint64_t
-        finish = true;
+        warmup_finish = true;
         break;
       }
     }
-    if (finish) {
+    if (warmup_finish) {
       // Record Instr/Cycle for soft warmup
       for (int i = 0; i < NUM_CORES; i++) {
         difftest[i]->warmup_record();

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -300,17 +300,16 @@ int simv_get_result(uint8_t step) {
     }
   }
   // Warmup Check
-  if (args.warmup_instr != -1) {
-    bool finish = false;
+  static bool warmup_finish = false;
+  if (args.warmup_instr != -1 && !warmup_finish) {
     for (int i = 0; i < NUM_CORES; i++) {
       auto trap = difftest[i]->get_trap_event();
       if (trap->instrCnt >= args.warmup_instr) {
-        args.warmup_instr = -1; // maxium of uint64_t
-        finish = true;
+        warmup_finish = true;
         break;
       }
     }
-    if (finish) {
+    if (warmup_finish) {
       Info("Warmup finished. The performance counters will be dumped and then reset.\n");
       // Record Instr/Cycle for soft warmup
       for (int i = 0; i < NUM_CORES; i++) {


### PR DESCRIPTION
Previous we simply modify args.warmup_instr to -1 to mark finish. However, -1 is also used as default value, which confuses following logic whether warmup_instr is set or not.