### PR TITLE
fix(StoreChecker): fix incorrect mask truncation for misaligned vector stores

### DIFF
--- a/src/test/csrc/difftest/checkers/store.cpp
+++ b/src/test/csrc/difftest/checkers/store.cpp
@@ -63,7 +63,7 @@ int StoreRecorder::check(const DifftestStoreEvent &probe) {
       uint64_t selVecData = offset >= 8 ? highData : lowData;
       uint16_t rawOffset = offset % 8;
       uint64_t refStoreCommitData = selVecData << (64 - (rawOffset * 8)) >> (64 - (rawOffset * 8));
-      uint8_t refStoreCommitMask = mask << rawOffset >> rawOffset;
+      uint8_t refStoreCommitMask = mask & ((1U << rawOffset) - 1);
       DiffState::StoreCommit storeCommit = {probe.valid,
                                             addr,
                                             refStoreCommitData,


### PR DESCRIPTION
fix incorrect mask truncation for misaligned vector stores

When difftest store checker splits the committed vector store instructions, there was an error in the mask assignment logic for misaligned cases - it should preserve the lower rawOffset bits.

The original logic failed to correctly preserve the mask according to the lower rawOffset bits, and our modification fixes this issue.

Reviewed by ：fuhuakai, yuwenlong, wangzhizun