### PR TITLE
fix(difftest): rename DifftestMacros.v to svh

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -138,7 +138,7 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
       else ""
     val modDef =
       s"""
-         |`include "DifftestMacros.v"
+         |`include "DifftestMacros.svh"
          |module $desiredName(
          |  $modPortsString
          |);

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -784,6 +784,6 @@ object DifftestModule {
     macros.foreach(m => difftestV += s"`define $m")
     val cpu_s = cpu.replace("-", "_").replace(" ", "").toUpperCase
     difftestV += s"`define CPU_$cpu_s"
-    FileControl.write(difftestV, "DifftestMacros.v")
+    FileControl.write(difftestV, "DifftestMacros.svh")
   }
 }

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -218,7 +218,7 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
   setInline(
     "SquashControl.v",
     s"""
-       |`include "DifftestMacros.v"
+       |`include "DifftestMacros.svh"
        |module SquashControl(
        |  input clock,
        |  input reset,

--- a/src/test/vsrc/fpga_sim/xdma_axi.v
+++ b/src/test/vsrc/fpga_sim/xdma_axi.v
@@ -13,7 +13,7 @@
 *
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
-`include "DifftestMacros.v"
+`include "DifftestMacros.svh"
 module xdma_axi(
   input clock,
   input reset,

--- a/src/test/vsrc/fpga_sim/xdma_wrapper.v
+++ b/src/test/vsrc/fpga_sim/xdma_wrapper.v
@@ -13,7 +13,7 @@
 *
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
-`include "DifftestMacros.v"
+`include "DifftestMacros.svh"
 module xdma_wrapper(
   input clock,
   input reset,

--- a/src/test/vsrc/vcs/DeferredControl.v
+++ b/src/test/vsrc/vcs/DeferredControl.v
@@ -1,4 +1,4 @@
-`include "DifftestMacros.v"
+`include "DifftestMacros.svh"
 `ifndef TB_NO_DPIC
 `ifdef CONFIG_DIFFTEST_DEFERRED_RESULT
 module DeferredControl(

--- a/src/test/vsrc/vcs/DifftestEndpoint.sv
+++ b/src/test/vsrc/vcs/DifftestEndpoint.sv
@@ -15,7 +15,7 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-`include "DifftestMacros.v"
+`include "DifftestMacros.svh"
 module DifftestEndpoint(
   input  wire        clock,
   input  wire        reset,

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -15,7 +15,7 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 
-`include "DifftestMacros.v"
+`include "DifftestMacros.svh"
 module tb_top();
 
 `ifdef PALLADIUM


### PR DESCRIPTION
This change will help tools like vivado to view DifftestMacros as header file.