### PR TITLE
fix(difftest): define interface width in single-core

### DIFF
--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -209,8 +209,9 @@ object Gateway {
       }
       val endpoint = Module(new GatewayEndpoint(instanceWithDelay.toSeq, config))
       endpoint.in := gatewayIn
+      val numCores = instances.count(_.isUniqueIdentifier)
       GatewayResult(
-        vMacros = Seq(s"CONFIG_DIFFTEST_INTERFACE_WIDTH ${gatewayIn.getWidth}"),
+        vMacros = Seq(s"CONFIG_DIFFTEST_INTERFACE_WIDTH ${gatewayIn.getWidth / numCores}"),
         instances = endpoint.instances,
         structPacked = Some(config.isBatch),
         structAligned = Some(config.isDelta),


### PR DESCRIPTION
This change defines the interface width in a single-core form. The generated DifftestInterface module is responsible for expanding the output to NCORES * INTERFACE_WIDTH, ensuring proper alignment with the multi-core Gateway interface.

Then in two-step flow, DUT can directly use DifftestMacros from difftest with acccelerated configures, instead of using original one.