### PR TITLE
fix(difftest): use gated clock for FPGA Gateway

### DIFF
--- a/src/main/scala/SimTop.scala
+++ b/src/main/scala/SimTop.scala
@@ -116,11 +116,11 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
     dontTouch(log_enable)
 
     val ref_clock = Option.when(gateway.refClock.isDefined)(IO(Input(Clock())))
-    gateway.refClock.foreach(_ := ref_clock.get)
+    gateway.refClock.foreach(_ := clock)
 
     // IO: difftest_fpga_*
     gateway.fpgaIO.map { fpgaIO =>
-      val host = withClock(ref_clock.getOrElse(clock)) { Module(new HostEndpoint(fpgaIO.data.getWidth)) }
+      val host = withClock(ref_clock.get) { Module(new HostEndpoint(fpgaIO.data.getWidth)) }
       host.io.difftest := fpgaIO
       val pcie_clock = IO(Input(Clock()))
       host.io.pcie_clock := pcie_clock


### PR DESCRIPTION
In PR #797, Gateway was switched to use the ungated ref_clock. Before the pipeline-based backpressure support introduced in PR #802, this caused fpga_sim failures.

This change temporarily reverts Gateway to use the gated clock to ensure correct behavior. Gateway will switch back to ref_clock after the pipeline refactoring in PR #802 is merged.