### PR TITLE
fix(Store): refactor vector store check

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -247,7 +247,12 @@ class UncacheMMStoreEvent extends DifftestBaseBundle with HasValid {
 class StoreEvent extends DifftestBaseBundle with HasValid {
   val addr = UInt(64.W)
   val data = UInt(64.W)
-  val mask = UInt(8.W)
+  val highData = UInt(64.W)
+  val mask = UInt(16.W)
+  val wLine = Bool()
+  val vecNeedSplit = Bool()
+  val eew = UInt(8.W)
+  val offset = UInt(16.W)
   val pc = UInt(64.W)
   val robidx = UInt(10.W)
 }

--- a/src/test/csrc/difftest/checkers/store.cpp
+++ b/src/test/csrc/difftest/checkers/store.cpp
@@ -15,6 +15,9 @@
 ***************************************************************************************/
 
 #include "checkers.h"
+#include "diffstate.h"
+#include <cstdint>
+#include <sys/types.h>
 
 #ifdef CONFIG_DIFFTEST_STOREEVENT
 bool StoreRecorder::get_valid(const DifftestStoreEvent &probe) {
@@ -25,7 +28,135 @@ void StoreRecorder::clear_valid(DifftestStoreEvent &probe) {
 }
 
 int StoreRecorder::check(const DifftestStoreEvent &probe) {
-  state->store_event_queue.push(probe);
+  if (!probe.valid)
+    return STATE_OK;
+
+  int BLOCKOFFSETBITS = 6;
+  int WORDBYTES = 8;
+  int COMMITBYTES = 16;
+
+  auto addr = probe.addr;
+  auto lowData = probe.data;
+  auto highData = probe.highData;
+  auto mask = probe.mask;
+  auto offset = probe.offset;
+  auto eew = probe.eew;
+  auto pc = probe.pc;
+  auto robIdx = probe.robidx;
+
+  uint64_t rawVecAddr = addr + offset;
+  uint16_t flow = COMMITBYTES / eew;
+  uint64_t flowMask = (eew == 1) ? 0x1ULL : (eew == 2) ? 0x3ULL : (eew == 4) ? 0xfULL : (eew == 8) ? 0xffULL : 0x0ULL;
+  uint64_t flowMaskBit = (eew == 1)   ? 0xffULL
+                         : (eew == 2) ? 0xffffULL
+                         : (eew == 4) ? 0xffffffffULL
+                         : (eew == 8) ? 0xffffffffffffffffULL
+                                      : 0x0ULL;
+
+  if (probe.vecNeedSplit) {
+    // cross 128bits.
+    bool handleMisalign = ((mask << (16 - offset)) & 0xFFFF) != 0;
+    // For requests exceeding 128 bits, we perform fragmentation.
+    // Processing the high-order bits of data exceeding 128 bits.
+    if (handleMisalign) {
+      uint64_t selVecData = offset >= 8 ? highData : lowData;
+      uint16_t rawOffset = offset % 8;
+      uint64_t refStoreCommitData = selVecData << (64 - (rawOffset * 8)) >> (64 - (rawOffset * 8));
+      uint8_t refStoreCommitMask = mask << rawOffset >> rawOffset;
+      DiffState::StoreCommit storeCommit = {probe.valid,
+                                            addr,
+                                            refStoreCommitData,
+                                            refStoreCommitMask,
+                                            pc,
+                                            robIdx
+#ifdef CONFIG_DIFFTEST_SQUASH
+                                            ,
+                                            probe.stamp
+#endif // CONFIG_DIFFTEST_SQUASH
+      };
+
+      state->store_event_queue.push(storeCommit);
+    }
+    for (int i = 0; i < flow; i++) {
+      uint32_t rawOffset = eew * i + offset;
+      uint32_t nextOffset = rawOffset + eew;
+
+      // to next sbuffer write event.
+      if (rawOffset >= 16)
+        break;
+
+      uint64_t selVecData = rawOffset >= 8 ? highData : lowData;
+      auto dataOffset = (rawOffset * 8) % 64;
+      auto refStoreCommitAddr = rawVecAddr + eew * i;
+      uint8_t refStoreCommitMask = (mask >> rawOffset) & flowMask;
+
+      if (refStoreCommitMask == 0)
+        continue;
+
+      uint64_t refStoreCommitData;
+      bool needNextData = (rawOffset < 8) && (nextOffset > 8);
+
+      if (needNextData) {
+        auto presentDataOffset = dataOffset;
+        auto presentData = lowData >> presentDataOffset;
+
+        nextOffset = 8 - rawOffset;
+        auto nextDataOffset = nextOffset * 8;
+        auto nextData = probe.highData << nextDataOffset;
+
+        refStoreCommitData = (nextData + presentData) & flowMaskBit;
+      } else {
+        refStoreCommitData = (selVecData >> dataOffset) & flowMaskBit;
+      }
+
+      DiffState::StoreCommit storeCommit = {probe.valid,
+                                            refStoreCommitAddr,
+                                            refStoreCommitData,
+                                            refStoreCommitMask,
+                                            pc,
+                                            robIdx
+#ifdef CONFIG_DIFFTEST_SQUASH
+                                            ,
+                                            probe.stamp
+#endif // CONFIG_DIFFTEST_SQUASH
+      };
+      state->store_event_queue.push(storeCommit);
+    }
+  } else if (probe.wLine) {
+    uint64_t blockAddr = addr >> BLOCKOFFSETBITS << BLOCKOFFSETBITS;
+    for (int i = 0; i < 8; i++) {
+      uint64_t refStoreCommitAddr = blockAddr + i * WORDBYTES;
+      uint64_t refStoreCommitData = 0;
+      uint8_t refStoreCommitMask = 0xff;
+
+      DiffState::StoreCommit storeCommit = {probe.valid,
+                                            refStoreCommitAddr,
+                                            refStoreCommitData,
+                                            refStoreCommitMask,
+                                            pc,
+                                            robIdx
+#ifdef CONFIG_DIFFTEST_SQUASH
+                                            ,
+                                            probe.stamp
+#endif // CONFIG_DIFFTEST_SQUASH
+      };
+      state->store_event_queue.push(storeCommit);
+    }
+  } else {
+    DiffState::StoreCommit storeCommit = {probe.valid,
+                                          probe.addr,
+                                          lowData,
+                                          static_cast<uint8_t>(probe.mask & 0xFF),
+                                          pc,
+                                          robIdx
+#ifdef CONFIG_DIFFTEST_SQUASH
+                                          ,
+                                          probe.stamp
+#endif // CONFIG_DIFFTEST_SQUASH
+    };
+    state->store_event_queue.push(storeCommit);
+  }
+
   return STATE_OK;
 }
 

--- a/src/test/csrc/difftest/diffstate.h
+++ b/src/test/csrc/difftest/diffstate.h
@@ -18,6 +18,7 @@
 #define __DIFFSTATE_H__
 
 #include "common.h"
+#include <cstdint>
 #include <queue>
 #include <unordered_set>
 
@@ -122,7 +123,19 @@ public:
 #endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
 
 #ifdef CONFIG_DIFFTEST_STOREEVENT
-  std::queue<DifftestStoreEvent> store_event_queue;
+  typedef struct {
+    uint8_t valid;
+    uint64_t addr;
+    uint64_t data;
+    uint8_t mask;
+    uint64_t pc;
+    uint16_t robidx;
+#ifdef CONFIG_DIFFTEST_SQUASH
+    uint32_t stamp;
+#endif
+  } StoreCommit;
+
+  std::queue<StoreCommit> store_event_queue;
 #endif // CONFIG_DIFFTEST_STOREEVENT
 
 #ifdef CONFIG_DIFFTEST_CMOINVALEVENT


### PR DESCRIPTION
We have updated the handling of difftest store events by moving the core logic to the difftest side.

This change is necessary because XiangShan implements specific micro-architectural (uarch) optimizations for vector memory operations. However, NEMU, adhering to the principles of a standard ISA simulator, does not include these uarch details. 

Consequently, complex handling is required to reconcile these differences during difftest.

Previously, this logic was implemented in XiangShan's Sbuffer.scala. Due to some bugs encountered there, I decided to migrate the logic out to simplify the implementation and improve stability.

The primary approach involves decomposing vector memory access into element granularity, with additional handing for misalign.
 
Please help me review, but don't merge, i need  to incorporate it along with the of nemu.