### PR TITLE
feat(fpga): model XDMA config bar in fpga sim

### DIFF
--- a/src/main/scala/SimTop.scala
+++ b/src/main/scala/SimTop.scala
@@ -18,9 +18,10 @@ package difftest
 
 import chisel3._
 import chisel3.experimental.prefix
+import chisel3.experimental.dataview._
 import chisel3.reflect.DataMirror
-import difftest.common.DifftestWiring
-import difftest.fpga.HostEndpoint
+import difftest.common.{AXI4LiteBundle, DifftestWiring, VerilogAXI4LiteRecord}
+import difftest.fpga.{HostEndpoint, XDMAConfigBar, XDMAHostCtrlIO}
 
 class DifftestTopIO extends Bundle {
   val exit = Output(UInt(64.W))
@@ -94,10 +95,11 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
   override def desiredName: String = modPrefix.getOrElse("") + super.desiredName
   val cpu = Module(cpuGen)
   cpu.dutClock := clock
-  cpu.dutReset := reset.asTypeOf(cpu.dutReset)
 
   val cpuName = cpu.cpuName.getOrElse(cpu.getClass.getName.split("\\.").last)
   val gateway = DifftestModule.collect(cpuName)
+  val fpgaHostReset = WireInit(false.B)
+  val fpgaDiffEnable = WireInit(true.B)
 
   // IO: difftest_*
   val difftest = IO(new DifftestTopIO)
@@ -120,22 +122,41 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
 
     // IO: difftest_fpga_*
     gateway.fpgaIO.foreach { fpgaIO =>
-      val host = withClock(ref_clock) { Module(new HostEndpoint(fpgaIO.bits.getWidth)) }
-      host.io.difftest <> fpgaIO
+      val ref_reset = IO(Input(Bool()))
+      val cfg = withClockAndReset(ref_clock.get, ref_reset) {
+        Module(new XDMAConfigBar)
+      }
+      val host = withClock(ref_clock.get) {
+        Module(new HostEndpoint(fpgaIO.bits.getWidth))
+      }
+
+      host.io.difftest.valid := fpgaIO.valid && cfg.io.ctrl.diffEnable
+      host.io.difftest.bits := fpgaIO.bits
+      fpgaIO.ready := Mux(cfg.io.ctrl.diffEnable, host.io.difftest.ready, true.B)
       val pcie_clock = IO(Input(Clock()))
       host.io.pcie_clock := pcie_clock
 
       val toHost = host.io.to_host_axis
       val to_host_axis = IO(chiselTypeOf(toHost))
       to_host_axis <> toHost
+
+      val cfg_axilite = IO(Flipped(new VerilogAXI4LiteRecord(32, 32)))
+      cfg.io.axilite <> cfg_axilite.viewAs[AXI4LiteBundle]
+
+      val hostCtrl = IO(Output(new XDMAHostCtrlIO))
+      hostCtrl := cfg.io.ctrl
+
+      fpgaHostReset := hostCtrl.reset
+      fpgaDiffEnable := hostCtrl.diffEnable
     }
 
     gateway.clockEnable.foreach { clockEnable =>
       val clock_enable = IO(Output(Bool()))
-      clock_enable := clockEnable
+      clock_enable := clockEnable || fpgaHostReset || !fpgaDiffEnable
     }
   }
 
