### PR TITLE
fix(Delta): invalidate delta output when updates cleared

### DIFF
--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -155,7 +155,7 @@ class DeltaSplitter(v_gen: Valid[DifftestBundle], config: GatewayConfig) extends
       val seqID = gid * config.deltaLimit + idx
       val delta = WireInit(0.U.asTypeOf(Valid(new DiffDeltaElem(v_gen.bits))))
       if (seqID < elems.length) {
-        delta.valid := updates(seqID)
+        delta.valid := updates(seqID) && group_updates =/= 0.U
         delta.bits.coreid := in.bits.coreid
         delta.bits.index := seqID.U
         delta.bits.data := elems(seqID)


### PR DESCRIPTION
Previously, the Delta output selects a group of elems from PriorityEncoder. When updates cleared, the encoder kept selecting the last group and repeatedly output its cached value as valid.

This change explicitly invalidates Delta outputs once updates are cleared, preventing stale or duplicated data.