### PR TITLE
fix(verilator,gsim): use bfd linker for PGO+BOLT builds

### DIFF
--- a/gsim.mk
+++ b/gsim.mk
@@ -130,7 +130,7 @@ endif # ifdef LLVM_PROFDATA
 					   PGO_LDFLAGS="-fprofile-use=$(GSIM_EMU_PGO_DIR)"
 else # ifneq ($(PGO_BOLT),1)
 	@echo "Building emu..."
-	@$(MAKE) gsim-build-emu PGO_LDFLAGS="-Wl,--emit-relocs -fuse-ld=ld"
+	@$(MAKE) gsim-build-emu PGO_LDFLAGS="-Wl,--emit-relocs -fuse-ld=bfd"
 	@mv $(GSIM_EMU_TARGET) $(GSIM_EMU_TARGET).pre-bolt
 	@sync -d $(BUILD_DIR) -d $(GSIM_EMU_BUILD_DIR)
 	@echo "Training emu with PGO Workload..."

--- a/verilator.mk
+++ b/verilator.mk
@@ -193,7 +193,7 @@ endif # ifdef LLVM_PROFDATA
 					   PGO_LDFLAGS="-fprofile-use=$(VERILATOR_PGO_DIR)"
 else # ifneq ($(PGO_BOLT),1)
 	@echo "Building emu..."
-	@$(MAKE) verilator-build-emu OPT_FAST=$(OPT_FAST) PGO_LDFLAGS="-Wl,--emit-relocs -fuse-ld=ld"
+	@$(MAKE) verilator-build-emu OPT_FAST=$(OPT_FAST) PGO_LDFLAGS="-Wl,--emit-relocs -fuse-ld=bfd"
 	@mv $(VERILATOR_TARGET) $(VERILATOR_TARGET).pre-bolt
 	@sync -d $(BUILD_DIR) -d $(VERILATOR_BUILD_DIR)
 	@echo "Training emu with PGO Workload..."


### PR DESCRIPTION
When verilator is built to use GCC, current LDFLAGS use `-fuse-ld=ld` will cause gcc error as `ld` is not recognized. Change it to use `-fuse-ld=bfd` instead to compatible with GCC. Since bfd is the default linker for most GNU Linux systems, this should not cause any change in LLVM builds.

Some users may use verilator with GCC toolchain, so this change is necessary to avoid build errors.