### PR TITLE
fix(fpga): support no-diff without specified ref-so

### DIFF
--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -84,7 +84,7 @@ void fpga_init() {
   init_ram(args.image, DEFAULT_EMU_RAM_SIZE);
   init_flash(args.flash_bin);
 
-  difftest_init(true, DEFAULT_EMU_RAM_SIZE);
+  difftest_init(args.enable_diff, DEFAULT_EMU_RAM_SIZE);
 
   init_device();
 


### PR DESCRIPTION
Previously we always use difftest_init(true, ) even with --no-diff, which requires us to specify ref-so path or NEMU_HOME.

This change replace it with difftest_init(args.enable_diff, ).