### PR TITLE
refactor(difftest): pipeline gateway stages with DecoupleIO 

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -20,7 +20,7 @@ import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
 import difftest.common.DifftestPerf
-import difftest.util.LookupTree
+import difftest.util.{LookupTree, PipelineConnect}
 
 import scala.collection.mutable.ListBuffer
 
@@ -62,7 +62,6 @@ class BatchStats(param: BatchParam) extends Bundle {
 
 class BatchOutput(param: BatchParam, config: GatewayConfig) extends Bundle {
   val io = new BatchIO(param)
-  val enable = Bool()
   val step = UInt(config.stepWidth.W)
 }
 
@@ -71,13 +70,21 @@ class BatchInfo extends Bundle {
   val num = UInt(8.W)
 }
 
+class BatchStepResult(param: BatchParam, config: GatewayConfig) extends Bundle {
+  val data = UInt(param.StepDataBitLen.W)
+  val info = UInt(param.StepInfoBitLen.W)
+  // status of step_data_head split in different loc
+  val status = Vec(param.StepGroupSize, new BatchStats(param))
+  val trace_info = Option.when(config.hasReplay)(new DiffTraceInfo(config))
+}
+
 object Batch {
   private val template = ListBuffer.empty[DifftestBundle]
 
-  def apply(bundles: MixedVec[Valid[DifftestBundle]], config: GatewayConfig): BatchOutput = {
-    template ++= chiselTypeOf(bundles).map(_.bits).distinctBy(_.desiredCppName)
-    val module = Module(new BatchEndpoint(chiselTypeOf(bundles).toSeq, config))
-    module.in := bundles
+  def apply(bundles: DecoupledIO[MixedVec[Valid[DifftestBundle]]], config: GatewayConfig): DecoupledIO[BatchOutput] = {
+    template ++= chiselTypeOf(bundles.bits).map(_.bits).distinctBy(_.desiredCppName)
+    val module = Module(new BatchEndpoint(chiselTypeOf(bundles.bits).toSeq, config))
+    module.in <> bundles
     module.out
   }
 
@@ -89,29 +96,18 @@ object Batch {
 }
 
 class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
-  val in = IO(Input(MixedVec(bundles)))
-  val param = BatchParam(config, in.map(_.bits).toSeq)
+  val in = IO(Flipped(Decoupled(MixedVec(bundles))))
+  val param = BatchParam(config, in.bits.map(_.bits).toSeq)
 
   // Collect valid bundles of same cycle
-  val collector = Module(new BatchCollector(bundles, param))
-  collector.in := RegNext(in)
-  val step_data = collector.step_data
-  val step_info = collector.step_info
-  val step_enable = collector.step_enable
-  val step_status = collector.step_status
+  val collector = Module(new BatchCollector(bundles, param, config))
+  PipelineConnect(in, collector.in, collector.in.fire)
 
   // Assemble collected data from different cycles
   val assembler = Module(new BatchAssembler(param, config))
-  assembler.step_data := step_data
-  assembler.step_info := step_info
-  assembler.step_status := step_status
-  assembler.step_enable := step_enable
-  if (config.hasReplay) {
-    val trace_info = in.map(_.bits).filter(_.desiredCppName == "trace_info").head.asInstanceOf[DiffTraceInfo]
-    assembler.step_trace_info.get := trace_info
-  }
-  val out = IO(Output(new BatchOutput(param, config)))
-  out := assembler.out
+  assembler.in <> collector.out
+  val out = IO(chiselTypeOf(assembler.out))
+  out <> assembler.out
 }
 
 // Cluster Data from same group in same cycle
@@ -148,51 +144,60 @@ class BatchCluster(bundleType: DifftestBundle, groupSize: Int, param: BatchParam
 }
 
 // Collect Data from different group in same cycle
-class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam) extends Module {
-  val in = IO(Input(MixedVec(bundles)))
-  val step_data = IO(Output(UInt(param.StepDataBitLen.W)))
-  val step_info = IO(Output(UInt(param.StepInfoBitLen.W)))
-  // status of step_data_head split in different loc
-  val step_status = IO(Output(Vec(param.StepGroupSize, new BatchStats(param))))
-  val step_enable = IO(Output(Bool()))
+class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, config: GatewayConfig) extends Module {
+  val in = IO(Flipped(Decoupled(MixedVec(bundles))))
+  val out = IO(Decoupled(new BatchStepResult(param, config)))
 
   def getGroupDataWidth: Seq[Valid[DifftestBundle]] => Int = { group =>
     group.length * group.head.bits.getByteAlignWidth
   }
 
-  val in_group = in.groupBy(_.bits.desiredCppName).values
+  val in_group = in.bits.groupBy(_.bits.desiredCppName).values
   val in_group_single = in_group.filter(_.size == 1).toSeq
   val in_group_multi = in_group.filterNot(_.size == 1).flatMap(_.grouped(8)).toSeq
   val sorted = in_group_single.sortBy(getGroupDataWidth).reverse ++ in_group_multi.sortBy(getGroupDataWidth)
 
   // Stage 1: concat bundles with same desiredCppName
-  val group_info = Wire(Vec(param.StepGroupSize, UInt(param.infoWidth.W)))
-  val group_status = Wire(Vec(param.StepGroupSize, new BatchStats(param)))
-  val group_data = Wire(MixedVec(sorted.map(getGroupDataWidth).map(group_w => UInt(group_w.W))))
+  class GroupBundle extends Bundle {
+    val data = MixedVec(sorted.map(getGroupDataWidth).map(group_w => UInt(group_w.W)))
+    val info = Vec(param.StepGroupSize, UInt(param.infoWidth.W))
+    val status = Vec(param.StepGroupSize, new BatchStats(param))
+    val trace_info = Option.when(config.hasReplay)(new DiffTraceInfo(config))
+  }
+  val grouped = Wire(Decoupled(new GroupBundle))
+  grouped.valid := in.valid
+  in.ready := grouped.ready
 
+  grouped.bits.trace_info.foreach(
+    _ := in.bits.map(_.bits).filter(_.desiredCppName == "trace_info").head.asInstanceOf[DiffTraceInfo]
+  )
   sorted.zipWithIndex.foreach { case (v_gens, gid) =>
     val cluster = Module(new BatchCluster(chiselTypeOf(v_gens.head.bits), v_gens.length, param))
     cluster.in := v_gens
-    val status_base = if (gid == 0) 0.U.asTypeOf(new BatchStats(param)) else group_status(gid - 1)
+    val status_base = if (gid == 0) 0.U.asTypeOf(new BatchStats(param)) else grouped.bits.status(gid - 1)
     cluster.status_base := status_base
-    group_data(gid) := cluster.out_data
-    group_info(gid) := cluster.out_info
-    group_status(gid) := cluster.status_sum
+    grouped.bits.data(gid) := cluster.out_data
+    grouped.bits.info(gid) := cluster.out_info
+    grouped.bits.status(gid) := cluster.status_sum
   }
 
   // Stage 2: delay grouped data, concat different group
-  val delay_group_data = RegNext(group_data)
-  val delay_group_info = RegNext(group_info)
-  val delay_group_status = RegNext(group_status)
+  val delay_grouped = Wire(Decoupled(new GroupBundle))
+  PipelineConnect(grouped, delay_grouped, delay_grouped.fire)
+  delay_grouped.ready := out.ready
+
+  val delay_group_data = delay_grouped.bits.data
+  val delay_group_info = delay_grouped.bits.info
+  val delay_group_status = delay_grouped.bits.status
   val info_num = delay_group_status.last.info_size
   val BatchStep = Wire(new BatchInfo)
   BatchStep.id := Batch.getTemplate.length.U
   BatchStep.num := info_num // unused, only for debugging
 
-  step_enable := info_num =/= 0.U
+  out.valid := delay_grouped.valid && info_num =/= 0.U
   // append BatchStep to last step_status
-  step_status := delay_group_status
-  step_status.last.info_size := delay_group_status.last.info_size + 1.U
+  out.bits.status := delay_group_status
+  out.bits.status.last.info_size := delay_group_status.last.info_size + 1.U
 
   val toCat_data = delay_group_data.take(in_group_single.size).reverse
   val toCat_info = delay_group_info.take(in_group_single.size).reverse
@@ -226,7 +231,7 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam) ext
   } else {
     0.U
   }
