### PR TITLE
feat(difftest): specify source name for XMR probe

### DIFF
--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -171,7 +171,8 @@ object Gateway {
   }
 
   def apply[T <: DifftestBundle](gen: T, delay: Int): T = {
-    val bundle = WireInit(0.U.asTypeOf(gen))
+    val bundle = WireInit(0.U.asTypeOf(gen)).suggestName(gen.desiredCppName)
+    dontTouch(bundle)
     if (!config.traceLoad) {
       if (config.needEndpoint) {
         val packed = WireInit(UInt(bundle.getWidth.W), bundle.asUInt)


### PR DESCRIPTION
This change specifies explicit signal names for Difftest sources, so that target signals can be directly captured via XMR paths.

Example:
  val xx = DifftestModule(new DifftestTrapEvent)

The corresponding signal name will be exposed as `xx_trap`.