### PR TITLE
chore: disable OBJCACHE for verilator by default

### DIFF
--- a/emu.mk
+++ b/emu.mk
@@ -74,7 +74,7 @@ emu:
 ifeq ($(GSIM),1)
 	@$(MAKE) emu-gsim
 else
-	@$(MAKE) emu-verilator
+	@$(MAKE) emu-verilator OBJCACHE="$(OBJCACHE)"
 endif
 
 emu-mk: verilator-emu-mk

--- a/verilator.mk
+++ b/verilator.mk
@@ -128,6 +128,7 @@ ifeq ($(REMOTE),localhost)
 						OPT_FAST=$(OPT_FAST) \
 						PGO_CFLAGS="$(PGO_CFLAGS)" \
 						PGO_LDFLAGS="$(PGO_LDFLAGS)" \
+						OBJCACHE="$(OBJCACHE)" \
 						-C $(VERILATOR_BUILD_DIR) -f $(VERILATOR_MK) $(EMU_COMPILE_FILTER)
 	@sync -d $(BUILD_DIR) -d $(VERILATOR_BUILD_DIR)
 else
@@ -136,7 +137,8 @@ else
 					   -j `nproc` \
 					   OPT_FAST="'"$(OPT_FAST)"'" \
 					   PGO_CFLAGS="'"$(PGO_CFLAGS)"'" \
-					   PGO_LDFLAGS="'"$(PGO_LDFLAGS)"'"'
+					   PGO_LDFLAGS="'"$(PGO_LDFLAGS)"'" \
+					   OBJCACHE="'"$(OBJCACHE)"'"'
 endif
 
 # Profile Guided Optimization


### PR DESCRIPTION
1. it does not help XiangShan's build performance in most cases, as slight change in chisel result in significant change in cpp code
2. it introduces too much IO overhead

use 'make emu OBJCACHE=ccache' to enable it

See also: https://github.com/OpenXiangShan/XiangShan/pull/5907