### PR TITLE
fix(common): fix thousand seperator for printf 

### DIFF
--- a/src/test/csrc/common/common.cpp
+++ b/src/test/csrc/common/common.cpp
@@ -15,6 +15,7 @@
 ***************************************************************************************/
 
 #include "common.h"
+#include <limits.h>
 #include <locale.h>
 #include <signal.h>
 #include <time.h>
@@ -66,6 +67,30 @@ uint32_t uptime(void) {
 
 static char mybuf[BUFSIZ];
 
+static bool numeric_locale_has_grouping() {
+  struct lconv *lc = localeconv();
+  if (lc == NULL || lc->thousands_sep == NULL || lc->grouping == NULL) {
+    return false;
+  }
+  if (lc->thousands_sep[0] == '\0' || lc->grouping[0] == '\0') {
+    return false;
+  }
+  unsigned char first_group = lc->grouping[0];
+  return first_group != CHAR_MAX;
+}
+
+void common_set_locale() {
+  const char *numeric_locales[] = {
+    "", "en_US.UTF-8", "en_US.utf8", "zh_CN.UTF-8", "zh_CN.utf8",
+  };
+
+  for (auto locale: numeric_locales) {
+    if (setlocale(LC_NUMERIC, locale) != NULL && numeric_locale_has_grouping()) {
+      return;
+    }
+  }
+}
+
 void common_init_without_assertion(const char *program_name) {
   // set emu_path
   emu_path = program_name;
@@ -78,7 +103,7 @@ void common_init_without_assertion(const char *program_name) {
   setbuf(stderr, mybuf);
 
   // enable thousands separator for printf()
-  setlocale(LC_NUMERIC, "");
+  common_set_locale();
 
   // set up SIGINT handler
   if (signal(SIGINT, sig_handler) == SIG_ERR) {

--- a/src/test/csrc/common/common.h
+++ b/src/test/csrc/common/common.h
@@ -111,6 +111,9 @@ void common_init(const char *program_name);
 void common_init_without_assertion(const char *program_name);
 void common_enable_assert();
 
+// Set locale for printf thousands separators.
+void common_set_locale();
+
 // Enable external log system
 typedef int (*eprintf_handle_t)(const char *fmt, va_list ap);
 extern "C" void common_enable_log(eprintf_handle_t h);

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -61,6 +61,8 @@ FpgaXdma *xdma_device = NULL;
 SerialPort *serial_port = NULL;
 #endif // USE_SERIAL_PORT
 int main(int argc, const char *argv[]) {
+  common_set_locale();
+
   fpga_ddr_load_cmd = std::getenv("FPGA_DDR_LOAD_CMD");
   fpga_ila_dump_cmd = std::getenv("FPGA_ILA_DUMP_CMD");
   args = parse_args(argc, argv);


### PR DESCRIPTION
Previous `setlocale(NUMERIC, "")` will get env from local to enable
thousand seperator. However sometimes local env may not has seperator,
or overriding LC_NUMERIC, such as set LC_ALL=C.UTF-8.

This change will try a list to fallback NUMERIC with seperator, it
works on most of local machine. But note the CI container will has
not locale and does not support thousand seperator.