### PR TITLE
feat(scripts): support RELEASE_SUFFIX to fpga release

### DIFF
--- a/fpga.mk
+++ b/fpga.mk
@@ -36,4 +36,4 @@ fpga-clean:
 
 RELEASE_DIR ?= $(NOOP_HOME)
 fpga-release:
-	bash ./scripts/fpga/release.sh $(NOOP_HOME) $(RELEASE_DIR)
+	bash ./scripts/fpga/release.sh $(NOOP_HOME) $(RELEASE_DIR) $(RELEASE_SUFFIX)

--- a/scripts/fpga/release.sh
+++ b/scripts/fpga/release.sh
@@ -7,8 +7,9 @@ set -e
 
 CPU_DIR="$1"
 RELEASE_DIR="$2"
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <CPU_PATH> <RELEASE_FOLDER>"
+RELEASE_SUFFIX="${3:-}"
+if [ $# -ne 2 ] && [ $# -ne 3]; then
+    echo "Usage: $0 <CPU_PATH> <RELEASE_FOLDER> [RELEASE_SUFFIX]"
     exit 1
 fi
 DIFF_HOME="$CPU_DIR/difftest"
@@ -64,6 +65,9 @@ fi
 
 DATE=$(date +"%Y%m%d")
 RELEASE_TAG="${DATE}_${CPU_NAME}_${CPU_CONFIG}_${DIFF_LEVEL}_${DIFF_CONFIG}"
+if [ -n "$RELEASE_SUFFIX" ]; then
+  RELEASE_TAG+="_${RELEASE_SUFFIX}"
+fi
 RELEASE_HOME="$CPU_DIR/$RELEASE_TAG"
 
 # ----------------------------------------------------------


### PR DESCRIPTION
This change support extra suffix to better clarify release packet.

Example usage:
make fpga_release RELEASE_DIR=.. RELEASE_SUFFIX=..