-  step_data := res_single.last | res_multi
+  out.bits.data := res_single.last | res_multi
 
   // Collect info from tail, collect(i) include last 0~i
   val toCollect_info = delay_group_info.reverse
@@ -235,7 +240,8 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam) ext
     val info_base = if (idx == 0) BatchStep.asUInt else info_res(idx - 1)
     info_res(idx) := Mux(toCollect_info(idx) =/= 0.U, Cat(info_base, toCollect_info(idx)), info_base)
   }
-  step_info := info_res.last
+  out.bits.info := info_res.last
+  out.bits.trace_info.foreach(_ := delay_grouped.bits.trace_info.get)
 }
 
 // Assemble step_data from different cycles
@@ -243,12 +249,8 @@ class BatchAssembler(
   param: BatchParam,
   config: GatewayConfig,
 ) extends Module {
-  val step_data = IO(Input(UInt(param.StepDataBitLen.W)))
-  val step_info = IO(Input(UInt(param.StepInfoBitLen.W)))
-  val step_status = IO(Input(Vec(param.StepGroupSize, new BatchStats(param))))
-  val step_enable = IO(Input(Bool()))
-  val step_trace_info = Option.when(config.hasReplay)(IO(Input(new DiffTraceInfo(config))))
-  val out = IO(Output(new BatchOutput(param, config)))
+  val in = IO(Flipped(Decoupled(new BatchStepResult(param, config))))
+  val out = IO(Decoupled(new BatchOutput(param, config)))
 
   val state_data = RegInit(0.U(param.MaxDataBitLen.W))
   val state_info = RegInit(0.U(param.MaxInfoBitLen.W))
@@ -261,11 +263,15 @@ class BatchAssembler(
   //   1. RegNext signal from BatchCollector to cut of combination logic path
   //   1. data/info_exceed_vec: mark whether different length fragments of step data/info exceed available space
   //   2. concat/remain_stats: record statistic for data/info to be concatenated to output or remained to state
-  val delay_step_data = RegNext(step_data)
-  val delay_step_info = RegNext(step_info)
-  val delay_step_status = RegNext(step_status)
-  val delay_step_enable = RegNext(step_enable)
-  val delay_step_trace_info = Option.when(config.hasReplay)(RegNext(step_trace_info.get))
+  val delay_step = Wire(Decoupled(new BatchStepResult(param, config)))
+  PipelineConnect(in, delay_step, delay_step.fire)
+  val want_tick = Wire(Bool())
+  delay_step.ready := out.ready
+  val delay_step_data = delay_step.bits.data
+  val delay_step_info = delay_step.bits.info
+  val delay_step_status = delay_step.bits.status
+  val delay_step_enable = delay_step.valid
+  val delay_step_trace_info = delay_step.bits.trace_info
   val data_bytes_avail = param.MaxDataByteLen.U -& state_status.data_bytes
   // Always leave space for BatchFinish, use MaxInfoSize - 1
   val info_size_avail = (param.MaxInfoSize - 1).U -& state_status.info_size
@@ -285,7 +291,7 @@ class BatchAssembler(
 
   val step_exceed = delay_step_enable && (state_step_cnt === config.batchSize.U)
   val cont_exceed = data_exceed || info_exceed
-  val state_flush = step_enable && step_status.last.data_bytes >= param.MaxDataByteLen.U // use Stage 1 bytes to flush ahead
+  val state_flush = in.valid && in.bits.status.last.data_bytes >= param.MaxDataByteLen.U // use Stage 1 bytes to flush ahead
 
   if (config.batchSplit) {
     val data_exceed_v = VecInit(delay_step_status.map(_.data_bytes > data_bytes_avail && delay_step_enable))
@@ -372,25 +378,27 @@ class BatchAssembler(
     DifftestPerf("BatchExceed_timeout", timeout.asUInt)
     if (config.hasReplay) DifftestPerf("BatchExceed_trace", trace_exceed.get.asUInt)
   }
-  val in_replay = Option.when(config.hasReplay)(step_trace_info.get.in_replay)
+  val in_replay = Option.when(config.hasReplay)(delay_step.bits.trace_info.get.in_replay)
 
-  val should_tick = timeout || state_flush || cont_exceed || step_exceed ||
+  want_tick := timeout || state_flush || cont_exceed || step_exceed ||
     trace_exceed.getOrElse(false.B) || in_replay.getOrElse(false.B)
+  val should_tick = want_tick && out.ready
   when(!should_tick) {
     timeout_count := timeout_count + 1.U
   }.otherwise {
     timeout_count := 0.U
   }
 
-  out.io.data := state_data | (append_data << (state_status.data_bytes << 3).asUInt).asUInt
-  out.io.info := state_info | (append_info << (state_status.info_size * param.infoWidth.U)).asUInt
-  out.enable := should_tick
-  out.step := Mux(out.enable, finish_step, 0.U)
+  out.bits.io.data := state_data | (append_data << (state_status.data_bytes << 3).asUInt).asUInt
+  out.bits.io.info := state_info | (append_info << (state_status.info_size * param.infoWidth.U)).asUInt
+  out.bits.step := Mux(out.valid, finish_step, 0.U)
+  out.valid := want_tick
 
-  val state_update = delay_step_enable || state_flush || timeout
+  val delay_step_fire = delay_step.fire
+  val state_update = delay_step_fire || (should_tick && !delay_step_enable)
 
   when(state_update) {
-    when(delay_step_enable) {
+    when(delay_step_fire) {
       when(should_tick) {
         state_step_cnt := next_state_step_cnt
         state_data := next_state_data

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -21,16 +21,19 @@ import chisel3.util._
 import difftest._
 import difftest.common.FileControl
 import difftest.gateway.GatewayConfig
-import difftest.util.LookupTree
+import difftest.util.{LookupTree, PipelineConnect}
 
 import scala.collection.mutable.ListBuffer
 
 object Delta {
   private val instances = ListBuffer.empty[DifftestBundle]
-  def apply(bundles: MixedVec[Valid[DifftestBundle]], config: GatewayConfig): MixedVec[Valid[DifftestBundle]] = {
-    instances ++= bundles.map(_.bits)
-    val module = Module(new DeltaEndpoint(chiselTypeOf(bundles).toSeq, config))
-    module.in := bundles
+  def apply(
+    bundles: DecoupledIO[MixedVec[Valid[DifftestBundle]]],
+    config: GatewayConfig,
+  ): DecoupledIO[MixedVec[Valid[DifftestBundle]]] = {
+    instances ++= bundles.bits.map(_.bits)
+    val module = Module(new DeltaEndpoint(chiselTypeOf(bundles.bits).toSeq, config))
+    module.in <> bundles
     module.out
   }
   def collect(): Unit = {
@@ -94,43 +97,18 @@ object Delta {
   }
 }
 
-class DeltaQueue(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
-  val in = IO(Input(MixedVec(bundles)))
-  val inPending = IO(Input(Bool()))
-  val out = IO(Output(MixedVec(bundles)))
-  val mem = Mem(config.deltaQueueDepth, MixedVec(bundles))
-  val cnt = RegInit(0.U(8.W))
-  val head = RegInit(0.U(8.W))
-  val tail = RegInit(0.U(8.W))
-  val enqueue = VecInit(in.map(_.valid)).asUInt.orR
-  val dequeue = !RegNext(inPending) && cnt =/= 0.U
-  when(enqueue && !dequeue) {
-    cnt := cnt + 1.U
-  }.elsewhen(!enqueue && dequeue) {
-    cnt := cnt - 1.U
-  }
-  assert(cnt <= config.deltaQueueDepth.U)
-  when(enqueue) {
-    head := Mux(head === (config.deltaQueueDepth - 1).U, 0.U, head + 1.U)
-    mem(head) := in
-  }
-  when(dequeue) {
-    tail := Mux(tail === (config.deltaQueueDepth - 1).U, 0.U, tail + 1.U)
-  }
-  out := Mux(dequeue, mem(tail), 0.U.asTypeOf(out))
-}
-
 class DeltaSplitter(v_gen: Valid[DifftestBundle], filter: Option[UInt], config: GatewayConfig) extends Module {
-  val in = IO(Input(v_gen))
+  val in = IO(Flipped(Decoupled(v_gen)))
   val in_filter = Option.when(filter.isDefined)(IO(Input(chiselTypeOf(filter.get))))
-  val out = IO(Output(Vec(config.deltaLimit, Valid(new DiffDeltaElem(v_gen.bits)))))
+  val out = IO(Decoupled(Vec(config.deltaLimit, Valid(new DiffDeltaElem(v_gen.bits)))))
   val inPending = IO(Output(Bool()))
-  val first_elems = VecInit(in.bits.dataElements.flatMap(_._3))
+
+  val first_elems = VecInit(in.bits.bits.dataElements.flatMap(_._3))
   val r_elems = RegInit(0.U.asTypeOf(first_elems))
 
   val update_mask = in_filter.getOrElse(Fill(first_elems.length, true.B)).asBools
   val first_updates = VecInit(first_elems.zip(r_elems).zip(update_mask).map { case ((e, s), m) =>
-    e =/= s && in.valid && m
+    e =/= s && in.fire && in.bits.valid && m
   })
   r_elems.zip(first_elems).zip(first_updates).map { case ((r, e), u) =>
     when(u) {
@@ -149,16 +127,25 @@ class DeltaSplitter(v_gen: Valid[DifftestBundle], filter: Option[UInt], config: 
   val group_idx = PriorityEncoder(group_updates)
   val mask = (~0.U(group_size.W) << (group_idx +& 1.U)).asUInt(group_size - 1, 0)
   val next_group_updates = group_updates.asUInt & mask
-  r_group_updates := next_group_updates
+  when(needUpdate) {
+    r_group_updates := Mux(out.fire, next_group_updates, first_group_updates.asUInt)
+  }.elsewhen(out.fire) {
+    r_group_updates := next_group_updates
+  }
 
   inPending := next_group_updates =/= 0.U
-  out.zipWithIndex.foreach { case (gen, idx) =>
+  val visiblePending = group_updates =/= 0.U && !out.fire
+  // Block new input in the cycle after a held visible beat so a stalled final group
+  // cannot be replaced by the next transaction without a top-level holding register.
+  in.ready := !RegNext(inPending || visiblePending, false.B)
+  out.valid := group_updates =/= 0.U
+  out.bits.zipWithIndex.foreach { case (gen, idx) =>
     val sel_map = Seq.tabulate(group_size) { gid =>
       val seqID = gid * config.deltaLimit + idx
       val delta = WireInit(0.U.asTypeOf(Valid(new DiffDeltaElem(v_gen.bits))))
       if (seqID < elems.length) {
         delta.valid := updates(seqID) && group_updates =/= 0.U
-        delta.bits.coreid := in.bits.coreid
+        delta.bits.coreid := in.bits.bits.coreid
         delta.bits.index := seqID.U
         delta.bits.data := elems(seqID)
       }
@@ -169,19 +156,19 @@ class DeltaSplitter(v_gen: Valid[DifftestBundle], filter: Option[UInt], config: 
 }
 
 class DeltaEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
-  val in = IO(Input(MixedVec(bundles)))
-  val queue = Module(new DeltaQueue(bundles, config))
-  queue.in := in
-  val queued = queue.out
-  val toDeltas = queued.filter(_.bits.supportsDelta)
+  val in = IO(Flipped(Decoupled(MixedVec(bundles))))
+  val pipelined = Wire(Decoupled(MixedVec(bundles)))
+  PipelineConnect(in, pipelined, pipelined.fire)
+
+  val toDeltas = pipelined.bits.filter(_.bits.supportsDelta)
   val inPending = Wire(Vec(toDeltas.length, Bool()))
-  queue.inPending := inPending.asUInt.orR
-  val deltas = toDeltas.zipWithIndex.flatMap { case (v_gen, idx) =>
+
+  val splitters = toDeltas.zipWithIndex.map { case (v_gen, idx) =>
     val filter: Option[UInt] = v_gen.bits match {
       case preg: DiffPhyRegState =>
         Option.when(preg.needRat) {
           val filterWidth = preg.numPhyRegs
-          queued.map { v_gen =>
+          pipelined.bits.map { v_gen =>
             val res = v_gen.bits match {
               case rat: DiffArchRenameTable if rat.desiredCppName == preg.ratTarget.desiredCppName => {
                 rat.value.map { regIdx => UIntToOH(regIdx, filterWidth) }.reduce(_ | _)
@@ -204,11 +191,14 @@ class DeltaEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) 
     }
 
     val module = Module(new DeltaSplitter(chiselTypeOf(v_gen), filter, config))
-    module.in := v_gen
+    module.in.valid := pipelined.valid
+    module.in.bits := v_gen
     module.in_filter.foreach(_ := filter.get)
     inPending(idx) := module.inPending
-    module.out
+    module
   }
+  val deltas = splitters.flatMap(_.out.bits)
+
   val deltaInfo = Wire(Valid(new DiffDeltaInfo))
   // Only transfer deltaInfo when there is no pending deltas
   val lastPending = VecInit(deltas.map(_.valid)).asUInt.orR && !inPending.asUInt.orR
@@ -216,7 +206,23 @@ class DeltaEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) 
   deltaInfo.bits.valid := lastPending
   deltaInfo.bits.coreid := 0.U
 
-  val withDeltas = MixedVecInit((queued.filterNot(_.bits.supportsDelta) ++ deltas ++ Seq(deltaInfo)).toSeq)
-  val out = IO(Output(chiselTypeOf(withDeltas)))
-  out := withDeltas
+  // Gate non-delta bits to only be valid during pipelined.fire
+  val pipelinedFire = pipelined.fire
+  val nonDeltaBits = pipelined.bits.filterNot(_.bits.supportsDelta).map { b =>
+    val gated = WireInit(b)
+    gated.valid := b.valid && pipelinedFire
+    gated.bits.bits.getValidOption.foreach(_ := b.valid && pipelinedFire)
+    gated
+  }
+
+  val withDeltas = MixedVecInit((nonDeltaBits ++ deltas ++ Seq(deltaInfo)).toSeq)
+  val out = IO(Decoupled(chiselTypeOf(withDeltas)))
+
+  out.valid := VecInit(withDeltas.map(_.valid)).asUInt.orR
+  out.bits := withDeltas
+
+  splitters.foreach(_.out.ready := out.ready)
+  pipelined.ready := VecInit(splitters.map(_.in.ready)).asUInt.andR && out.ready
+  // All splitters must fire synchronously to avoid mixing data from different pipeline stages
+  splitters.foreach(_.in.valid := pipelined.fire)
 }

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -62,7 +62,7 @@ case class GatewayConfig(
   def batchSplit: Boolean = !isFPGA // Disable split for FPGA to reduce gates
   def deltaLimit: Int = 8
   def deltaQueueDepth: Int = 4
-  def hasClockGate = isFPGA
+  def hasClockGate = isFPGA || isDelta
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
   def needEndpoint: Boolean =
@@ -115,10 +115,7 @@ case class GatewayConfig(
   }
 }
 
-class FpgaDiffIO(dataWidth: Int) extends Bundle {
-  val data = UInt(dataWidth.W)
-  val enable = Bool()
-}
+class FpgaDiffIO(dataWidth: Int) extends DecoupledIO(UInt(dataWidth.W))
 
 case class GatewayResult(
   cppMacros: Seq[String] = Seq(),
@@ -131,6 +128,7 @@ case class GatewayResult(
   exit: Option[UInt] = None,
   step: Option[UInt] = None,
   fpgaIO: Option[FpgaDiffIO] = None,
+  clockEnable: Option[Bool] = None,
 ) {
   def +(that: GatewayResult): GatewayResult = {
     GatewayResult(
@@ -144,6 +142,7 @@ case class GatewayResult(
       exit = if (exit.isDefined) exit else that.exit,
       step = if (step.isDefined) step else that.step,
       fpgaIO = if (fpgaIO.isDefined) fpgaIO else that.fpgaIO,
+      clockEnable = if (clockEnable.isDefined) clockEnable else that.clockEnable,
     )
   }
 }
@@ -223,6 +222,7 @@ object Gateway {
         refClock = Option.when(config.hasClockGate)(endpoint.clock),
         step = Some(endpoint.step),
         fpgaIO = endpoint.fpgaIO,
+        clockEnable = endpoint.clockEnable,
       )
     } else {
       GatewayResult(instances = getInstance(instances)) + GatewaySink.collect(config, getInstance(instances))
@@ -239,40 +239,57 @@ object Gateway {
 class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: GatewayConfig) extends Module {
   val in = IO(Input(UInt(instanceWithDelay.map(_._1.getWidth).sum.W)))
   val in_bundle = in.asTypeOf(MixedVec(instanceWithDelay.map(_._1)))
-  val bundle = if (config.traceLoad) {
-    in_bundle
+  val decoupledIn = Wire(Decoupled(chiselTypeOf(in_bundle)))
+  val clockEnable = Option.when(config.hasClockGate)(IO(Output(Bool())))
+  // clockEnable should hold with one cycle fire to sample signals
+  decoupledIn.valid := !reset.asBool
+  clockEnable.foreach { ce =>
+    val ready = decoupledIn.ready
+    val valid = RegInit(true.B)
+    decoupledIn.valid := !reset.asBool && valid
+    when(ready) { valid := false.B } // fire to clear valid
+    when(ce) { valid := true.B } // setup valid for next cycle
+    ce := (ready && valid) || reset.asBool
+  }
+
+  if (config.traceLoad) {
+    decoupledIn.bits := in_bundle
   } else {
     val delayed = MixedVecInit(
-      in_bundle.zip(instanceWithDelay.map(_._2)).map { case (i, d) => Delayer(i, d) }.toSeq
+      in_bundle.zip(instanceWithDelay.map(_._2)).map { case (i, d) => Delayer(i, d, decoupledIn.fire) }.toSeq
     )
     if (config.traceDump) Trace(delayed)
-    delayed
+    decoupledIn.bits := delayed
+  }
+
+  if (!config.hasClockGate) {
+    assert(decoupledIn.ready)
   }
 
   val preprocessed = if (config.needPreprocess) {
-    WireInit(Preprocess(bundle, config))
+    Preprocess(decoupledIn, config)
   } else {
-    WireInit(bundle)
+    decoupledIn
   }
 
   val replayed = if (config.hasReplay) {
-    WireInit(Replay(preprocessed, config))
+    Replay(preprocessed, config)
   } else {
-    WireInit(preprocessed)
+    preprocessed
   }
 
   val validated = Validate(replayed, config)
 
   val squashed = if (config.isSquash) {
-    WireInit(Squash(validated, config))
+    Squash(validated, config)
   } else {
-    WireInit(validated)
+    validated
   }
-  val instances = Gateway.getInstance(chiselTypeOf(squashed).map(_.bits).toSeq)
+  val instances = Gateway.getInstance(chiselTypeOf(squashed.bits).map(_.bits).toSeq)
   val deltas = if (config.isDelta) {
-    WireInit(Delta(squashed, config))
+    Delta(squashed, config)
   } else {
-    WireInit(squashed)
+    squashed
   }
   val toSink = deltas
 
@@ -280,19 +297,23 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
   val step = IO(Output(UInt(config.stepWidth.W)))
   val control = Wire(new GatewaySinkControl(config))
 
-  val fpgaIO = Option.when(config.isBatch && config.isFPGA)(IO(Output(new FpgaDiffIO(config.batchBitWidth))))
+  val fpgaIO = Option.when(config.isBatch && config.isFPGA)(IO(new FpgaDiffIO(config.batchBitWidth)))
 
   if (config.isBatch) {
     val batch = Batch(toSink, config)
-    step := RegNext(batch.step, 0.U) // expose Batch step to check timeout
-    control.enable := batch.enable
-    GatewaySink.batch(Batch.getTemplate, control, batch.io, config)
+    step := RegNext(batch.bits.step, 0.U) // expose Batch step to check timeout
+    control.enable := batch.valid
+    GatewaySink.batch(Batch.getTemplate, control, batch.bits.io, config)
     if (config.isFPGA) {
-      fpgaIO.get.data := batch.io.asUInt
-      fpgaIO.get.enable := batch.enable
+      fpgaIO.get.bits := batch.bits.io.asUInt
+      fpgaIO.get.valid := batch.valid
+      batch.ready := fpgaIO.get.ready
+    } else {
+      batch.ready := true.B
     }
   } else {
-    val sink_enable = VecInit(toSink.map(_.valid).toSeq).asUInt.orR
+    toSink.ready := true.B
+    val sink_enable = VecInit(toSink.bits.map(_.valid).toSeq).asUInt.orR
     step := RegNext(sink_enable, 0.U)
     control.enable := sink_enable
     if (config.hasDutZone) {
@@ -300,8 +321,8 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
       control.dut_zone.get := zoneControl.get.dut_zone
     }
 
-    for (id <- 0 until toSink.length) {
-      GatewaySink(control, toSink(id), config)
+    for (id <- 0 until toSink.bits.length) {
+      GatewaySink(control, toSink.bits(id), config)
     }
   }
 

--- a/src/main/scala/Preprocess.scala
+++ b/src/main/scala/Preprocess.scala
@@ -20,11 +20,15 @@ import chisel3._
 import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
+import difftest.util.PipelineConnect
 
 object Preprocess {
-  def apply(bundles: MixedVec[DifftestBundle], config: GatewayConfig): MixedVec[DifftestBundle] = {
-    val module = Module(new PreprocessEndpoint(chiselTypeOf(bundles).toSeq, config))
-    module.in := bundles
+  def apply(
+    bundles: DecoupledIO[MixedVec[DifftestBundle]],
+    config: GatewayConfig,
+  ): DecoupledIO[MixedVec[DifftestBundle]] = {
+    val module = Module(new PreprocessEndpoint(chiselTypeOf(bundles.bits).toSeq, config))
+    module.in <> bundles
     module.out
   }
 
@@ -101,23 +105,27 @@ object Preprocess {
 }
 
 class PreprocessEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
-  val in = IO(Input(MixedVec(bundles)))
+  val in = IO(Flipped(Decoupled(MixedVec(bundles))))
+  val pipelined = Wire(Decoupled(MixedVec(bundles)))
+  PipelineConnect(in, pipelined, pipelined.fire)
 
-  val replaceReg = if (!config.softArchUpdate && in.exists(_.desiredCppName == "pregs_xrf")) {
+  val replaceReg = if (!config.softArchUpdate && pipelined.bits.exists(_.desiredCppName == "pregs_xrf")) {
     // extract ArchReg in Hardware
-    Preprocess.replaceRegs(in)
+    Preprocess.replaceRegs(pipelined.bits)
   } else {
-    in
+    pipelined.bits
   }
 
   // LoadEvent will not be checked when single-core
-  val skipLoad = if (in.count(_.isUniqueIdentifier) == 1) {
+  val skipLoad = if (replaceReg.count(_.isUniqueIdentifier) == 1) {
     replaceReg.filterNot(_.desiredCppName == "load")
   } else {
     replaceReg
   }
 
   val preprocessed = MixedVecInit(skipLoad.toSeq)
-  val out = IO(Output(chiselTypeOf(preprocessed)))
-  out := preprocessed
+  val out = IO(Decoupled(chiselTypeOf(preprocessed)))
+  pipelined.ready := out.ready
+  out.valid := pipelined.valid
+  out.bits := preprocessed
 }

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -22,12 +22,20 @@ import difftest._
 import difftest.gateway.GatewayConfig
 import difftest.common.DifftestPerf
 import difftest.validate.Validate._
+import difftest.util.PipelineConnect
 
 object Squash {
-  def apply(bundles: MixedVec[Valid[DifftestBundle]], config: GatewayConfig): MixedVec[Valid[DifftestBundle]] = {
-    val squashIn = Stamp(bundles)
-    val module = Module(new SquashEndpoint(chiselTypeOf(squashIn).toSeq, config))
-    module.in := squashIn
+  def apply(
+    bundles: DecoupledIO[MixedVec[Valid[DifftestBundle]]],
+    config: GatewayConfig,
+  ): DecoupledIO[MixedVec[Valid[DifftestBundle]]] = {
+    val squashInBits = Stamp(bundles.bits)
+    val squashIn = Wire(Decoupled(chiselTypeOf(squashInBits)))
+    squashIn.bits := squashInBits
+    squashIn.valid := bundles.valid
+    bundles.ready := squashIn.ready
+    val module = Module(new SquashEndpoint(chiselTypeOf(squashInBits).toSeq, config))
+    module.in <> squashIn
     module.out
   }
 }
@@ -101,14 +109,17 @@ class Stamper(bundles: Seq[Valid[DifftestBundle]]) extends Module {
 }
 
 class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
-  val in = IO(Input(MixedVec(bundles)))
-  val numCores = in.count(_.bits.isUniqueIdentifier)
+  val in = IO(Flipped(Decoupled(MixedVec(bundles))))
+  val numCores = in.bits.count(_.bits.isUniqueIdentifier)
 
+  val pipelined = Wire(Decoupled(MixedVec(bundles)))
+  PipelineConnect(in, pipelined, pipelined.fire)
   val control = Module(new SquashControl(config))
   control.clock := clock
   control.reset := reset
   val in_replay =
-    in.map(_.bits)
+    pipelined.bits
+      .map(_.bits)
       .filter(_.desiredCppName == "trace_info")
       .map(_.asInstanceOf[DiffTraceInfo].in_replay)
       .foldLeft(false.B)(_ || _)
@@ -141,39 +152,46 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
       .reduce(_ || _)
   })
 
-  val s_out_vec = uniqBundles.zip(want_tick_vec).map { case (u, wt) =>
-    val s_in = in.filter(_.bits.desiredCppName == u.desiredCppName)
+  val squashers = uniqBundles.zip(want_tick_vec).map { case (u, wt) =>
+    val s_in = pipelined.bits.filter(_.bits.desiredCppName == u.desiredCppName)
     val squasher = Module(new Squasher(chiselTypeOf(s_in.head), s_in.length, numCores, config))
-    squasher.in.zip(s_in).foreach { case (i, s_i) => i := s_i }
+    squasher.in.valid := pipelined.valid
+    squasher.in.bits.zip(s_in).foreach { case (dst, src) => dst := src }
     wt := squasher.want_tick
     val group_tick =
       group_name_vec
         .zip(group_tick_vec)
         .collect { case (n, gt) if u.squashGroup.contains(n) => gt }
         .foldLeft(false.B)(_ || _)
-    squasher.should_tick := wt || group_tick || global_tick
-    squasher.out
+    squasher.group_tick := group_tick
+    squasher.global_tick := global_tick
+    squasher
   }
+  val s_out_vec = squashers.map(_.out.bits)
   // Flatten Seq[MixedVec[DifftestBundle]] to MixedVec[DifftestBundle]
-  val out = IO(Output(MixedVec(s_out_vec.flatMap(chiselTypeOf(_)))))
+  val out = IO(Decoupled(MixedVec(s_out_vec.flatMap(chiselTypeOf(_)))))
   s_out_vec.zipWithIndex.foreach { case (vec, i) =>
     val base = if (i != 0) {
       s_out_vec.take(i).map(_.length).sum
     } else 0
     vec.zipWithIndex.foreach { case (gen, idx) =>
-      out(base + idx) := gen
+      out.bits(base + idx) := gen
     }
   }
+  squashers.foreach(_.out.ready := out.ready)
+  pipelined.ready := VecInit(squashers.map(_.in.ready)).asUInt.andR
+  out.valid := VecInit(squashers.map(_.out.valid)).asUInt.orR
 }
 
 // It will help do squash for bundles with same Class, return tick and state
 class Squasher(bundleType: Valid[DifftestBundle], length: Int, numCores: Int, config: GatewayConfig) extends Module {
-  val in = IO(Input(Vec(length, bundleType)))
+  val in = IO(Flipped(Decoupled(Vec(length, bundleType))))
   val want_tick = IO(Output(Bool()))
-  val should_tick = IO(Input(Bool()))
+  val group_tick = IO(Input(Bool()))
+  val global_tick = IO(Input(Bool()))
 
   val state = RegInit(0.U.asTypeOf(Vec(length, bundleType)))
-  val out = IO(Output(Vec(length, bundleType)))
+  val out = IO(Decoupled(Vec(length, bundleType)))
 
   // Mark the initial commit events as non-squashable for initial state synchronization.
   val tick_first_commit = Option.when(bundleType.bits.desiredCppName == "commit") {
@@ -191,7 +209,7 @@ class Squasher(bundleType: Valid[DifftestBundle], length: Int, numCores: Int, co
   }
 
   // If one of the bundles cannot be squashed, the others are not squashed as well.
-  val supportsSquashVec = VecInit(in.zip(state).map { case (i, s) => i.supportsSquash(s) }.toSeq)
+  val supportsSquashVec = VecInit(in.bits.zip(state).map { case (i, s) => i.supportsSquash(s) }.toSeq)
   val supportsSquash = supportsSquashVec.asUInt.andR
 
   // If one of the bundles cannot be the new base, the others are not as well.
@@ -200,14 +218,21 @@ class Squasher(bundleType: Valid[DifftestBundle], length: Int, numCores: Int, co
 
   want_tick := !supportsSquash || !supportsSquashBase || tick_first_commit.getOrElse(false.B)
 
-  for ((i, s) <- in.zip(state)) {
-    when(should_tick) {
+  val should_tick = want_tick || group_tick || global_tick
+
+  // Decoupled control
+  out.valid := should_tick
+  in.ready := Mux(should_tick, out.ready, true.B)
+
+  // State update: only on fire
+  for ((i, s) <- in.bits.zip(state)) {
+    when(out.fire) {
       s := i
-    }.otherwise {
+    }.elsewhen(in.fire) {
       s := i.squash(s)
     }
   }
-  out := Mux(should_tick, state, 0.U.asTypeOf(out))
+  out.bits := Mux(should_tick, state, 0.U.asTypeOf(out.bits))
 }
 
 class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleInline {

--- a/src/main/scala/util/Delayer.scala
+++ b/src/main/scala/util/Delayer.scala
@@ -22,12 +22,13 @@ import chisel3.util._
 private class Delayer[T <: Data](gen: T, n_cycles: Int) extends Module {
   val i = IO(Input(chiselTypeOf(gen)))
   val o = IO(Output(chiselTypeOf(gen)))
+  val enable = IO(Input(Bool()))
 }
 
 private class DelayReg[T <: Data](gen: T, n_cycles: Int) extends Delayer(gen, n_cycles) {
   var r = WireInit(i)
   for (_ <- 0 until n_cycles) {
-    r = RegNext(r, 0.U.asTypeOf(gen))
+    r = RegEnable(r, 0.U.asTypeOf(gen), enable)
   }
   o := r
 }
@@ -36,27 +37,33 @@ private class DelayMem[T <: Data](gen: T, n_cycles: Int) extends Delayer(gen, n_
   val mem = Mem(n_cycles, chiselTypeOf(gen))
   val ptr = RegInit(0.U(log2Ceil(n_cycles).W))
   val init_flag = RegInit(false.B)
-  mem(ptr) := i
-  ptr := ptr + 1.U
-  when(ptr === (n_cycles - 1).U) {
-    init_flag := true.B
-    ptr := 0.U
+  when(enable) {
+    mem(ptr) := i
+    ptr := ptr + 1.U
+    when(ptr === (n_cycles - 1).U) {
+      init_flag := true.B
+      ptr := 0.U
+    }
   }
   o := Mux(init_flag, mem(ptr), 0.U.asTypeOf(gen))
 }
 
 object Delayer {
-  def apply[T <: Data](gen: T, n_cycles: Int, useMem: Boolean = false): T = {
+  def apply[T <: Data](gen: T, n_cycles: Int, enable: Bool, useMem: Boolean): T = {
     if (n_cycles > 0) {
       val delayer = if (useMem) {
         Module(new DelayMem(gen, n_cycles))
       } else {
         Module(new DelayReg(gen, n_cycles))
       }
+      delayer.enable := enable
       delayer.i := gen
       delayer.o
     } else {
       gen
     }
   }
+  def apply[T <: Data](gen: T, n_cycles: Int, enable: Bool): T = apply(gen, n_cycles, enable, false)
+  def apply[T <: Data](gen: T, n_cycles: Int): T = apply(gen, n_cycles, true.B)
+
 }

--- a/src/main/scala/util/PipelineConnect.scala
+++ b/src/main/scala/util/PipelineConnect.scala
@@ -1,0 +1,51 @@
+/***************************************************************************************
+ * Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+package difftest.util
+
+import chisel3._
+import chisel3.util._
+import difftest.DifftestBundle
+
+object PipelineConnect {
+  private def connect[T <: Data](left: DecoupledIO[T], right: DecoupledIO[T], rightOutFire: Bool): T = {
+    val valid = RegInit(false.B)
+    when(rightOutFire) { valid := false.B }
+    when(left.valid && right.ready) { valid := true.B }
+
+    val data = RegEnable(left.bits, left.valid && right.ready)
+    left.ready := right.ready
+    right.bits := data
+    right.valid := valid
+    data
+  }
+
+  def apply[T <: Data](left: DecoupledIO[T], right: DecoupledIO[T], rightOutFire: Bool): T =
+    connect(left, right, rightOutFire)
+
+  def apply(
+    left: DecoupledIO[MixedVec[Valid[DifftestBundle]]],
+    right: DecoupledIO[MixedVec[Valid[DifftestBundle]]],
+    rightOutFire: Bool,
+  ): MixedVec[Valid[DifftestBundle]] = {
+    val data = connect(left, right, rightOutFire)
+    right.bits.zip(data).foreach { case (r, d) =>
+      val valid = d.valid && right.valid
+      r.valid := valid
+      r.bits.bits.getValidOption.foreach(_ := valid)
+    }
+    data
+  }
+}


### PR DESCRIPTION
Convert the difftest gateway path to a Decoupled pipeline and add a
reusable PipelineConnect stage register for staged transport between
preprocess, validate, replay, squash, delta and batch.

For clkgate/backpressure, update Delayer to advance only on real pipeline
fire, and rework the FPGA difftest path to propagate host backpressure
through DecoupledIO instead of a separate enable signal. Note we keep
clockEnable for one extra cycle beyond ready, ensuring the valid signal
is sampled correctly on the fire handshake.

For delta, replace the old queue-based flow with staged splitters. And
non-delta and delta bundles are handled separately:
- non-delta bundles are only made valid for the single pipelined.fire
  cycle, even if the combined output remains valid.
- delta bundles continue to drain through the splitters under backpressure.
  When the final visible delta beat is stalled, block new input for the
  following cycle so the current beat cannot be replaced before it is consumed.

This change preserves correctness when delta emits long consecutive data and
decouples stage logic for future optimization.