### PR TITLE
fix(fpga-nightly): track default branchs and fpga-release

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -1,4 +1,4 @@
-name: Evening Regression
+name: FPGA Nightly Regression
 
 on:
   schedule:
@@ -17,31 +17,31 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/..
           rm -rf NutShell && rm -rf env-scripts
-          proxychains git clone -b dev-difftest --single-branch --depth 1 https://github.com/OSCPU/NutShell.git
+          proxychains git clone --single-branch --depth 1 https://github.com/OSCPU/NutShell.git
           cd NutShell && make init && rm -rf difftest && cp -r $GITHUB_WORKSPACE .
           echo "NOOP_HOME=$(pwd)" >> $GITHUB_ENV
-          echo "DUT_HOME=$(pwd)/build" >> $GITHUB_ENV
           echo "DIFFTEST_LOG=/nfs/home/ci-runner/ci-runner-difftest/pr_log" >> "$GITHUB_ENV"
           echo "/nfs/home/tools/Xilinx/Vivado/2020.2/bin" >> "$GITHUB_PATH"
 
       - name: Prepare FPGA scripts
         run: |
           cd $GITHUB_WORKSPACE/..
-          proxychains git clone -b dev_difftest --single-branch --depth 1 https://github.com/OpenXiangShan/env-scripts.git
+          proxychains git clone --single-branch --depth 1 https://github.com/OpenXiangShan/env-scripts.git
           cd env-scripts
           echo "ENV_SCRIPTS_HOME=$(pwd)" >> $GITHUB_ENV
 
       - name: Build NutShell
         run: |
           cd $NOOP_HOME
-          make verilog BOARD=fpgadiff MILL_ARGS="--difftest-config ESBIFDU" -j2 
-          cp -i ./difftest/src/test/vsrc/fpga/fpga_clock_gate.v ./build/rtl/
+          make verilog BOARD=fpgadiff MILL_ARGS="--difftest-config ESBIFDU" -j2
+          make -C difftest fpga-release RELEASE_SUFFIX="ci"
+          echo "RELEASE_HOME=$(pwd)/$(ls -d *_NutShell_*_ci)" >> $GITHUB_ENV
 
       - name: Create FPGA project
         run: |
           source /nfs/home/tools/Xilinx/Vivado/2020.2/settings64.sh
           cd $GITHUB_WORKSPACE/../env-scripts/fpga_diff
-          make update_core_flist CORE_DIR=$DUT_HOME
+          make update_core_flist CORE_DIR=$RELEASE_HOME/build
           make vivado CPU=nutshell
 
       - name: Build FPGA synth


### PR DESCRIPTION
1. This change rename the FPGA Nightly CI job for clarity.
2. The nightly flow now tracks the default branches of env-scripts and NutShell, ensuring it follows upstream changes by default.
3. FPGA regressions are executed using the fpga-release path to standardize operational workflows