### PR TITLE
refactor(Batch): stream chunk-aligned payload beats

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,13 +163,6 @@ jobs:
             ./build/emu -i microbench.bin --diff $REF_SO --as-footprints
             make clean
 
-      - name: Difftest with Batch
-        run: |
-            cd $NOOP_HOME
-            make emu MILL_ARGS="--difftest-config B" -j2
-            ./build/emu -i $WORKLOAD --diff $REF_SO
-            make clean
-
       - name: Difftest with Global DPI-C Enable
         run: |
             cd $NOOP_HOME
@@ -184,17 +177,10 @@ jobs:
             ./build/emu -i $WORKLOAD --diff $REF_SO
             make clean
 
-      - name: Difftest with Squash Batch and Global Enable
+      - name: Difftest with Squash GlobalEnable and Query
         run: |
             cd $NOOP_HOME
-            make emu MILL_ARGS="--difftest-config ESB" -j2
-            ./build/emu -i $WORKLOAD --diff $REF_SO
-            make clean
-
-      - name: Difftest with Squash Batch GlobalEnable and Query
-        run: |
-            cd $NOOP_HOME
-            make emu MILL_ARGS="--difftest-config ESB" DIFFTEST_QUERY=1 -j2
+            make emu MILL_ARGS="--difftest-config ES" DIFFTEST_QUERY=1 -j2
             ./build/emu -i $WORKLOAD --diff $REF_SO
             make clean
 

--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -19,7 +19,6 @@ import chisel3._
 import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
-import difftest.common.DifftestPerf
 import difftest.util.{LookupTree, PipelineConnect}
 
 import scala.collection.mutable.ListBuffer
@@ -28,40 +27,45 @@ import scala.collection.mutable.ListBuffer
 case class BatchParam(config: GatewayConfig, bundles: Seq[DifftestBundle]) {
   val infoWidth = (new BatchInfo).getWidth
   val infoByte = infoWidth / 8 // byteAligned by default
+  val ChunkByteLen = config.batchChunkBytes
+  val ChunkBitLen = ChunkByteLen * 8
+  val BeatChunkSize = config.batchBeatChunks
+  val BeatByteLen = BeatChunkSize * ChunkByteLen
+  val BeatBitLen = BeatByteLen * 8
 
-  // Maximum Byte length decided by transmission function
-  val MaxDataByteLen = config.batchArgByteLen._1
-  val MaxDataBitLen = MaxDataByteLen * 8
-  val MaxInfoByteLen = config.batchArgByteLen._2
-  val MaxInfoBitLen = MaxInfoByteLen * 8
-  val MaxInfoSize = MaxInfoByteLen / infoByte
+  require(BeatChunkSize > 0, s"Batch beat chunk size $BeatChunkSize must be greater than 0")
+  require(isPow2(BeatChunkSize), s"Batch beat chunk size $BeatChunkSize must be a power of 2")
 
-  val StepGroupSize = bundles.groupBy(_.desiredCppName).values.flatMap(_.grouped(8).toSeq).size
-  val StepDataByteLen = bundles.map(_.getByteAlignWidth).map { w => w / 8 }.sum
-  val StepDataBitLen = StepDataByteLen * 8
-  val StepInfoByteLen = (StepGroupSize + 1) * (infoWidth / 8) // Include BatchStep to update buffer index
+  def alignChunkBytes(bytes: Int): Int = ((bytes + ChunkByteLen - 1) / ChunkByteLen) * ChunkByteLen
+
+  val ClusterGroups = bundles.groupBy(_.desiredCppName).values.toSeq
+  val StepGroupSize = ClusterGroups.size
+  val ClusterDataByteLen = ClusterGroups
+    .map(group => alignChunkBytes(group.length * group.head.getByteAlignWidth / 8))
+    .toSeq
+  val StepDataByteLen = ClusterDataByteLen.sum
+  // Include BatchHead and BatchStep.
+  val StepInfoSize = StepGroupSize + 2
+  val StepInfoRawByteLen = StepInfoSize * infoByte
+  val StepInfoByteLen = alignChunkBytes(StepInfoRawByteLen)
   val StepInfoBitLen = StepInfoByteLen * 8
+  val StepInfoChunks = StepInfoByteLen / ChunkByteLen
 
-  // Width of statistic for data/info byte length
-  val StatsDataWidth = log2Ceil(math.max(MaxDataByteLen, StepDataByteLen))
-  val StatsInfoWidth = log2Ceil(math.max(MaxInfoSize, StepGroupSize + 1))
-
-  // Truncate width when shifting to reduce useless gates
-  val TruncDataBitLen = math.min(MaxDataBitLen, StepDataBitLen)
-}
-
-class BatchIO(param: BatchParam) extends Bundle {
-  val data = UInt(param.MaxDataBitLen.W)
-  val info = UInt(param.MaxInfoBitLen.W)
+  // Width of statistic for data chunk length
+  val StepDataChunks = StepDataByteLen / ChunkByteLen
+  val StatsDataWidth = math.max(1, log2Ceil(StepDataChunks + 1))
+  val StatsInfoWidth = math.max(1, log2Ceil(StepInfoSize + 1))
 }
 
 class BatchStats(param: BatchParam) extends Bundle {
-  val data_bytes = UInt(param.StatsDataWidth.W)
-  val info_size = UInt(param.StatsInfoWidth.W)
+  val data_chunks = UInt(param.StatsDataWidth.W)
+  val info_cnt = UInt(param.StatsInfoWidth.W)
+  val cluster_data_chunks = UInt(param.StatsDataWidth.W)
+  val cluster_info_cnt = UInt(param.StatsInfoWidth.W)
 }
 
