### PR TITLE
fix(DPIC): support width 8/16 for DeltaElem index

### DIFF
--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -234,7 +234,8 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
     elem_names.zipWithIndex.foreach { case (name, idx) =>
       if (Seq("coreid", "index", "address").contains(name)) {
         val offset = elem_bytes.take(idx).sum
-        unpack += s"$name = data[$offset];"
+        val typeStr = s"uint${elem_bytes(idx) * 8}_t"
+        unpack += s"$name = *(($typeStr*)(data + $offset));"
       }
     }
     unpack += getPacketDecl(gen, "", config)

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -32,7 +32,8 @@ trait DifftestWithCoreid {
 }
 
 trait DifftestWithIndex {
-  val index = UInt(8.W)
+  def idxWidth = 8
+  val index = UInt(idxWidth.W)
 }
 
 trait DifftestWithStamp {
@@ -177,6 +178,7 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   val supportsDelta: Boolean = false
   def isDeltaElem: Boolean = this.isInstanceOf[DiffDeltaElem]
   def deltaElemWidth: Int = dataElements.map(_._2).max
+  def deltaIdxWidth: Int = math.max(8, log2Ceil(dataElements.map(_._3.length).sum))
 
   // Byte align all elements
   def getByteAlignElems(isTrace: Boolean): Seq[(String, Data)] = {
@@ -226,6 +228,7 @@ private[difftest] class DiffDeltaElem(gen: DifftestBundle)
   with DifftestBundle
   with DifftestWithIndex {
   def srcGenType: DifftestBundle = gen
+  override def idxWidth = gen.deltaIdxWidth
   override val desiredCppName: String = gen.desiredCppName + "_elem"
   override def desiredModuleName: String = gen.desiredModuleName + "Elem"
 }


### PR DESCRIPTION
This change support both uint8_t/uint16_t for index, enabling update DifftestDeltaElem with index > 256. It fix mismatched Vec registers when PhyVecReg is splitted to more than 256 reg with Delta, and pass new-built linux-hello with Vec extension in Palladium.