+  cpu.dutReset := (reset.asBool || fpgaHostReset).asTypeOf(cpu.dutReset)
   cpu.connectTopIOs(difftest)
   cpu.dutIOs.foreach { case (name, gen) =>
     val io = IO(chiselTypeOf(gen)).suggestName(name)

--- a/src/main/scala/common/AXI4Lite.scala
+++ b/src/main/scala/common/AXI4Lite.scala
@@ -1,0 +1,108 @@
+/***************************************************************************************
+ * Copyright (c) 2025-2026 Beijing Institute of Open Source Chip
+ * Copyright (c) 2020-2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.common
+
+import chisel3._
+import chisel3.experimental.dataview._
+import chisel3.util._
+import scala.collection.immutable.SeqMap
+
+class AXI4LiteBundleA(val addrWidth: Int) extends Bundle {
+  val addr = UInt(addrWidth.W)
+}
+
+class AXI4LiteBundleAR(addrWidth: Int) extends AXI4LiteBundleA(addrWidth)
+
+class AXI4LiteBundleAW(addrWidth: Int) extends AXI4LiteBundleA(addrWidth)
+
+class AXI4LiteBundleW(val dataWidth: Int) extends Bundle {
+  val data = UInt(dataWidth.W)
+  val strb = UInt((dataWidth / 8).W)
+}
+
+class AXI4LiteBundleB extends Bundle {
+  val resp = UInt(2.W)
+}
+
+class AXI4LiteBundleR(val dataWidth: Int) extends Bundle {
+  val data = UInt(dataWidth.W)
+  val resp = UInt(2.W)
+}
+
+class AXI4LiteBundle(val addrWidth: Int, val dataWidth: Int) extends Bundle {
+  val aw = Decoupled(new AXI4LiteBundleAW(addrWidth))
+  val w = Decoupled(new AXI4LiteBundleW(dataWidth))
+  val b = Flipped(Decoupled(new AXI4LiteBundleB))
+  val ar = Decoupled(new AXI4LiteBundleAR(addrWidth))
+  val r = Flipped(Decoupled(new AXI4LiteBundleR(dataWidth)))
+}
+
+class VerilogAXI4LiteRecord(val addrWidth: Int, val dataWidth: Int) extends Record {
+  private val axilite = new AXI4LiteBundle(addrWidth, dataWidth)
+  private def traverseAndMap(data: (String, Data)): SeqMap[String, Data] = {
+    data match {
+      case (name, node: Bundle) =>
+        SeqMap.from(
+          node.elements.toSeq.flatMap(traverseAndMap).map { case (nodeName, nodeData) =>
+            s"${name.replace("bits", "")}$nodeName" -> nodeData
+          }
+        )
+      case (name, node) => SeqMap(name -> node)
+    }
+  }
+  private val outputPattern = "^(aw|w|ar).*".r
+  private val elems = traverseAndMap("" -> axilite).map { case (name, node) =>
+    val directed = name match {
+      case outputPattern(_) => Output(node)
+      case _                => Input(node)
+    }
+    name match {
+      case s"${_}ready" => name -> Flipped(directed)
+      case _            => name -> directed
+    }
+  }
+
+  override def elements: SeqMap[String, Data] = elems
+}
+
+object VerilogAXI4LiteRecord {
+  private val elementsMap: Seq[(VerilogAXI4LiteRecord, AXI4LiteBundle) => (Data, Data)] = {
+    val names = new VerilogAXI4LiteRecord(1, 8).elements.keys
+    val pattern = "^(aw|w|b|ar|r)(.*)".r
+    names.map { name => (verilog: VerilogAXI4LiteRecord, chisel: AXI4LiteBundle) =>
+      val (channel, signal) = name match {
+        case pattern(prefix, suffix) =>
+          chisel.elements(prefix).asInstanceOf[Record] -> suffix
+        case _ => throw new IllegalArgumentException(s"unexpected AXI4-Lite port name: $name")
+      }
+      val chiselData = channel.elements.applyOrElse(
+        signal,
+        channel.elements("bits").asInstanceOf[Record].elements,
+      )
+      verilog.elements(name) -> chiselData
+    }.toSeq
+  }
+
+  implicit val recordToBundle: DataView[VerilogAXI4LiteRecord, AXI4LiteBundle] =
+    DataView[VerilogAXI4LiteRecord, AXI4LiteBundle](
+      record => new AXI4LiteBundle(record.addrWidth, record.dataWidth),
+      elementsMap: _*
+    )
+
+  implicit val bundleToRecord: DataView[AXI4LiteBundle, VerilogAXI4LiteRecord] =
+    recordToBundle.invert(bundle => new VerilogAXI4LiteRecord(bundle.addrWidth, bundle.dataWidth))
+}

--- a/src/main/scala/common/AXI4Stream.scala
+++ b/src/main/scala/common/AXI4Stream.scala
@@ -14,7 +14,7 @@
  * See the Mulan PSL v2 for more details.
  ***************************************************************************************/
 
-package difftest.fpga
+package difftest.common
 import chisel3._
 import chisel3.util._
 

--- a/src/main/scala/fpga/Host.scala
+++ b/src/main/scala/fpga/Host.scala
@@ -18,6 +18,7 @@ package difftest.fpga
 
 import chisel3._
 import chisel3.util._
+import difftest.common.AXI4Stream
 import difftest.gateway.FpgaDiffIO
 import difftest.util.{Delayer, PipelineConnect}
 

--- a/src/main/scala/fpga/XDMAConfigBar.scala
+++ b/src/main/scala/fpga/XDMAConfigBar.scala
@@ -1,0 +1,123 @@
+/***************************************************************************************
+ * Copyright (c) 2025-2026 Beijing Institute of Open Source Chip
+ * Copyright (c) 2020-2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.fpga
+
+import chisel3._
+import chisel3.util._
+import difftest.common.AXI4LiteBundle
+
+/** XDMA Config BAR for both FPGA/FPGA_SIM
+  *
+  * Register Map:
+  *   - 0x00: HOST_IO_RESET
+  *   - 0x04: HOST_IO_DIFF_ENABLE
+  *   - 0x08: HOST_IO_ILA_TRIGGER
+  *   - 0x0c..0x1c: reserved, read as zero
+  */
+class XDMAHostCtrlIO extends Bundle {
+  val reset = Bool()
+  val diffEnable = Bool()
+  val ilaTrigger = Bool()
+}
+
+private object XDMAConfigReg extends Enumeration {
+  val HostReset, DiffEnable, IlaTrigger = Value
+}
+
+class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Module {
+  require(dataWidth == 32, "XDMAConfigBar currently models a 32-bit AXI-Lite BAR")
+
+  val io = IO(new Bundle {
+    val axilite = Flipped(new AXI4LiteBundle(addrWidth, dataWidth))
+    val ctrl = Output(new XDMAHostCtrlIO)
+  })
+
+  private val numRegs = XDMAConfigReg.maxId
+  private val idxBits = log2Ceil(numRegs)
+  private val regfile = RegInit(VecInit(Seq.fill(numRegs)(0.U(dataWidth.W))))
+
+  io.ctrl.reset := regfile(XDMAConfigReg.HostReset.id)(0)
+  io.ctrl.diffEnable := regfile(XDMAConfigReg.DiffEnable.id)(0)
+  io.ctrl.ilaTrigger := regfile(XDMAConfigReg.IlaTrigger.id)(0)
+
+  private def mergeByByte(oldData: UInt, newData: UInt, strb: UInt): UInt = {
+    VecInit((0 until dataWidth / 8).map { i =>
+      Mux(strb(i), newData(8 * i + 7, 8 * i), oldData(8 * i + 7, 8 * i))
+    }).asUInt
+  }
+
+  val awaddr = Reg(UInt(addrWidth.W))
+  val awValid = RegInit(false.B)
+  val wdata = Reg(UInt(dataWidth.W))
+  val wstrb = Reg(UInt((dataWidth / 8).W))
+  val wValid = RegInit(false.B)
+  val bValid = RegInit(false.B)
+
+  io.axilite.aw.ready := !awValid && !bValid
+  io.axilite.w.ready := !wValid && !bValid
+  io.axilite.b.valid := bValid
+  io.axilite.b.bits.resp := 0.U
+
+  val awFire = io.axilite.aw.fire
+  val wFire = io.axilite.w.fire
+  val nextAwAddr = Mux(awFire, io.axilite.aw.bits.addr, awaddr)
+  val nextWData = Mux(wFire, io.axilite.w.bits.data, wdata)
+  val nextWStrb = Mux(wFire, io.axilite.w.bits.strb, wstrb)
+  val doWrite = !bValid && (awValid || awFire) && (wValid || wFire)
+
+  when(awFire) {
+    awaddr := io.axilite.aw.bits.addr
+    awValid := true.B
+  }
+  when(wFire) {
+    wdata := io.axilite.w.bits.data
+    wstrb := io.axilite.w.bits.strb
+    wValid := true.B
+  }
+  when(doWrite) {
+    val writeWord = nextAwAddr(addrWidth - 1, 2)
+    val writeIdx = writeWord(idxBits - 1, 0)
+    when(writeWord < numRegs.U) {
+      regfile(writeIdx) := mergeByByte(regfile(writeIdx), nextWData, nextWStrb)
+    }
+    awValid := false.B
+    wValid := false.B
+    bValid := true.B
+  }.elsewhen(bValid && io.axilite.b.ready) {
+    bValid := false.B
+  }
+
+  val arReady = RegInit(true.B)
+  val rValid = RegInit(false.B)
+  val rData = Reg(UInt(dataWidth.W))
+
+  io.axilite.ar.ready := arReady
+  io.axilite.r.valid := rValid
+  io.axilite.r.bits.data := rData
+  io.axilite.r.bits.resp := 0.U
+
+  when(io.axilite.ar.valid && arReady) {
+    val readWord = io.axilite.ar.bits.addr(addrWidth - 1, 2)
+    val readIdx = readWord(idxBits - 1, 0)
+    rData := Mux(readWord < numRegs.U, regfile(readIdx), 0.U)
+    arReady := false.B
+    rValid := true.B
+  }.elsewhen(rValid && io.axilite.r.ready) {
+    arReady := true.B
+    rValid := false.B
+  }
+}

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -104,10 +104,10 @@ static bool run_external_cmd(const char *cmd, const char *tag) {
 
 void fpga_init() {
   xdma_device = new FpgaXdma();
-#ifndef FPGA_SIM
   xdma_device->fpga_io(HOST_IO_RESET, true);
   xdma_device->fpga_io(HOST_IO_DIFFTEST_ENABLE, args.enable_diff);
   xdma_device->fpga_io(HOST_IO_ILA_TRIGGER, false);
+#ifndef FPGA_SIM
   usleep(1000);
 #endif // FPGA_SIM
 
@@ -136,16 +136,16 @@ void fpga_init() {
 
   difftest_init(args.enable_diff, DEFAULT_EMU_RAM_SIZE);
 
-#ifndef FPGA_SIM
   xdma_device->fpga_io(HOST_IO_ILA_TRIGGER, false);
+#ifndef FPGA_SIM
   if (fpga_ila_dump_cmd) {
     if (!run_external_cmd(fpga_ila_dump_cmd, "ILA dump")) {
       fprintf(stderr, "[fpga-host] warning: failed to arm external ILA dump command\n");
       exit(1);
     }
   }
-  xdma_device->fpga_io(HOST_IO_RESET, false);
 #endif // FPGA_SIM
+  xdma_device->fpga_io(HOST_IO_RESET, false);
 }
 
 void fpga_finish() {
@@ -188,9 +188,7 @@ int fpga_get_result(uint8_t step) {
   // Compare DUT and REF
   int trapCode = difftest_nstep(step, args.enable_diff);
   if (trapCode != STATE_RUNNING) {
-#ifndef FPGA_SIM
     xdma_device->fpga_io(HOST_IO_ILA_TRIGGER, true);
-#endif // FPGA_SIM
     if (trapCode == STATE_GOODTRAP)
       return FPGA_GOODTRAP;
     else

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -74,6 +74,9 @@ FpgaXdma::FpgaXdma()
     std::cout << "XDMA link " << c2h_device << std::endl;
 #endif // FPGA_SIM
   }
+#ifdef FPGA_SIM
+  xdma_sim_axilite_open(true);
+#endif // FPGA_SIM
 #ifdef CONFIG_USE_XDMA_H2C
   xdma_h2c_fd = open(XDMA_H2C_DEVICE, O_WRONLY);
   if (xdma_h2c_fd == -1) {
@@ -85,8 +88,32 @@ FpgaXdma::FpgaXdma()
 #endif
 }
 
+FpgaXdma::~FpgaXdma() {
+#ifdef FPGA_SIM
+  for (int i = 0; i < CONFIG_DMA_CHANNELS; i++) {
+    xdma_sim_close(i);
+  }
+  xdma_sim_axilite_close(true);
+#endif // FPGA_SIM
+}
+
 // write xdma_bypass memory or xdma_user
 void FpgaXdma::device_write(bool is_bypass, const char *workload, uint64_t addr, uint64_t value) {
+#ifdef FPGA_SIM
+  if (is_bypass) {
+    // FPGA_SIM already passes the workload to simv through +workload. Keep the
+    // host API shape but avoid a duplicate per-byte DPI DDR load path.
+    (void)workload;
+    printf("[fpga-host] FPGA_SIM uses simv +workload for DDR init; skip XDMA bypass load\n");
+    return;
+  }
+  if (xdma_sim_axilite_write(static_cast<uint32_t>(addr), static_cast<uint32_t>(value), 0xf) != 0) {
+    fprintf(stderr, "[fpga-host] FPGA_SIM AXI-Lite command queue is full, addr=0x%lx value=0x%lx\n", addr, value);
+    exit(-1);
+  }
+  return;
+#endif // FPGA_SIM
+
   uint64_t pg_size = sysconf(_SC_PAGE_SIZE);
   uint64_t size = !is_bypass ? 0x1000 : 0x100000;
   uint64_t aligned_size = (size + 0xffful) & ~0xffful;
@@ -198,7 +225,8 @@ void FpgaXdma::write_difftest_thread() {
   }
 }
 
-#else
+#else // !USE_THREAD_MEMPOOL
+
 void *posix_memalignd_malloc(size_t size) {
   void *ptr = nullptr;
   int ret = posix_memalign(&ptr, 4096, size);

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -58,6 +58,7 @@ typedef struct __attribute__((packed)) {
 class FpgaXdma {
 public:
   FpgaXdma();
+  ~FpgaXdma();
 
   void start(bool enable_diff) {
     running = true;

--- a/src/test/csrc/fpga_sim/xdma_sim.cpp
+++ b/src/test/csrc/fpga_sim/xdma_sim.cpp
@@ -21,11 +21,57 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
+#ifndef FPGA_HOST
+#include "svdpi.h"
+#endif // FPGA_HOST
 
 #define BUFFER_SIZE 65536
+
+template <typename T> class xdma_shm_device {
+private:
+  int shm_fd = -1;
+  std::string shm_path;
+  size_t shm_size;
+
+protected:
+  T *shm_ptr = nullptr;
+  bool is_host;
+
+public:
+  xdma_shm_device(const char *path, size_t size, bool _is_host, const char *desc)
+      : shm_path(path), shm_size(size), is_host(_is_host) {
+    shm_fd = shm_open(shm_path.c_str(), O_CREAT | O_RDWR, 0666);
+    if (shm_fd == -1) {
+      fprintf(stderr, "XDMA_SIM: Failed to open %s shared memory %s\n", desc, shm_path.c_str());
+      perror("shm_open");
+      exit(-1);
+    }
+    if (is_host && ftruncate(shm_fd, shm_size) != 0) {
+      perror("XDMA_SIM: Failed to size shared memory device");
+      exit(-1);
+    }
+    shm_ptr = (T *)mmap(NULL, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+    if (shm_ptr == MAP_FAILED) {
+      perror("XDMA_SIM: Failed to mmap shared memory");
+      exit(-1);
+    }
+    if (is_host) {
+      memset(shm_ptr, 0, shm_size);
+    }
+  }
+
+  ~xdma_shm_device() {
+    if (is_host) {
+      shm_unlink(shm_path.c_str());
+    }
+    munmap(shm_ptr, shm_size);
+    close(shm_fd);
+  }
+};
 
 typedef struct {
   pthread_mutex_t lock;
@@ -36,28 +82,28 @@ typedef struct {
   char buffer[BUFFER_SIZE];
 } xdma_shm;
 
-class xdma_sim {
+typedef struct {
+  pthread_mutex_t lock;
+  pthread_cond_t write_cond;
+  pthread_cond_t done_cond;
+  bool valid;
+  bool done;
+  uint32_t addr;
+  uint32_t data;
+  uint8_t strb;
+} xdma_axilite_shm;
+
+class xdma_sim : private xdma_shm_device<xdma_shm> {
 private:
-  int shm_fd = -1;
-  xdma_shm *shm_ptr = nullptr;
-  char path[128];
-  bool is_host;
+  static std::string path(int channel) {
+    char path[128];
+    sprintf(path, "/xdma_sim_c2h%d", channel);
+    return path;
+  }
 
 public:
-  xdma_sim(int channel, bool _is_host) {
-    is_host = _is_host;
-    sprintf(path, "/xdma_sim_c2h%d", channel);
-    shm_fd = shm_open(path, O_CREAT | O_RDWR, 0666);
-    if (shm_fd == -1) {
-      perror("XDMA_SIM: Failed to open shared memory device\n");
-      exit(-1);
-    }
+  xdma_sim(int channel, bool is_host) : xdma_shm_device(path(channel).c_str(), sizeof(xdma_shm), is_host, "C2H") {
     if (is_host) {
-      ftruncate(shm_fd, sizeof(xdma_shm));
-    }
-    shm_ptr = (xdma_shm *)mmap(NULL, sizeof(xdma_shm), PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
-    if (is_host) {
-      memset(shm_ptr, 0, sizeof(xdma_shm));
       pthread_mutexattr_t attr;
       pthread_mutexattr_init(&attr);
       pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
@@ -68,13 +114,7 @@ public:
       pthread_cond_init(&shm_ptr->read_cond, &cattr);
     }
   }
-  ~xdma_sim() {
-    if (is_host) {
-      shm_unlink(path);
-    }
-    munmap(shm_ptr, sizeof(xdma_shm));
-    close(shm_fd);
-  }
+
   int read(char *buf, size_t size) {
     assert(size <= BUFFER_SIZE);
     pthread_mutex_lock(&shm_ptr->lock);
@@ -92,6 +132,7 @@ public:
 
     return to_copy;
   }
+
   int write(const char *buf, unsigned char tlast, size_t size) {
     pthread_mutex_lock(&shm_ptr->lock);
     while (!shm_ptr->read_waiting) {
@@ -116,16 +157,103 @@ public:
   }
 };
 
+class xdma_axilite_sim : private xdma_shm_device<xdma_axilite_shm> {
+private:
+  static const char *path() {
+    return "/xdma_sim_axilite";
+  }
+
+public:
+  xdma_axilite_sim(bool is_host) : xdma_shm_device(path(), sizeof(xdma_axilite_shm), is_host, "AXI-Lite") {
+    if (is_host) {
+      pthread_mutexattr_t attr;
+      pthread_mutexattr_init(&attr);
+      pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+      pthread_mutex_init(&shm_ptr->lock, &attr);
+      pthread_condattr_t cattr;
+      pthread_condattr_init(&cattr);
+      pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED);
+      pthread_cond_init(&shm_ptr->write_cond, &cattr);
+      pthread_cond_init(&shm_ptr->done_cond, &cattr);
+    }
+  }
+
+  int write(uint32_t addr, uint32_t data, uint8_t strb) {
+    pthread_mutex_lock(&shm_ptr->lock);
+    while (shm_ptr->valid) {
+      pthread_cond_wait(&shm_ptr->done_cond, &shm_ptr->lock);
+    }
+
+    shm_ptr->addr = addr;
+    shm_ptr->data = data;
+    shm_ptr->strb = strb;
+    shm_ptr->done = false;
+    shm_ptr->valid = true;
+    pthread_cond_signal(&shm_ptr->write_cond);
+
+    while (!shm_ptr->done) {
+      pthread_cond_wait(&shm_ptr->done_cond, &shm_ptr->lock);
+    }
+    shm_ptr->valid = false;
+    pthread_cond_broadcast(&shm_ptr->done_cond);
+    pthread_mutex_unlock(&shm_ptr->lock);
+    return 0;
+  }
+
+  int wait(uint32_t *addr, uint32_t *data, uint8_t *strb, volatile bool *stop) {
+    pthread_mutex_lock(&shm_ptr->lock);
+    while (!shm_ptr->valid && !*stop) {
+      pthread_cond_wait(&shm_ptr->write_cond, &shm_ptr->lock);
+    }
+    if (*stop) {
+      pthread_mutex_unlock(&shm_ptr->lock);
+      return 0;
+    }
+
+    *addr = shm_ptr->addr;
+    *data = shm_ptr->data;
+    *strb = shm_ptr->strb;
+    pthread_mutex_unlock(&shm_ptr->lock);
+    return 1;
+  }
+
+  void complete() {
+    pthread_mutex_lock(&shm_ptr->lock);
+    shm_ptr->done = true;
+    pthread_cond_broadcast(&shm_ptr->done_cond);
+    pthread_mutex_unlock(&shm_ptr->lock);
+  }
+
+  void notify() {
+    pthread_mutex_lock(&shm_ptr->lock);
+    pthread_cond_signal(&shm_ptr->write_cond);
+    pthread_cond_broadcast(&shm_ptr->done_cond);
+    pthread_mutex_unlock(&shm_ptr->lock);
+  }
+};
+
 // API for shared XDMA Dev
 xdma_sim *xsim[8] = {nullptr};
+xdma_axilite_sim *axilite_sim = nullptr;
+static pthread_mutex_t xsim_lock = PTHREAD_MUTEX_INITIALIZER;
+
+#ifndef FPGA_HOST
+static void xdma_axilite_stop_thread();
+#endif // FPGA_HOST
 
 void xdma_sim_open(int channel, bool is_host) {
-  xsim[channel] = new xdma_sim(channel, is_host);
+  pthread_mutex_lock(&xsim_lock);
+  if (xsim[channel] == nullptr) {
+    xsim[channel] = new xdma_sim(channel, is_host);
+  }
+  pthread_mutex_unlock(&xsim_lock);
 }
 
 void xdma_sim_close(int channel) {
+  pthread_mutex_lock(&xsim_lock);
   delete xsim[channel];
   xsim[channel] = nullptr;
+  pthread_mutex_unlock(&xsim_lock);
 }
 
 int xdma_sim_read(int channel, char *buf, size_t size) {
@@ -136,6 +264,97 @@ int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size) {
   return xsim[channel]->write(buf, tlast, size);
 }
 
+void xdma_sim_axilite_open(bool is_host) {
+  pthread_mutex_lock(&xsim_lock);
+  if (axilite_sim == nullptr) {
+    axilite_sim = new xdma_axilite_sim(is_host);
+  }
+  pthread_mutex_unlock(&xsim_lock);
+}
+
+void xdma_sim_axilite_close(bool is_host) {
+#ifndef FPGA_HOST
+  if (!is_host) {
+    xdma_axilite_stop_thread();
+  }
+#endif // FPGA_HOST
+  pthread_mutex_lock(&xsim_lock);
+  delete axilite_sim;
+  axilite_sim = nullptr;
+  pthread_mutex_unlock(&xsim_lock);
+}
+
+int xdma_sim_axilite_write(uint32_t addr, uint32_t data, uint8_t strb) {
+  return axilite_sim->write(addr, data, strb);
+}
+
 extern "C" void v_xdma_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {
   xdma_sim_write(channel, axi_tdata, axi_tlast, 64);
 }
+
+extern "C" void v_xdma_c2h_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {
+  xdma_sim_write(channel, axi_tdata, axi_tlast, 64);
+}
+
+#ifndef FPGA_HOST
+static svScope axilite_scope = nullptr;
+static pthread_t axilite_thread;
+static bool axilite_thread_started = false;
+static volatile bool axilite_thread_stop = false;
+
+extern "C" void v_xdma_axilite_write(uint32_t addr, uint32_t data, uint8_t strb, uint8_t *accepted);
+
+static void *xdma_axilite_thread_main(void *) {
+  xdma_sim_axilite_open(false);
+  while (!axilite_thread_stop) {
+    uint32_t addr = 0;
+    uint32_t data = 0;
+    uint8_t strb = 0;
+    if (!axilite_sim->wait(&addr, &data, &strb, &axilite_thread_stop)) {
+      continue;
+    }
+
+    uint8_t accepted = 0;
+    while (!accepted && !axilite_thread_stop) {
+      svSetScope(axilite_scope);
+      v_xdma_axilite_write(addr, data, strb, &accepted);
+      if (!accepted) {
+        usleep(1000);
+      }
+    }
+
+    axilite_sim->complete();
+  }
+  return nullptr;
+}
+
+extern "C" void v_xdma_axilite_set_scope() {
+  axilite_scope = svGetScope();
+  if (axilite_thread_started) {
+    return;
+  }
+
+  axilite_thread_stop = false;
+  int ret = pthread_create(&axilite_thread, nullptr, xdma_axilite_thread_main, nullptr);
+  if (ret != 0) {
+    errno = ret;
+    perror("XDMA_SIM: Failed to create AXI-Lite thread");
+    exit(-1);
+  }
+  axilite_thread_started = true;
+}
+
+static void xdma_axilite_stop_thread() {
+  if (!axilite_thread_started) {
+    return;
+  }
+
+  axilite_thread_stop = true;
+  if (axilite_sim != nullptr) {
+    axilite_sim->notify();
+  }
+  pthread_join(axilite_thread, nullptr);
+  axilite_thread_started = false;
+  axilite_scope = nullptr;
+}
+#endif // FPGA_HOST

--- a/src/test/csrc/fpga_sim/xdma_sim.h
+++ b/src/test/csrc/fpga_sim/xdma_sim.h
@@ -20,7 +20,10 @@
 
 void xdma_sim_open(int channel, bool is_host);
 void xdma_sim_close(int channel);
+void xdma_sim_axilite_open(bool is_host);
+void xdma_sim_axilite_close(bool is_host);
 int xdma_sim_read(int channel, char *buf, size_t size);
 int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size);
+int xdma_sim_axilite_write(uint32_t addr, uint32_t data, uint8_t strb);
 
 #endif // __XDMA_SIM_H__

--- a/src/test/vsrc/fpga_sim/xdma_axi_c2h.v
+++ b/src/test/vsrc/fpga_sim/xdma_axi_c2h.v
@@ -1,6 +1,6 @@
 /***************************************************************************************
-* Copyright (c) 2025 Beijing Institute of Open Source Chip (BOSC)
-* Copyright (c) 2020-2025 Institute of Computing Technology, Chinese Academy of Sciences
+* Copyright (c) 2025-2026 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2026 Institute of Computing Technology, Chinese Academy of Sciences
 *
 * DiffTest is licensed under Mulan PSL v2.
 * You can use this software according to the terms and conditions of the Mulan PSL v2.
@@ -14,7 +14,9 @@
 * See the Mulan PSL v2 for more details.
 ***************************************************************************************/
 `include "DifftestMacros.svh"
-module xdma_axi(
+
+// XDMA C2H AXI-Stream software model.
+module xdma_axi_c2h(
   input clock,
   input reset,
   input [511:0] axi_tdata,
@@ -23,7 +25,7 @@ module xdma_axi(
   input axi_tvalid
 );
 
-import "DPI-C" function void v_xdma_write(
+import "DPI-C" function void v_xdma_c2h_write(
   input byte channel,
   input bit [511:0] axi_tdata,
   input bit axi_tlast
@@ -32,6 +34,7 @@ import "DPI-C" function void v_xdma_write(
 // Simulate random ready of tready
 reg [63:0] ready_timer;
 assign axi_tready = !reset && ready_timer == 64'b0;
+
 always @(posedge clock) begin
   if (reset) begin
     ready_timer <= 64'h0;
@@ -48,7 +51,8 @@ end
 
 always @(posedge clock) begin
   if (!reset & axi_tvalid & axi_tready) begin
-    v_xdma_write(0, axi_tdata, axi_tlast);
+    v_xdma_c2h_write(0, axi_tdata, axi_tlast);
   end
 end
+
 endmodule

--- a/src/test/vsrc/fpga_sim/xdma_axilite.v
+++ b/src/test/vsrc/fpga_sim/xdma_axilite.v
@@ -1,0 +1,175 @@
+/***************************************************************************************
+* Copyright (c) 2025-2026 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2026 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+`include "DifftestMacros.svh"
+
+// XDMA AXI4-Lite master software model.
+// The simulator does not support timing controls in DPI-exported tasks, so the DPI
+// call submits one command and reports whether the local AXI-Lite FSM accepted it.
+module xdma_axilite(
+  input clock,
+  input reset,
+
+  output [31:0] awaddr,
+  output        awvalid,
+  input         awready,
+
+  output [31:0] wdata,
+  output [3:0]  wstrb,
+  output        wvalid,
+  input         wready,
+
+  input  [1:0]  bresp,
+  input         bvalid,
+  output        bready,
+
+  output [31:0] araddr,
+  output        arvalid,
+  input         arready,
+
+  input  [31:0] rdata,
+  input  [1:0]  rresp,
+  input         rvalid,
+  output        rready
+);
+
+import "DPI-C" context function void v_xdma_axilite_set_scope();
+
+localparam [1:0] AXIL_IDLE = 2'd0;
+localparam [1:0] AXIL_WRITE = 2'd1;
+localparam [1:0] AXIL_RESP = 2'd2;
+
+reg [1:0]  state;
+reg [31:0] cmd_addr;
+reg [31:0] cmd_data;
+reg [3:0]  cmd_strb;
+reg        cmd_request;
+reg        cmd_ack;
+reg [31:0] pending_addr;
+reg [31:0] pending_data;
+reg [3:0]  pending_strb;
+reg        awvalid_r;
+reg        wvalid_r;
+reg        bready_r;
+
+assign awaddr = cmd_addr;
+assign awvalid = awvalid_r;
+assign wdata = cmd_data;
+assign wstrb = cmd_strb;
+assign wvalid = wvalid_r;
+assign bready = bready_r;
+
+assign araddr = 32'h0;
+assign arvalid = 1'b0;
+assign rready = 1'b1;
+
+/* verilator lint_off UNUSED */
+wire [1:0]  unused_bresp = bresp;
+wire        unused_arready = arready;
+wire [31:0] unused_rdata = rdata;
+wire [1:0]  unused_rresp = rresp;
+wire        unused_rvalid = rvalid;
+/* verilator lint_on UNUSED */
+
+initial begin
+  state = AXIL_IDLE;
+  cmd_addr = 32'h0;
+  cmd_data = 32'h0;
+  cmd_strb = 4'h0;
+  cmd_request = 1'b0;
+  cmd_ack = 1'b0;
+  pending_addr = 32'h0;
+  pending_data = 32'h0;
+  pending_strb = 4'h0;
+  awvalid_r = 1'b0;
+  wvalid_r = 1'b0;
+  bready_r = 1'b0;
+  v_xdma_axilite_set_scope();
+end
+
+export "DPI-C" task v_xdma_axilite_write;
+task v_xdma_axilite_write(
+  input int unsigned addr,
+  input int unsigned data,
+  input byte unsigned strb,
+  output byte unsigned accepted
+);
+begin
+  if (!reset && (cmd_request == cmd_ack)) begin
+    pending_addr = addr;
+    pending_data = data;
+    pending_strb = strb[3:0];
+    cmd_request = ~cmd_request;
+    accepted = 8'd1;
+  end
+  else begin
+    accepted = 8'd0;
+  end
+end
+endtask
+
+always @(posedge clock) begin
+  if (reset) begin
+    state <= AXIL_IDLE;
+    cmd_addr <= 32'h0;
+    cmd_data <= 32'h0;
+    cmd_strb <= 4'h0;
+    awvalid_r <= 1'b0;
+    wvalid_r <= 1'b0;
+    bready_r <= 1'b0;
+    cmd_ack <= cmd_request;
+  end
+  else begin
+    case (state)
+      AXIL_IDLE: begin
+        awvalid_r <= 1'b0;
+        wvalid_r <= 1'b0;
+        bready_r <= 1'b0;
+        if (cmd_request != cmd_ack) begin
+          cmd_addr <= pending_addr;
+          cmd_data <= pending_data;
+          cmd_strb <= pending_strb;
+          cmd_ack <= cmd_request;
+          awvalid_r <= 1'b1;
+          wvalid_r <= 1'b1;
+          state <= AXIL_WRITE;
+        end
+      end
+      AXIL_WRITE: begin
+        if (awvalid_r && awready) begin
+          awvalid_r <= 1'b0;
+        end
+        if (wvalid_r && wready) begin
+          wvalid_r <= 1'b0;
+        end
+        if ((!awvalid_r || awready) && (!wvalid_r || wready)) begin
+          bready_r <= 1'b1;
+          state <= AXIL_RESP;
+        end
+      end
+      AXIL_RESP: begin
+        if (bvalid) begin
+          bready_r <= 1'b0;
+          state <= AXIL_IDLE;
+        end
+      end
+      default: begin
+        state <= AXIL_IDLE;
+      end
+    endcase
+  end
+end
+
+endmodule

--- a/src/test/vsrc/fpga_sim/xdma_wrapper.v
+++ b/src/test/vsrc/fpga_sim/xdma_wrapper.v
@@ -1,0 +1,86 @@
+/***************************************************************************************
+* Copyright (c) 2025-2026 Beijing Institute of Open Source Chip (BOSC)
+* Copyright (c) 2020-2026 Institute of Computing Technology, Chinese Academy of Sciences
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+`include "DifftestMacros.svh"
+
+// FPGA_SIM software XDMA IP model.
+//
+// Each XDMA-facing bus is represented by a small Verilog/DPI wrapper:
+//   - C2H AXI-Stream writes DiffTest packets into shared memory.
+//   - AXI4-Lite replays fpga-host BAR writes into the Chisel ConfigBar.
+//
+// H2C/DDRs are intentionally not modeled here; BOARD=sim keeps RAM/MMIO inside
+// SimTop and the workload still enters through the existing simv +workload path.
+module xdma_wrapper(
+  input pcie_clock,
+  input axilite_clock,
+  input reset,
+
+  input [511:0] axi_c2h_tdata,
+  input         axi_c2h_tlast,
+  output        axi_c2h_tready,
+  input         axi_c2h_tvalid,
+
+  output [31:0] cfg_awaddr,
+  output        cfg_awvalid,
+  input         cfg_awready,
+  output [31:0] cfg_wdata,
+  output [3:0]  cfg_wstrb,
+  output        cfg_wvalid,
+  input         cfg_wready,
+  input  [1:0]  cfg_bresp,
+  input         cfg_bvalid,
+  output        cfg_bready,
+  output [31:0] cfg_araddr,
+  output        cfg_arvalid,
+  input         cfg_arready,
+  input  [31:0] cfg_rdata,
+  input  [1:0]  cfg_rresp,
+  input         cfg_rvalid,
+  output        cfg_rready
+);
+
+xdma_axi_c2h xdma_c2h(
+  .clock(pcie_clock),
+  .reset(reset),
+  .axi_tdata(axi_c2h_tdata),
+  .axi_tlast(axi_c2h_tlast),
+  .axi_tready(axi_c2h_tready),
+  .axi_tvalid(axi_c2h_tvalid)
+);
+
+xdma_axilite xdma_cfg(
+  .clock(axilite_clock),
+  .reset(reset),
+  .awaddr(cfg_awaddr),
+  .awvalid(cfg_awvalid),
+  .awready(cfg_awready),
+  .wdata(cfg_wdata),
+  .wstrb(cfg_wstrb),
+  .wvalid(cfg_wvalid),
+  .wready(cfg_wready),
+  .bresp(cfg_bresp),
+  .bvalid(cfg_bvalid),
+  .bready(cfg_bready),
+  .araddr(cfg_araddr),
+  .arvalid(cfg_arvalid),
+  .arready(cfg_arready),
+  .rdata(cfg_rdata),
+  .rresp(cfg_rresp),
+  .rvalid(cfg_rvalid),
+  .rready(cfg_rready)
+);
+
+endmodule

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -131,19 +131,57 @@ wire sim_clock;
   wire c2h_axi_tready;
   wire c2h_axi_tvalid;
   wire [511:0] c2h_axi_tdata;
+  wire [31:0] cfg_awaddr;
+  wire        cfg_awvalid;
+  wire        cfg_awready;
+  wire [31:0] cfg_wdata;
+  wire [3:0]  cfg_wstrb;
+  wire        cfg_wvalid;
+  wire        cfg_wready;
+  wire [1:0]  cfg_bresp;
+  wire        cfg_bvalid;
+  wire        cfg_bready;
+  wire [31:0] cfg_araddr;
+  wire        cfg_arvalid;
+  wire        cfg_arready;
+  wire [31:0] cfg_rdata;
+  wire [1:0]  cfg_rresp;
+  wire        cfg_rvalid;
+  wire        cfg_rready;
+  wire        host_ctrl_reset;
+  wire        host_ctrl_diff_enable;
+  wire        host_ctrl_ila_trigger;
 
   assign difftest_pcie_clock = clock;
-xdma_axi xaxi(
-  .clock(difftest_pcie_clock),
-  .reset(reset),
-  .axi_tdata(c2h_axi_tdata),
-  .axi_tlast(c2h_axi_tlast),
-  .axi_tready(c2h_axi_tready),
-  .axi_tvalid(c2h_axi_tvalid)
-);
 xdma_clock xclk(
   .clock(difftest_pcie_clock),
   .clock_out(sim_clock)
+);
+xdma_wrapper xdma(
+  .pcie_clock(difftest_pcie_clock),
+  .axilite_clock(sim_clock),
+  .reset(reset),
+  .axi_c2h_tdata(c2h_axi_tdata),
+  .axi_c2h_tlast(c2h_axi_tlast),
+  .axi_c2h_tready(c2h_axi_tready),
+  .axi_c2h_tvalid(c2h_axi_tvalid),
+  .cfg_awaddr(cfg_awaddr),
+  .cfg_awvalid(cfg_awvalid),
+  .cfg_awready(cfg_awready),
+  .cfg_wdata(cfg_wdata),
+  .cfg_wstrb(cfg_wstrb),
+  .cfg_wvalid(cfg_wvalid),
+  .cfg_wready(cfg_wready),
+  .cfg_bresp(cfg_bresp),
+  .cfg_bvalid(cfg_bvalid),
+  .cfg_bready(cfg_bready),
+  .cfg_araddr(cfg_araddr),
+  .cfg_arvalid(cfg_arvalid),
+  .cfg_arready(cfg_arready),
+  .cfg_rdata(cfg_rdata),
+  .cfg_rresp(cfg_rresp),
+  .cfg_rvalid(cfg_rvalid),
+  .cfg_rready(cfg_rready)
 );
 `else
   assign sim_clock = clock;
@@ -166,10 +204,31 @@ SimTop sim(
   .reset(reset),
 `ifdef FPGA_SIM
   .difftest_pcie_clock(difftest_pcie_clock),
+  .difftest_ref_reset(reset),
+  .difftest_hostCtrl_reset(host_ctrl_reset),
+  .difftest_hostCtrl_diffEnable(host_ctrl_diff_enable),
+  .difftest_hostCtrl_ilaTrigger(host_ctrl_ila_trigger),
   .difftest_to_host_axis_valid(c2h_axi_tvalid),
   .difftest_to_host_axis_ready(c2h_axi_tready),
   .difftest_to_host_axis_bits_data(c2h_axi_tdata),
   .difftest_to_host_axis_bits_last(c2h_axi_tlast),
+  .difftest_cfg_axilite_awvalid(cfg_awvalid),
+  .difftest_cfg_axilite_awaddr(cfg_awaddr),
+  .difftest_cfg_axilite_awready(cfg_awready),
+  .difftest_cfg_axilite_wvalid(cfg_wvalid),
+  .difftest_cfg_axilite_wdata(cfg_wdata),
+  .difftest_cfg_axilite_wstrb(cfg_wstrb),
+  .difftest_cfg_axilite_wready(cfg_wready),
+  .difftest_cfg_axilite_bvalid(cfg_bvalid),
+  .difftest_cfg_axilite_bresp(cfg_bresp),
+  .difftest_cfg_axilite_bready(cfg_bready),
+  .difftest_cfg_axilite_arvalid(cfg_arvalid),
+  .difftest_cfg_axilite_araddr(cfg_araddr),
+  .difftest_cfg_axilite_arready(cfg_arready),
+  .difftest_cfg_axilite_rvalid(cfg_rvalid),
+  .difftest_cfg_axilite_rdata(cfg_rdata),
+  .difftest_cfg_axilite_rresp(cfg_rresp),
+  .difftest_cfg_axilite_rready(cfg_rready),
 `endif // FPGA_SIM
 `ifdef CONFIG_DIFFTEST_CLOCKGATE
   .difftest_ref_clock(sim_clock),


### PR DESCRIPTION
XDMA config BAR is moved into Difftest Chisel so FPGA_SIM and FPGA
share the same host control registers. SimTop now exposes a standard
AXI4-Lite config port and keeps the host/XDMA control path on a global
reset, avoid being cleared while restarting DUT.

XDMA AXI-Lite in fpga_sim with software thread instead of a per-cycle
DPI poll. The thread will listen to shared memory to get cmd from
fpga_host, and call a extern DPIC task to convert cmd to axi-lite,
and write to configBar with standard axi-lite.

Co-authored-by: Kami <fengkehan@bosc.ac.cn>