### PR TITLE
fix(ci): exit 1 when fpga_sim failed

### DIFF
--- a/scripts/fpga_sim/ci.sh
+++ b/scripts/fpga_sim/ci.sh
@@ -1,6 +1,23 @@
 set -e  # exit when some command failed
 set -o pipefail
 
+HOST_PID=""
+SIMV_PID=""
+
+cleanup() {
+  echo "[CLEANUP] kill fpga-host and simv..."
+  trap - INT TERM EXIT
+  if [[ -n "$SIMV_PID" ]]; then
+    kill -INT "$SIMV_PID" 2>/dev/null || true
+  fi
+
+  if [[ -n "$HOST_PID" ]]; then
+    kill -INT "$HOST_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup INT TERM EXIT
+
 ./build/fpga-host --diff ready-to-run/riscv64-nemu-interpreter-so -i ready-to-run/microbench.bin &
 HOST_PID=$!
 
@@ -9,8 +26,10 @@ sleep 2
 ./build/simv +workload=./ready-to-run/microbench.bin +e=0 +diff=./ready-to-run/riscv64-nemu-interpreter-so & #> build/try.txt 2>&1 &
 SIMV_PID=$!
 
+set +e # disable exit to get exitCode
 wait $HOST_PID
 HOST_EXIT_CODE=$?
+set -e
 
 kill -9 $SIMV_PID
 

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -64,7 +64,7 @@ int main(int argc, const char *argv[]) {
   xdma_device->start(); // Trigger stop by fpga_nstep
   fpga_finish();
   printf("difftest releases the fpga device and exits\n");
-  return 0;
+  return !(fpga_result == FPGA_GOODTRAP);
 }
 
 void fpga_init() {


### PR DESCRIPTION
This change fix exitCode of fpga-host and CI scripts, so that CI
can trigger failure when fpga_sim failed. And this change also
allows ci scripts to clean jobs when ctrl+c stop.