### PR TITLE
chore(difftest): map phy->arch reg with explicit target

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -364,18 +364,27 @@ abstract class DiffPhyRegState(val numPhyRegs: Int) extends PhyRegState(numPhyRe
   override val supportsDelta: Boolean = true
   override def classArgs: Map[String, Any] = Map("numPhyRegs" -> numPhyRegs)
   override val updateDependency: Seq[String] = Seq("commit", "event")
+  def archTarget: ArchRegState with DifftestBundle
+  def ratTarget: DiffArchRenameTable
+  def needRat: Boolean = numPhyRegs != archTarget.numRegs
 }
 
 class DiffPhyIntRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {
   override val desiredCppName: String = "pregs_xrf"
+  override def archTarget = new DiffArchIntRegState
+  override def ratTarget = new DiffArchIntRenameTable(numPhyRegs)
 }
 
 class DiffPhyFpRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {
   override val desiredCppName: String = "pregs_frf"
+  override def archTarget = new DiffArchFpRegState
+  override def ratTarget = new DiffArchFpRenameTable(numPhyRegs)
 }
 
 class DiffPhyVecRegState(numPhyRegs: Int) extends DiffPhyRegState(numPhyRegs) {
   override val desiredCppName: String = "pregs_vrf"
+  override def archTarget = new DiffArchVecRegState
+  override def ratTarget = new DiffArchVecRenameTable(numPhyRegs)
 }
 
 class DiffVecCSRState extends VecCSRState with DifftestBundle {


### PR DESCRIPTION
Previously we resolve (PhyReg, RenameTable) -> ArchReg mapping by a shared name suffix across bundles. This change add explicit archTarget and ratTarget to PhyReg for a more reliable mapping.