-class BatchOutput(param: BatchParam, config: GatewayConfig) extends Bundle {
-  val io = new BatchIO(param)
+class BatchIO(val param: BatchParam, config: GatewayConfig) extends Bundle {
+  val payload = UInt(param.BeatBitLen.W)
   val step = UInt(config.stepWidth.W)
 }
 
@@ -70,18 +74,10 @@ class BatchInfo extends Bundle {
   val num = UInt(8.W)
 }
 
-class BatchStepResult(param: BatchParam, config: GatewayConfig) extends Bundle {
-  val data = UInt(param.StepDataBitLen.W)
-  val info = UInt(param.StepInfoBitLen.W)
-  // status of step_data_head split in different loc
-  val status = Vec(param.StepGroupSize, new BatchStats(param))
-  val trace_info = Option.when(config.hasReplay)(new DiffTraceInfo(config))
-}
-
 object Batch {
   private val template = ListBuffer.empty[DifftestBundle]
 
-  def apply(bundles: DecoupledIO[MixedVec[Valid[DifftestBundle]]], config: GatewayConfig): DecoupledIO[BatchOutput] = {
+  def apply(bundles: DecoupledIO[MixedVec[Valid[DifftestBundle]]], config: GatewayConfig): DecoupledIO[BatchIO] = {
     template ++= chiselTypeOf(bundles.bits).map(_.bits).distinctBy(_.desiredCppName)
     val module = Module(new BatchEndpoint(chiselTypeOf(bundles.bits).toSeq, config))
     module.in <> bundles
@@ -103,16 +99,14 @@ class BatchEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) 
   val collector = Module(new BatchCollector(bundles, param, config))
   PipelineConnect(in, collector.in, collector.in.fire)
 
-  // Assemble collected data from different cycles
-  val assembler = Module(new BatchAssembler(param, config))
-  assembler.in <> collector.out
-  val out = IO(chiselTypeOf(assembler.out))
-  out <> assembler.out
+  val out = IO(Decoupled(new BatchIO(param, config)))
+  out <> collector.out
 }
 
 // Cluster Data from same group in same cycle
 class BatchCluster(bundleType: DifftestBundle, groupSize: Int, param: BatchParam) extends Module {
   val alignWidth = bundleType.getByteAlignWidth
+  val elemBytes = alignWidth / 8
   val in = IO(Input(Vec(groupSize, Valid(bundleType))))
   val out_data = IO(Output(UInt((groupSize * alignWidth).W)))
   val out_info = IO(Output(UInt(param.infoWidth.W)))
@@ -138,26 +132,41 @@ class BatchCluster(bundleType: DifftestBundle, groupSize: Int, param: BatchParam
   info.num := v_size
   out_info := Mux(v_size =/= 0.U, info.asUInt, 0.U)
 
-  val bytes_map = Seq.tabulate(groupSize + 1) { vi => (vi.U, (alignWidth / 8 * vi).U) }
-  status_sum.data_bytes := status_base.data_bytes +& LookupTree(v_size, bytes_map)
-  status_sum.info_size := status_base.info_size +& Mux(v_size =/= 0.U, 1.U, 0.U)
+  val chunks_map = Seq.tabulate(groupSize + 1) { vi =>
+    (vi.U, (param.alignChunkBytes(elemBytes * vi) / param.ChunkByteLen).U)
+  }
+  val cluster_data_chunks = LookupTree(v_size, chunks_map)
+  val cluster_info_cnt = Mux(v_size =/= 0.U, 1.U, 0.U)
+  status_sum.data_chunks := status_base.data_chunks +& cluster_data_chunks
+  status_sum.info_cnt := status_base.info_cnt +& cluster_info_cnt
+  status_sum.cluster_data_chunks := cluster_data_chunks
+  status_sum.cluster_info_cnt := cluster_info_cnt
 }
 
 // Collect Data from different group in same cycle
 class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, config: GatewayConfig) extends Module {
   val in = IO(Flipped(Decoupled(MixedVec(bundles))))
-  val out = IO(Decoupled(new BatchStepResult(param, config)))
+  val out = IO(Decoupled(new BatchIO(param, config)))
 
-  def getGroupDataWidth: Seq[Valid[DifftestBundle]] => Int = { group =>
+  def getGroupDataWidth(group: Seq[Valid[DifftestBundle]]): Int =
     group.length * group.head.bits.getByteAlignWidth
+
+  def getGroupDataChunks(group: Seq[Valid[DifftestBundle]]): Int = {
+    val bytes = group.length * group.head.bits.getByteAlignWidth / 8
+    param.alignChunkBytes(bytes) / param.ChunkByteLen
   }
 
   val in_group = in.bits.groupBy(_.bits.desiredCppName).values
   val in_group_single = in_group.filter(_.size == 1).toSeq
-  val in_group_multi = in_group.filterNot(_.size == 1).flatMap(_.grouped(8)).toSeq
+  val in_group_multi = in_group.filterNot(_.size == 1).toSeq
   val sorted = in_group_single.sortBy(getGroupDataWidth).reverse ++ in_group_multi.sortBy(getGroupDataWidth)
+  val clusterMaxDataChunks = sorted.map(getGroupDataChunks)
+  val stepMaxDataChunks = clusterMaxDataChunks.sum
+  val stepMaxPayloadChunks = param.StepInfoChunks + stepMaxDataChunks
+  val stepMaxPayloadBeats = (stepMaxPayloadChunks + param.BeatChunkSize - 1) / param.BeatChunkSize
+  require(stepMaxPayloadChunks <= 255, s"BatchStep.num only has 8 bits, but max batch chunks is $stepMaxPayloadChunks")
 
-  // Stage 1: concat bundles with same desiredCppName
+  // Stage 1: compact valid bundles inside each cluster and collect per-cluster stats.
   class GroupBundle extends Bundle {
     val data = MixedVec(sorted.map(getGroupDataWidth).map(group_w => UInt(group_w.W)))
     val info = Vec(param.StepGroupSize, UInt(param.infoWidth.W))
@@ -181,247 +190,157 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, con
     grouped.bits.status(gid) := cluster.status_sum
   }
 
-  // Stage 2: delay grouped data, concat different group
+  // Stage 2: build the chunk-aligned step payload from info and cluster data.
+  // This pipeline register is held while Batch scans the payload beats.
   val delay_grouped = Wire(Decoupled(new GroupBundle))
   PipelineConnect(grouped, delay_grouped, delay_grouped.fire)
-  delay_grouped.ready := out.ready
 
   val delay_group_data = delay_grouped.bits.data
   val delay_group_info = delay_grouped.bits.info
   val delay_group_status = delay_grouped.bits.status
-  val info_num = delay_group_status.last.info_size
+  val info_num = delay_group_status.last.info_cnt
+
+  val cluster_chunk_count = delay_group_status.map(_.cluster_data_chunks)
+
+  val BatchHead = Wire(new BatchInfo)
+  BatchHead.id := Batch.getTemplate.length.U
+  BatchHead.num := info_num
   val BatchStep = Wire(new BatchInfo)
-  BatchStep.id := Batch.getTemplate.length.U
-  BatchStep.num := info_num // unused, only for debugging
+  BatchStep.id := (Batch.getTemplate.length + 1).U
 
-  out.valid := delay_grouped.valid && info_num =/= 0.U
-  // append BatchStep to last step_status
-  out.bits.status := delay_group_status
-  out.bits.status.last.info_size := delay_group_status.last.info_size + 1.U
-
-  val toCat_data = delay_group_data.take(in_group_single.size).reverse
-  val toCat_info = delay_group_info.take(in_group_single.size).reverse
-  val res_single = Wire(MixedVec(Seq.tabulate(in_group_single.size) { idx =>
-    val width = toCat_data.take(idx + 1).map(_.getWidth).sum
-    UInt(width.W)
-  }))
-  res_single(0) := toCat_data(0)
-  (1 until in_group_single.size).foreach { idx =>
-    val base = res_single(idx - 1)
-    res_single(idx) := Mux(toCat_info(idx) =/= 0.U, Cat(base, toCat_data(idx)), base)
-  }
-  // Collect data by shifter
-  val res_multi = if (in_group_multi.size != 0) {
-    MixedVecInit(
-      delay_group_data.zipWithIndex
-        .drop(in_group_single.size)
-        .map { case (gen, idx) =>
-          val maxWidth = delay_group_data.take(idx).map(_.getWidth).sum
-          // Truncate width of offset to reduce useless gates
-          val offset = Wire(UInt(log2Ceil(maxWidth + 1).W))
-          if (idx == 0) {
-            offset := 0.U
-          } else {
-            offset := delay_group_status(idx - 1).data_bytes << 3
-          }
-          (gen << offset).asUInt
-        }
-        .toSeq
-    ).reduce(_ | _)
-  } else {
-    0.U
-  }
-  out.bits.data := res_single.last | res_multi
-
-  // Collect info from tail, collect(i) include last 0~i
+  // Collect info as BatchHead, valid bundle infos, BatchStep.
+  // C++ scans BatchInfo from low bits to high bits, so append BatchHead at the
+  // lowest bits and keep BatchStep after the compacted bundle infos.
   val toCollect_info = delay_group_info.reverse
   val info_res = Wire(MixedVec(Seq.tabulate(param.StepGroupSize) { idx => UInt(((idx + 2) * param.infoWidth).W) }))
   Seq.tabulate(param.StepGroupSize) { idx =>
     val info_base = if (idx == 0) BatchStep.asUInt else info_res(idx - 1)
     info_res(idx) := Mux(toCollect_info(idx) =/= 0.U, Cat(info_base, toCollect_info(idx)), info_base)
   }
-  out.bits.info := info_res.last
-  out.bits.trace_info.foreach(_ := delay_grouped.bits.trace_info.get)
-}
+  val info_raw = Cat(info_res.last, BatchHead.asUInt)
+  val info_chunks = info_raw.pad(param.StepInfoBitLen).asTypeOf(Vec(param.StepInfoChunks, UInt(param.ChunkBitLen.W)))
+  val info_chunk_count_map = Seq.tabulate(param.StepInfoSize + 1) { size =>
+    val infoBytes = param.alignChunkBytes(size * param.infoByte)
+    (size.U, (infoBytes / param.ChunkByteLen).U)
+  }
+  val info_chunk_count = LookupTree(info_num + 2.U, info_chunk_count_map)
 
-// Assemble step_data from different cycles
-class BatchAssembler(
-  param: BatchParam,
-  config: GatewayConfig,
-) extends Module {
-  val in = IO(Flipped(Decoupled(new BatchStepResult(param, config))))
-  val out = IO(Decoupled(new BatchOutput(param, config)))
+  val payload_chunks = Wire(Vec(stepMaxPayloadChunks, UInt(param.ChunkBitLen.W)))
+  val payload_chunk_valid = Wire(Vec(stepMaxPayloadChunks, Bool()))
+  payload_chunks.foreach(_ := 0.U)
+  payload_chunk_valid.foreach(_ := false.B)
 
-  val state_data = RegInit(0.U(param.MaxDataBitLen.W))
-  val state_info = RegInit(0.U(param.MaxInfoBitLen.W))
-  val state_status = RegInit(0.U.asTypeOf(new BatchStats(param)))
-  val state_step_cnt = RegInit(0.U(config.stepWidth.W))
-  val state_trace_size = Option.when(config.hasReplay)(RegInit(0.U(config.replayWidth.W)))
-
-  // Assemble step data/info into state in 3 stage
-  // Stage 1:
-  //   1. RegNext signal from BatchCollector to cut of combination logic path
-  //   1. data/info_exceed_vec: mark whether different length fragments of step data/info exceed available space
-  //   2. concat/remain_stats: record statistic for data/info to be concatenated to output or remained to state
-  val delay_step = Wire(Decoupled(new BatchStepResult(param, config)))
-  PipelineConnect(in, delay_step, delay_step.fire)
-  val want_tick = Wire(Bool())
-  delay_step.ready := out.ready
-  val delay_step_data = delay_step.bits.data
-  val delay_step_info = delay_step.bits.info
-  val delay_step_status = delay_step.bits.status
-  val delay_step_enable = delay_step.valid
-  val delay_step_trace_info = delay_step.bits.trace_info
-  val data_bytes_avail = param.MaxDataByteLen.U -& state_status.data_bytes
-  // Always leave space for BatchFinish, use MaxInfoSize - 1
-  val info_size_avail = (param.MaxInfoSize - 1).U -& state_status.info_size
-  val data_exceed = Wire(Bool())
-  val info_exceed = Wire(Bool())
-  val append_data = Wire(UInt(param.TruncDataBitLen.W))
-  val append_info = Wire(UInt(param.StepInfoBitLen.W))
-  val finish_step = Wire(UInt(config.stepWidth.W))
-  val next_state_step_cnt = Wire(UInt(config.stepWidth.W))
-  val next_state_data = Wire(UInt(param.MaxDataBitLen.W))
-  val next_state_info = Wire(UInt(param.MaxInfoBitLen.W))
-  val next_state_stats = Wire(new BatchStats(param))
-
-  val BatchFinish = Wire(new BatchInfo)
-  BatchFinish.id := (Batch.getTemplate.length + 1).U
-  BatchFinish.num := finish_step
-
-  val step_exceed = delay_step_enable && (state_step_cnt === config.batchSize.U)
-  val cont_exceed = data_exceed || info_exceed
-  val state_flush = in.valid && in.bits.status.last.data_bytes >= param.MaxDataByteLen.U // use Stage 1 bytes to flush ahead
-
-  if (config.batchSplit) {
-    val data_exceed_v = VecInit(delay_step_status.map(_.data_bytes > data_bytes_avail && delay_step_enable))
-    val info_exceed_v = VecInit(delay_step_status.map(_.info_size > info_size_avail && delay_step_enable))
-    data_exceed := data_exceed_v.asUInt.orR
-    info_exceed := info_exceed_v.asUInt.orR
-    val exceed_v = VecInit(data_exceed_v.zip(info_exceed_v).map { case (de, ie) => de | ie })
-
-    // Extract last non-exceed stats
-    // When no stats exceeds, return step_stats to append whole step for state flushing
-    val concat_mask = VecInit.tabulate(param.StepGroupSize - 1) { idx => exceed_v(idx) ^ exceed_v(idx + 1) }
-    val concat_stats = Mux(
-      !exceed_v.asUInt.orR,
-      delay_step_status.last,
-      VecInit(delay_step_status.dropRight(1).zip(concat_mask).map { case (stats, mask) =>
-        Mux(mask, stats.asUInt, 0.U)
-      }).reduceTree(_ | _).asTypeOf(new BatchStats(param)),
-    )
-    val remain_stats = Wire(new BatchStats(param))
-    remain_stats.data_bytes := delay_step_status.last.data_bytes -& concat_stats.data_bytes
-    remain_stats.info_size := delay_step_status.last.info_size -& concat_stats.info_size
-    assert(remain_stats.data_bytes <= param.MaxDataByteLen.U)
-    assert(remain_stats.info_size + 1.U <= param.MaxInfoSize.U)
-
-    // Note we need only lowest bits to update state, truncate high bits to reduce gates
-    val concat_data = (~(~0.U(param.TruncDataBitLen.W) <<
-      (concat_stats.data_bytes << 3).asUInt)).asUInt & delay_step_data
-    val concat_info = (~(~0.U(param.StepInfoBitLen.W) <<
-      (concat_stats.info_size * param.infoWidth.U))).asUInt & delay_step_info
-    val remain_data = (delay_step_data >> (concat_stats.data_bytes << 3).asUInt).asUInt
-    val remain_info = (delay_step_info >> (concat_stats.info_size * param.infoWidth.U)).asUInt
-
-    // Delay step can be partly appended to output for making full use of transmission param
-    // Avoid appending when step equals batchSize(delay_step_exceed), last appended data will overwrite first step data
-    val has_append = delay_step_enable && (state_flush || cont_exceed) && !exceed_v.asUInt.andR && !step_exceed
-    // When the whole step is appended to output, state_step should be 0, and output step + 1
-    val append_whole = has_append && !cont_exceed
-    finish_step := state_step_cnt + Mux(append_whole, 1.U, 0.U)
-
-    append_data := Mux(has_append, concat_data(param.TruncDataBitLen - 1, 0), 0.U)
-    val append_finish_map = Seq.tabulate(param.StepGroupSize + 2) { g =>
-      (g.U, (BatchFinish.asUInt << (g * param.infoWidth)).asUInt)
+  Seq.tabulate(param.StepInfoChunks) { idx =>
+    payload_chunks(idx) := info_chunks(idx)
+    payload_chunk_valid(idx) := idx.U < info_chunk_count
+  }
+  var payloadOffset = param.StepInfoChunks
+  delay_group_data.zip(clusterMaxDataChunks).zipWithIndex.foreach { case ((data, chunks), groupIdx) =>
+    val data_chunks = data.pad(chunks * param.ChunkBitLen).asTypeOf(Vec(chunks, UInt(param.ChunkBitLen.W)))
+    Seq.tabulate(chunks) { chunkIdx =>
+      payload_chunks(payloadOffset + chunkIdx) := data_chunks(chunkIdx)
+      payload_chunk_valid(payloadOffset + chunkIdx) := chunkIdx.U < cluster_chunk_count(groupIdx)
     }
-    append_info := Mux(
-      has_append,
-      concat_info | LookupTree(concat_stats.info_size, append_finish_map),
-      BatchFinish.asUInt,
-    )
-
-    next_state_step_cnt := Mux(has_append && append_whole, 0.U, 1.U)
-    next_state_data := Mux(has_append, remain_data, delay_step_data)
-    next_state_info := Mux(has_append, remain_info, delay_step_info)
-    next_state_stats.data_bytes := Mux(has_append, remain_stats.data_bytes, delay_step_status.last.data_bytes)
-    next_state_stats.info_size := Mux(has_append, remain_stats.info_size, delay_step_status.last.info_size)
-  } else {
-    data_exceed := delay_step_enable && delay_step_status.last.data_bytes > data_bytes_avail
-    info_exceed := delay_step_enable && delay_step_status.last.info_size > info_size_avail
-    assert(delay_step_status.last.data_bytes <= param.MaxDataByteLen.U)
-    assert(delay_step_status.last.info_size <= param.MaxInfoSize.U)
-
-    finish_step := state_step_cnt
-    append_data := 0.U
-    append_info := BatchFinish.asUInt
-
-    next_state_step_cnt := 1.U
-    next_state_data := delay_step_data
-    next_state_info := delay_step_info
-    next_state_stats.data_bytes := delay_step_status.last.data_bytes
-    next_state_stats.info_size := delay_step_status.last.info_size
+    payloadOffset += chunks
   }
 
-  // Stage 2:
-  // update state
-  val trace_exceed = Option.when(config.hasReplay) {
-    delay_step_enable && (state_trace_size.get +& delay_step_trace_info.get.trace_size >= config.replaySize.U)
-  }
-  val timeout_count = RegInit(0.U(32.W))
-  val timeout = timeout_count === 200000.U
-  if (config.hasBuiltInPerf) {
-    DifftestPerf("BatchExceed_data", data_exceed)
-    DifftestPerf("BatchExceed_info", info_exceed)
-    DifftestPerf("BatchExceed_step", step_exceed.asUInt)
-    DifftestPerf("BatchExceed_flush", state_flush.asUInt)
-    DifftestPerf("BatchExceed_timeout", timeout.asUInt)
-    if (config.hasReplay) DifftestPerf("BatchExceed_trace", trace_exceed.get.asUInt)
-  }
-  val in_replay = Option.when(config.hasReplay)(delay_step.bits.trace_info.get.in_replay)
+  val payload_chunk_count = info_chunk_count +& cluster_chunk_count.reduce(_ +& _)
+  BatchStep.num := payload_chunk_count.pad(8)(7, 0)
 
-  want_tick := timeout || state_flush || cont_exceed || step_exceed ||
-    trace_exceed.getOrElse(false.B) || in_replay.getOrElse(false.B)
-  val should_tick = want_tick && out.ready
-  when(!should_tick) {
-    timeout_count := timeout_count + 1.U
-  }.otherwise {
-    timeout_count := 0.U
+  val payload_beats = payload_chunks.asUInt
+    .pad(stepMaxPayloadBeats * param.BeatBitLen)
+    .asTypeOf(Vec(stepMaxPayloadBeats, Vec(param.BeatChunkSize, UInt(param.ChunkBitLen.W))))
+  val payload_beat_valid = payload_chunk_valid.asUInt
+    .pad(stepMaxPayloadBeats * param.BeatChunkSize)
+    .asTypeOf(Vec(stepMaxPayloadBeats, UInt(param.BeatChunkSize.W)))
+
+  val beatIdxWidth = math.max(1, log2Ceil(stepMaxPayloadBeats))
+  val stateCountWidth = log2Ceil(param.BeatChunkSize + 1)
+  val appendIndexWidth = log2Ceil(param.BeatChunkSize * 2 + 1)
+  val remain_beat_mask = RegInit(0.U(stepMaxPayloadBeats.W))
+  val state_chunks = RegInit(0.U.asTypeOf(Vec(param.BeatChunkSize, UInt(param.ChunkBitLen.W))))
+  val state_count = RegInit(0.U(stateCountWidth.W))
+  val pending_beat = Reg(Vec(param.BeatChunkSize, UInt(param.ChunkBitLen.W)))
+  val pending_valid_mask = RegInit(0.U(param.BeatChunkSize.W))
+  val pending_last = RegInit(false.B)
+  val pending_valid = RegInit(false.B)
+
+  // Stage 3: scan the payload beat bitmap and register one selected beat as pending.
+  // Stage 4: independently merge pending into state and refill pending with the next beat.
+  val pending_count = PopCount(pending_valid_mask)
+  val merged_count = state_count +& pending_count
+  val pending_pos = Wire(Vec(param.BeatChunkSize, UInt(appendIndexWidth.W)))
+  pending_pos(0) := state_count
+  for (pid <- 1 until param.BeatChunkSize) {
+    pending_pos(pid) := pending_pos(pid - 1) + pending_valid_mask(pid - 1).asUInt
   }
+  val merged_chunks = Seq.tabulate(param.BeatChunkSize * 2) { idx =>
+    val stateOpt = Option.when(idx < param.BeatChunkSize)(Mux(idx.U < state_count, state_chunks(idx), 0.U))
+    val choices = stateOpt.toSeq ++ Seq.tabulate(param.BeatChunkSize) { pid =>
+      Mux(pending_valid_mask(pid) && pending_pos(pid) === idx.U, pending_beat(pid), 0.U)
+    }
+    VecInit(choices).reduce(_ | _)
+  }
+  val merged_head_chunks = VecInit(merged_chunks.take(param.BeatChunkSize))
+  val merged_tail_chunks = VecInit(merged_chunks.drop(param.BeatChunkSize))
+  val merge_full = merged_count >= param.BeatChunkSize.U
+  val payload_beat_mask = VecInit(payload_beat_valid.map(_.orR)).asUInt
+  val input_step_valid = delay_grouped.valid && info_num =/= 0.U && payload_beat_mask =/= 0.U
+  val select_beat_mask = Mux(
+    remain_beat_mask === 0.U,
+    Mux(!pending_valid && state_count === 0.U && input_step_valid, payload_beat_mask, 0.U),
+    remain_beat_mask,
+  )
+  val select_beat_idx = PriorityEncoder(select_beat_mask).pad(beatIdxWidth)
+  val select_beat =
+    if (stepMaxPayloadBeats == 1) payload_beats(0) else payload_beats(select_beat_idx)
+  val select_beat_valid =
+    if (stepMaxPayloadBeats == 1) payload_beat_valid(0) else payload_beat_valid(select_beat_idx)
+  val next_remain_beat_mask = select_beat_mask & ~UIntToOH(select_beat_idx, stepMaxPayloadBeats)
+  val state_tick = !pending_valid && select_beat_mask === 0.U && state_count =/= 0.U
+  val merged_tick = pending_valid && (merge_full || pending_last)
+  // A tick means emitting one Batch beat.
+  val should_tick = merged_tick || state_tick
+  val state_update = !should_tick || out.ready
+  val pending_consumed = pending_valid && state_update
+  // Only refill pending in the same cycle when the old pending beat can be
+  // merged into state without waiting for downstream ready. This cuts the
+  // out.ready -> load_pending_beat -> delay_grouped.ready control path.
+  val pending_consumed_without_tick = pending_valid && !should_tick
+  val pending_can_refill = !pending_valid || pending_consumed_without_tick
+  val load_pending_beat = pending_can_refill && select_beat_mask =/= 0.U
+  val next_state_chunks =
+    Mux(merged_tick, merged_tail_chunks.asUInt, merged_head_chunks.asUInt).asTypeOf(state_chunks)
+  val next_state_count = Mux(
+    merged_tick,
+    Mux(merge_full, merged_count - param.BeatChunkSize.U, 0.U),
+    merged_count,
+  )
+  val is_last_step_beat = state_tick || (merged_tick && pending_last && merged_count <= param.BeatChunkSize.U)
 
-  out.bits.io.data := state_data | (append_data << (state_status.data_bytes << 3).asUInt).asUInt
-  out.bits.io.info := state_info | (append_info << (state_status.info_size * param.infoWidth.U)).asUInt
-  out.bits.step := Mux(out.valid, finish_step, 0.U)
-  out.valid := want_tick
-
-  val delay_step_fire = delay_step.fire
-  val state_update = delay_step_fire || (should_tick && !delay_step_enable)
+  // Keep delay_grouped.bits stable while scanning the current step payload.
+  delay_grouped.ready := !input_step_valid || (load_pending_beat && next_remain_beat_mask === 0.U)
+  out.valid := should_tick
+  out.bits.payload := Mux(state_tick, state_chunks.asUInt, merged_head_chunks.asUInt)
+  out.bits.step := Mux(out.valid && is_last_step_beat, 1.U(config.stepWidth.W), 0.U)
 
   when(state_update) {
-    when(delay_step_fire) {
-      when(should_tick) {
-        state_step_cnt := next_state_step_cnt
-        state_data := next_state_data
-        state_info := next_state_info
-        state_status := next_state_stats
-        if (config.hasReplay) state_trace_size.get := delay_step_trace_info.get.trace_size
-      }.otherwise {
-        state_step_cnt := state_step_cnt + 1.U
-        state_data := state_data |
-          (delay_step_data(param.TruncDataBitLen - 1, 0) << (state_status.data_bytes << 3).asUInt).asUInt
-        state_info := state_info |
-          (delay_step_info << (state_status.info_size * param.infoWidth.U)).asUInt
-        state_status.data_bytes := state_status.data_bytes + delay_step_status.last.data_bytes
-        state_status.info_size := state_status.info_size + delay_step_status.last.info_size
-        if (config.hasReplay) state_trace_size.get := state_trace_size.get + delay_step_trace_info.get.trace_size
-      }
-    }.otherwise { // state_flush without new-coming step
-      state_step_cnt := 0.U
-      state_data := 0.U
-      state_info := 0.U
-      state_status.data_bytes := 0.U
-      state_status.info_size := 0.U
-      if (config.hasReplay) state_trace_size.get := 0.U
+    when(pending_valid) {
+      state_chunks := next_state_chunks
+      state_count := next_state_count(stateCountWidth - 1, 0)
+    }.elsewhen(state_tick) {
+      state_chunks := 0.U.asTypeOf(state_chunks)
+      state_count := 0.U
     }
+  }
+
+  when(load_pending_beat) {
+    remain_beat_mask := next_remain_beat_mask
+    pending_beat := select_beat
+    pending_valid_mask := select_beat_valid
+    pending_last := next_remain_beat_mask === 0.U
+    pending_valid := true.B
+  }.elsewhen(pending_consumed) {
+    pending_valid := false.B
   }
 }

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -21,7 +21,7 @@ import chisel3.reflect.DataMirror
 import chisel3.util._
 import difftest._
 import difftest.DifftestModule.createCppExtModule
-import difftest.batch.{BatchInfo, BatchIO}
+import difftest.batch.{Batch, BatchIO, BatchParam}
 import difftest.common.FileControl
 import difftest.delta.Delta
 import difftest.gateway.{GatewayConfig, GatewayResult, GatewaySinkControl}
@@ -96,6 +96,12 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
     }
     val index = if (gen.isIndexed) s"[${prefix}index]" else if (gen.isFlatten) s"[${prefix}address]" else ""
     s"auto packet = &($packet$index);"
+  }
+  def indentCppBlock(code: String, indent: Int): String = {
+    val prefix = " " * indent
+    code.linesIterator.map { line =>
+      if (line.isEmpty || line.startsWith("#")) line else s"$prefix$line"
+    }.mkString("\n")
   }
   def dpicFuncAssigns: Seq[String]
   def perfCnt: String = {
@@ -225,9 +231,9 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig) extends DPICBase(
 }
 
 class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: GatewayConfig) extends DPICBase(config) {
-  val io = IO(Input(UInt(batchIO.getWidth.W)))
+  val io = IO(Input(UInt(batchIO.payload.getWidth.W)))
 
-  def getDPICBundleUnpack(gen: DifftestBundle): String = {
+  def getDPICBundleUnpack(gen: DifftestBundle, source: String): String = {
     val unpack = ListBuffer.empty[String]
     // Note: locating elems will not in struct defined, but at the end of reordered Bundle
     val (elem_names, elem_bytes) = gen.getByteAlignElems.map { case (name, data) => (name, data.getWidth / 8) }.unzip
@@ -235,7 +241,7 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
       if (Seq("coreid", "index", "address").contains(name)) {
         val offset = elem_bytes.take(idx).sum
         val typeStr = s"uint${elem_bytes(idx) * 8}_t"
-        unpack += s"$name = *(($typeStr*)(data + $offset));"
+        unpack += s"$name = *(($typeStr*)($source + $offset));"
       }
     }
     unpack += getPacketDecl(gen, "", config)
@@ -244,111 +250,115 @@ class DPICBatch(template: Seq[DifftestBundle], batchIO: BatchIO, config: Gateway
     } else {
       s"sizeof(${gen.desiredModuleName})"
     }
-    unpack += s"memcpy(packet, data, $size);"
-    unpack += s"data += ${elem_bytes.sum};"
+    unpack += s"memcpy(packet, $source, $size);"
     if (config.isDelta && gen.isDeltaElem) {
       unpack += "dStats->hasProgress = true;"
     }
-    unpack +=
-      s"""
-         |#ifdef CONFIG_DIFFTEST_QUERY
-         |        ${Query.writeInvoke(gen)}
-         |#endif // CONFIG_DIFFTEST_QUERY
-         |""".stripMargin
-    unpack.toSeq.mkString("\n        ")
+    unpack += "#ifdef CONFIG_DIFFTEST_QUERY"
+    unpack += Query.writeInvoke(gen)
+    unpack += "#endif // CONFIG_DIFFTEST_QUERY"
+    unpack.toSeq.mkString("\n")
   }
 
   override def modPorts = super.modPorts ++ Seq(Seq(("io", io)))
 
   override def desiredName: String = "DiffExtBatch"
   override def dpicFuncAssigns: Seq[String] = {
-    val bundleEnum = template.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchStep", "BatchFinish")
+    val bundleEnum = template.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchHead", "BatchStep")
+    def elemSizeExpr(gen: DifftestBundle): String = {
+      val packetSize = if (config.isDelta && gen.isDeltaElem) {
+        s"sizeof(uint${gen.deltaElemWidth}_t)"
+      } else {
+        s"sizeof(${gen.desiredModuleName})"
+      }
+      val locatorBytes = gen.getByteAlignElems.collect {
+        case (name, data) if Seq("coreid", "index", "address").contains(name) => data.getWidth / 8
+      }.sum
+      if (locatorBytes == 0) packetSize else s"($packetSize + $locatorBytes)"
+    }
     val bundleAssign = template.zipWithIndex.map { case (t, idx) =>
       val bundleName = bundleEnum(idx)
       val perfName = "perf_Batch_" + bundleName
-      s"""
-         |    else if (id == $bundleName) {
+      val elemSize = elemSizeExpr(t)
+      s"""    else if (id == $bundleName) {
+         |      if (!parser.recv_cluster(chunk_payload, num, $elemSize)) continue;
          |#ifdef CONFIG_DIFFTEST_PERFCNT
          |      dpic_calls[$perfName] += num;
-         |      dpic_bytes[$perfName] += num * ${t.getByteAlignWidth / 8};
+         |      dpic_bytes[$perfName] += num * $elemSize;
          |#endif // CONFIG_DIFFTEST_PERFCNT
+         |      uint8_t* data = parser.cluster_buf();
          |      for (int j = 0; j < num; j++) {
-         |        ${getDPICBundleUnpack(t)}
+         |${indentCppBlock(getDPICBundleUnpack(t, "data"), 8)}
+         |        data += $elemSize;
          |      }
+         |      parser.finish_cluster();
          |    }
         """.stripMargin
-    }.mkString("")
+    }.mkString("\n")
 
-    def parse(gen: BatchIO): (String, Int) = {
-      val info = new BatchInfo
-      val infoLen = gen.info.getWidth / info.getWidth
-      val structDecl =
-        s"""
-           |  typedef struct {
-           |    ${info.elements.toSeq.map { case (name, data) => getDPICArgString(name, data, true, false) }
-            .mkString(";\n    ")};
-           |  } BatchInfo;
-           |  typedef struct {
-           |    ${gen.elements.toSeq.map { case (name, data) =>
-            if (name == "info") s"BatchInfo info[$infoLen]" else getDPICArgString(name, data, true, false)
-          }.mkString(";\n    ")};
-           |  } BatchPack;
-           |  BatchPack* batch = (BatchPack*)io;
-           |  BatchInfo* info = batch->info;
-           |  uint8_t* data = batch->data;
-           |""".stripMargin
-      (structDecl, infoLen)
-    }
-    val (batchDecl, infoLen) = parse(batchIO)
     val stepPending = if (config.isDelta) {
       """
-        |      if (dStats->need_pending())
-        |        continue; // Not changing dut_index
+        |      if (dStats->need_pending()) {
+        |        return; // Not changing dut_index
+        |      }
         |      dStats->sync(0, dut_index);
         |""".stripMargin
     } else ""
+    val batchStepAssign =
+      s"""    if (id == BatchStep) {
+         |      if (parser.info_count() != parser.parsed_info_count()) {
+         |        printf("Batch info size mismatch: expected %u, parsed %u\\n",
+         |          parser.info_count(), parser.parsed_info_count());
+         |        assert(0);
+         |      }
+         |      if (num != parser.parsed_chunk_count()) {
+         |        printf("Batch chunk size mismatch: expected %u, parsed %u\\n",
+         |          num, parser.parsed_chunk_count());
+         |        assert(0);
+         |      }
+         |#ifdef CONFIG_DIFFTEST_QUERY
+         |      if (qStats) qStats->BatchStep_write(batch_query_nums);
+         |      memset(batch_query_nums, 0, sizeof(batch_query_nums));
+         |#endif // CONFIG_DIFFTEST_QUERY
+         |      parser.reset_step();
+         |$stepPending
+         |      dut_index = (dut_index + 1) % CONFIG_DIFFTEST_BATCH_SIZE;
+         |#ifdef CONFIG_DIFFTEST_INTERNAL_STEP
+         |#ifdef FPGA_HOST
+         |      extern void fpga_nstep(uint8_t step);
+         |      fpga_nstep(1);
+         |#else
+         |      extern void simv_nstep(uint8_t step);
+         |      simv_nstep(1);
+         |#endif // FPGA_HOST
+         |#endif // CONFIG_DIFFTEST_INTERNAL_STEP
+         |      return;
+         |    }
+         |""".stripMargin
     Seq(s"""
-           |  enum DifftestBundleType {
-           |  ${bundleEnum.mkString(",\n  ")}
-           |  };
+           |  uint8_t* payload = (uint8_t*)io;
+           |  static DifftestBatchParser parser;
            |  static int dut_index = 0;
-           |#ifdef CONFIG_DIFFTEST_QUERY
-           |  static int batch_query_nums[${bundleEnum.length}] = {0};
-           |#endif // CONFIG_DIFFTEST_QUERY
-           |  $batchDecl
-           |  for (int i = 0; i < $infoLen; i++) {
-           |    if (!diffstate_buffer) return;
-           |    uint8_t id = info[i].id;
-           |    uint8_t num = info[i].num;
+           |
+           |  for (uint32_t chunk = 0; chunk <= DIFFTEST_BATCH_BEAT_CHUNKS; chunk++) {
+           |    bool has_chunk = chunk < DIFFTEST_BATCH_BEAT_CHUNKS;
+           |    const uint8_t* chunk_payload = payload + chunk * DIFFTEST_BATCH_CHUNK_BYTES;
+           |    if (has_chunk && parser.reading_info()) {
+           |      if (!parser.recv_info(chunk_payload)) return;
+           |      if (parser.reading_info() || parser.current_info().id != BatchStep) continue;
+           |    }
+           |    if (parser.reading_info()) continue;
+           |    if (!has_chunk && parser.current_info().id != BatchStep) continue;
+           |
+           |    uint8_t id = parser.current_info().id;
+           |    uint8_t num = parser.current_info().num;
            |    uint32_t coreid, index, address;
-           |#ifdef CONFIG_DIFFTEST_QUERY
-           |    if (qStats) {
-           |      qStats->BatchInfo_write(id, num);
-           |      batch_query_nums[id] = num;
+           |$batchStepAssign
+           |$bundleAssign
+           |    else {
+           |      printf("Batch bundle id mismatch: id %u\\n", id);
+           |      assert(0);
            |    }
-           |#endif // CONFIG_DIFFTEST_QUERY
-           |    if (id == BatchFinish) {
-           |      break;
-           |    }
-           |    else if (id == BatchStep) {
-           |#ifdef CONFIG_DIFFTEST_QUERY
-           |      if (qStats) qStats->BatchStep_write(batch_query_nums);
-           |      memset(batch_query_nums, 0, sizeof(batch_query_nums));
-           |#endif // CONFIG_DIFFTEST_QUERY
-           |      $stepPending
-           |      dut_index = (dut_index + 1) % CONFIG_DIFFTEST_BATCH_SIZE;
-           |#ifdef CONFIG_DIFFTEST_INTERNAL_STEP
-           |#ifdef FPGA_HOST
-           |      extern void fpga_nstep(uint8_t step);
-           |      fpga_nstep(1);
-           |#else
-           |      extern void simv_nstep(uint8_t step);
-           |      simv_nstep(1);
-           |#endif // FPGA_HOST
-           |#endif // CONFIG_DIFFTEST_INTERNAL_STEP
-           |      continue;
-           |    }
-           |    $bundleAssign
            |  }
            |""".stripMargin)
   }
@@ -379,13 +389,14 @@ private class DummyDPICBatchWrapper(
   dpic.clock := clock
   dpic.enable := control.enable && !reset.asBool
   if (config.hasDutZone) dpic.dut_zone.get := control.dut_zone.get
-  dpic.io := io.asUInt
+  dpic.io := io.payload
 }
 
 object DPIC {
   private val interfaces = ListBuffer.empty[(String, String, String)]
   private val deltaInstances = ListBuffer.empty[DifftestBundle]
   private val perfs = ListBuffer.empty[String]
+  private var batchParam: Option[BatchParam] = None
 
   def apply(control: GatewaySinkControl, io: Valid[DifftestBundle], config: GatewayConfig): Unit = {
     val bundleType = chiselTypeOf(io)
@@ -394,7 +405,8 @@ object DPIC {
     module.io := io
     val dpic = module.dpic
     if (!interfaces.map(_._1).contains(dpic.dpicFuncName)) {
-      Query.register(bundleType.bits, "io_", "dut_zone")
+      val dut_zone = if (config.hasDutZone) "dut_zone" else "0"
+      Query.register(bundleType.bits, "io_", dut_zone)
       perfs += dpic.dpicFuncName
       val interface = (dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc)
       interfaces += interface
@@ -406,6 +418,7 @@ object DPIC {
 
   def batch(template: Seq[DifftestBundle], control: GatewaySinkControl, io: BatchIO, config: GatewayConfig): Unit = {
     Query.registerBatch(template, "", "0")
+    batchParam = Some(io.param)
     val module = Module(new DummyDPICBatchWrapper(template, chiselTypeOf(io), config))
     module.control := control
     module.io := io
@@ -507,6 +520,27 @@ object DPIC {
     interfaceCpp += "#include \"perf.h\""
     interfaceCpp += "#endif // CONFIG_DIFFTEST_PERFCNT"
     interfaceCpp += ""
+    if (config.isBatch) {
+      val batchTemplate = Batch.getTemplate
+      val param = batchParam.get
+      val bundleEnum = batchTemplate.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchHead", "BatchStep")
+      val maxDataByteLen = param.ClusterDataByteLen.max
+      interfaceCpp +=
+        s"""
+           |enum DifftestBundleType {
+           |  ${bundleEnum.mkString(",\n  ")}
+           |};
+           |
+           |#define DIFFTEST_BATCH_CHUNK_BYTES ${param.ChunkByteLen}
+           |#define DIFFTEST_BATCH_BEAT_CHUNKS ${param.BeatChunkSize}
+           |#define DIFFTEST_BATCH_INFO_BYTES ${param.StepInfoByteLen}
+           |#define DIFFTEST_BATCH_MAX_DATA_BYTES $maxDataByteLen
+           |
+           |#ifdef CONFIG_DIFFTEST_QUERY
+           |static int batch_query_nums[${bundleEnum.length}] = {0};
+           |#endif // CONFIG_DIFFTEST_QUERY
+           |""".stripMargin
+    }
     if (config.isDelta) {
       interfaceCpp +=
         s"""
@@ -537,6 +571,133 @@ object DPIC {
          |  ${if (config.isDelta) "delete dStats;" else ""}
          |}
       """.stripMargin
+    if (config.isBatch) {
+      interfaceCpp +=
+        """
+          |typedef struct __attribute__((packed)) {
+          |  uint8_t num;
+          |  uint8_t id;
+          |} DifftestBatchInfo;
+          |
+          |class DifftestBatchParser {
+          |private:
+          |  uint32_t info_num = 0;
+          |  uint32_t parsed_infos = 0;
+          |  uint32_t info_idx = 0;
+          |  uint32_t data_len = 0;
+          |  uint32_t info_len = 0;
+          |  uint32_t info_bytes = 0;
+          |  uint32_t parsed_chunks = 0;
+          |  uint32_t cluster_bytes = 0;
+          |  uint8_t info_buf[DIFFTEST_BATCH_INFO_BYTES] = {0};
+          |  uint8_t data_buf[DIFFTEST_BATCH_MAX_DATA_BYTES] = {0};
+          |
+          |  inline uint32_t align_chunk(uint32_t bytes) const { return (bytes + DIFFTEST_BATCH_CHUNK_BYTES - 1) / DIFFTEST_BATCH_CHUNK_BYTES * DIFFTEST_BATCH_CHUNK_BYTES; }
+          |
+          |  inline DifftestBatchInfo* info_entries() { return reinterpret_cast<DifftestBatchInfo*>(info_buf); }
+          |
+          |public:
+          |  bool reading_info() const { return info_idx == 0; }
+          |  uint32_t info_count() const { return info_num; }
+          |  uint32_t parsed_info_count() const { return parsed_infos; }
+          |  uint32_t parsed_chunk_count() const { return parsed_chunks; }
+          |  DifftestBatchInfo current_info() { return info_entries()[info_idx]; }
+          |  uint8_t* cluster_buf() { return data_buf; }
+          |
+          |  bool recv_info(const uint8_t* chunk_payload) {
+          |    if (info_len + DIFFTEST_BATCH_CHUNK_BYTES > sizeof(info_buf)) {
+          |      printf("Batch info buffer overflow: offset %u, chunk %u, buffer %zu\n",
+          |        info_len, (uint32_t)DIFFTEST_BATCH_CHUNK_BYTES, sizeof(info_buf));
+          |      assert(0);
+          |    }
+          |    memcpy(info_buf + info_len, chunk_payload, DIFFTEST_BATCH_CHUNK_BYTES);
+          |    info_len += DIFFTEST_BATCH_CHUNK_BYTES;
+          |    DifftestBatchInfo* entries = info_entries();
+          |
+          |    if (info_bytes == 0) {
+          |      uint8_t id = entries[0].id;
+          |      uint8_t num = entries[0].num;
+          |      if (id != BatchHead) {
+          |        printf("Batch head marker mismatch: id %u, expected %u\n", id, BatchHead);
+          |        assert(0);
+          |      }
+          |      info_num = num;
+          |      info_bytes = align_chunk((info_num + 2) * sizeof(DifftestBatchInfo));
+          |      if (info_bytes > sizeof(info_buf)) {
+          |        printf("Batch info buffer overflow: expected %u, buffer %zu\n", info_bytes, sizeof(info_buf));
+          |        assert(0);
+          |      }
+          |    }
+          |
+          |    if (info_len < info_bytes) return true;
+          |    if (info_len != info_bytes) {
+          |      printf("Batch info size mismatch: received %u, expected %u\n", info_len, info_bytes);
+          |      assert(0);
+          |    }
+          |    for (uint32_t i = 0; i < info_num + 2; i++) {
+          |      if (!diffstate_buffer) return false;
+          |      uint8_t id = entries[i].id;
+          |      uint8_t num = entries[i].num;
+          |      if (i == info_num + 1) {
+          |        if (id != BatchStep) {
+          |          printf("Batch step marker mismatch: id %u, expected %u\n", id, BatchStep);
+          |          assert(0);
+          |        }
+          |      } else if (i > 0 && id == BatchStep) {
+          |        printf("Batch info size mismatch: BatchStep at %u, expected %u\n", i, info_num + 1);
+          |        assert(0);
+          |      }
+          |#ifdef CONFIG_DIFFTEST_QUERY
+          |      if (qStats) {
+          |        qStats->BatchInfo_write(id, num);
+          |        batch_query_nums[id] = num;
+          |      }
+          |#endif // CONFIG_DIFFTEST_QUERY
+          |    }
+          |    info_len = 0;
+          |    parsed_infos = 0;
+          |    info_idx = 1;
+          |    parsed_chunks = info_bytes / DIFFTEST_BATCH_CHUNK_BYTES;
+          |    return true;
+          |  }
+          |
+          |  bool recv_cluster(const uint8_t* chunk_payload, uint8_t num, uint32_t elem_bytes) {
+          |    uint32_t data_size = (uint32_t)num * elem_bytes;
+          |    cluster_bytes = align_chunk(data_size);
+          |    if (data_len + DIFFTEST_BATCH_CHUNK_BYTES > sizeof(data_buf)) {
+          |      printf("Batch data buffer overflow: offset %u, chunk %u, buffer %zu\n",
+          |        data_len, (uint32_t)DIFFTEST_BATCH_CHUNK_BYTES, sizeof(data_buf));
+          |      assert(0);
+          |    }
+          |    memcpy(data_buf + data_len, chunk_payload, DIFFTEST_BATCH_CHUNK_BYTES);
+          |    data_len += DIFFTEST_BATCH_CHUNK_BYTES;
+          |    if (data_len < cluster_bytes) return false;
+          |    if (data_len != cluster_bytes) {
+          |      printf("Batch cluster size mismatch: received %u, expected %u\n", data_len, cluster_bytes);
+          |      assert(0);
+          |    }
+          |    return true;
+          |  }
+          |
+          |  void finish_cluster() {
+          |    data_len = 0;
+          |    parsed_chunks += cluster_bytes / DIFFTEST_BATCH_CHUNK_BYTES;
+          |    parsed_infos++;
+          |    info_idx++;
+          |  }
+          |
+          |  void reset_step() {
+          |    info_idx = 0;
+          |    data_len = 0;
+          |    info_len = 0;
+          |    info_bytes = 0;
+          |    info_num = 0;
+          |    parsed_infos = 0;
+          |    parsed_chunks = 0;
+          |  }
+          |};
+          |""".stripMargin
+    }
     val diffstate_perfhead = if (perfs.head.contains("Batch")) 1 else 0
     interfaceCpp +=
       s"""

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -41,6 +41,8 @@ case class GatewayConfig(
   isDelta: Boolean = false,
   isBatch: Boolean = false,
   batchSize: Int = 64,
+  batchChunkBytes: Int = 64,
+  batchBeatChunks: Int = 2,
   hasInternalStep: Boolean = false,
   isNonBlock: Boolean = false,
   hasBuiltInPerf: Boolean = false,
@@ -57,12 +59,11 @@ case class GatewayConfig(
   def maxStep: Int = if (isBatch) batchSize else 1
   def stepWidth: Int = log2Ceil(maxStep + 1)
   def replayWidth: Int = log2Ceil(replaySize + 1)
-  def batchArgByteLen: (Int, Int) = if (isFPGA) (1900, 100) else if (isNonBlock) (3600, 400) else (7200, 800)
-  def batchBitWidth: Int = batchArgByteLen match { case (len1, len2) => (len1 + len2) * 8 }
-  def batchSplit: Boolean = !isFPGA // Disable split for FPGA to reduce gates
+  def batchBeatByteLen: Int = batchBeatChunks * batchChunkBytes
+  def batchBitWidth: Int = batchBeatByteLen * 8
+  def batchSplit: Boolean = false
   def deltaLimit: Int = 8
-  def deltaQueueDepth: Int = 4
-  def hasClockGate = isFPGA || isDelta
+  def hasClockGate = isFPGA || isDelta || isBatch
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
   def needEndpoint: Boolean =
@@ -79,7 +80,7 @@ case class GatewayConfig(
       macros ++= Seq(
         "CONFIG_DIFFTEST_BATCH",
         s"CONFIG_DIFFTEST_BATCH_SIZE ${batchSize}",
-        s"CONFIG_DIFFTEST_BATCH_BYTELEN ${batchArgByteLen._1 + batchArgByteLen._2}",
+        s"CONFIG_DIFFTEST_BATCH_BYTELEN ${batchBeatByteLen}",
       )
     if (isSquash) macros ++= Seq("CONFIG_DIFFTEST_SQUASH", s"CONFIG_DIFFTEST_SQUASH_STAMPSIZE 4096") // Stamp Width 12
     if (isDelta) macros += "CONFIG_DIFFTEST_DELTA"
@@ -106,6 +107,8 @@ case class GatewayConfig(
     if (hasReplay) require(isSquash)
     if (hasInternalStep) require(isBatch)
     if (isBatch) require(!hasDutZone)
+    if (isBatch) require(batchChunkBytes >= 64 && isPow2(batchChunkBytes))
+    if (isBatch) require(batchBeatChunks > 0 && isPow2(batchBeatChunks))
     // Currently Delta depends on Batch to ensure update and sync order
     if (isDelta) require(isBatch)
     // Batch provides unified IO interface for FPGA Diff
@@ -307,9 +310,9 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
     val batch = Batch(toSink, config)
     step := RegNext(batch.bits.step, 0.U) // expose Batch step to check timeout
     control.enable := batch.valid
-    GatewaySink.batch(Batch.getTemplate, control, batch.bits.io, config)
+    GatewaySink.batch(Batch.getTemplate, control, batch.bits, config)
     if (config.isFPGA) {
-      fpgaIO.get.bits := batch.bits.io.asUInt
+      fpgaIO.get.bits := batch.bits.payload
       fpgaIO.get.valid := batch.valid
       batch.ready := fpgaIO.get.ready
     } else {

--- a/src/main/scala/util/Query.scala
+++ b/src/main/scala/util/Query.scala
@@ -162,7 +162,7 @@ class QueryTable(val gen: DifftestBundle, locPrefix: String, dutZone: String, so
 
 class BatchQueryTable(template: Seq[DifftestBundle]) {
   private val bundleNames: Seq[String] =
-    template.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchStep", "BatchFinish")
+    template.map(_.desiredModuleName.replace("Difftest", "")) ++ Seq("BatchHead", "BatchStep")
 
   val members: String =
     s"""Query* query_BatchInfo;

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -250,7 +250,7 @@ SimTop sim(
 );
 
 DifftestEndpoint difftest(
-  .clock(core_clock),
+  .clock(sim_clock),
   .reset(reset),
 `ifdef ENABLE_WORKLOAD_SWITCH
   .workload_switch(workload_switch),


### PR DESCRIPTION
Before the Batch pipeline, hardware had to pack the peak payload for one cycle. That path concatenated variable valid data with wide shifts, which cost area and made routing congested. With pipeline load balancing, Batch can process one step over multiple cycles and emit only batchBeatChunks * batchChunkBytes per cycle. Software can now parse one hardware step across multiple chunks.

This change:
- Removes BatchAssembler multi-cycle concatenation. A step is streamed once collected, reducing software-side latency.
- Aligns every cluster payload to batchChunkBytes, 64B by default, so clusters can be concatenated and parsed with simple offsets.
- Allows one BatchStep to span multiple beats/chunks, and keeps DPIC parser state across calls for variable-length steps.
- Adds BatchHead to record the dynamic info count. The trailing BatchStep position checks the info count, and BatchStep.num checks  the total valid chunk count.
- Makes each beat carry multiple chunks, allowing the AXI side to drain Batch data across clock-frequency gaps such as 250MHz to 25MHz. Note when mergedChunk > beatChunk, we will delay pending chunk for 1 cycle to cut ready for timing.
- Remove Batch CI from verilator, because Batch now relys on clkgate backpressure, but verilator is still driven by cpp clock.