### PR TITLE
fix(difftest): fix xx-check memory overflow

### DIFF
--- a/src/test/csrc/difftest/diffstate.h
+++ b/src/test/csrc/difftest/diffstate.h
@@ -143,6 +143,13 @@ public:
   bool dump_commit_trace = false;
 
   DiffState(int coreid);
+  ~DiffState() {
+    while (!commit_trace.empty()) {
+      delete commit_trace.front();
+      commit_trace.pop();
+    }
+  }
+
   void record_group(uint64_t pc, uint32_t count) {
     if (retire_group_queue.size() >= DEBUG_GROUP_TRACE_SIZE) {
       retire_group_queue.pop();

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -198,6 +198,26 @@ Difftest::Difftest(int coreid) {
 }
 
 Difftest::~Difftest() {
+  for (auto checker: checkers) {
+    delete checker;
+  }
+
+  delete arch_event_checker;
+  for (int i = 0; i < CONFIG_DIFF_COMMIT_WIDTH; i++) {
+    delete instr_commit_checker[i];
+  }
+#ifdef CONFIG_DIFFTEST_STOREEVENT
+  delete store_checker;
+#endif // CONFIG_DIFFTEST_STOREEVENT
+#ifdef CONFIG_DIFFTEST_LOADEVENT
+  for (int i = 0; i < CONFIG_DIFF_LOAD_WIDTH; i++) {
+    delete load_checker[i];
+  }
+#ifdef CONFIG_DIFFTEST_SQUASH
+  delete load_squash_checker;
+#endif // CONFIG_DIFFTEST_SQUASH
+#endif // CONFIG_DIFFTEST_LOADEVENT
+
   delete state;
   delete difftrace;
   if (proxy) {


### PR DESCRIPTION
When handling the allocated memory for the application when exiting the program