### PR TITLE
feat(difftest): generate checkpoint on difftest mismatch

### DIFF
--- a/src/test/csrc/common/args.cpp
+++ b/src/test/csrc/common/args.cpp
@@ -89,6 +89,7 @@ static inline void print_help(const char *file) {
   printf("      --as-footprints        load the image as memory access footprints\n");
   printf("      --dump-linearized=NAME dump the linearized footprints to NAME\n");
   printf("      --copy-ram=OFFSET      duplicate the memory at OFFSET\n");
+  printf("      --auto-checkpoint       save checkpoint to $NOOP_HOME/build/ on difftest error\n");
   printf("  -h, --help                 print program help info\n");
   printf("\n");
 }
@@ -98,6 +99,8 @@ CommonArgs parse_args(int argc, const char *argv[]) {
   int long_index = 0;
 #ifndef CONFIG_NO_DIFFTEST
   extern const char *difftest_ref_so;
+  extern bool difftest_auto_cpt;
+  extern bool cpt_from_fork;
 #endif // CONFIG_NO_DIFFTEST
 
   /* clang-format off */
@@ -133,6 +136,7 @@ CommonArgs parse_args(int argc, const char *argv[]) {
     { "instr-trace",       1, NULL,  0  },
     { "copy-ram",          1, NULL,  0  },
     { "cst-file",          1, NULL,  0  },
+    { "auto-checkpoint",   0, NULL,  0  },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "fork-interval",     1, NULL, 'X' },
@@ -167,7 +171,11 @@ CommonArgs parse_args(int argc, const char *argv[]) {
           case 4: difftest_ref_so = optarg; continue;
 #endif // CONFIG_NO_DIFFTEST
           case 5: args.enable_diff = false; continue;
-          case 6: args.enable_fork = true; continue;
+          case 6: args.enable_fork = true;
+#ifndef CONFIG_NO_DIFFTEST
+            cpt_from_fork = true;
+#endif // CONFIG_NO_DIFFTEST
+            continue;
           case 7: enable_simjtag = true; continue;
           case 8: args.wave_path = optarg; continue;
           case 9: args.ram_size = optarg; continue;
@@ -244,6 +252,11 @@ CommonArgs parse_args(int argc, const char *argv[]) {
           case 28: args.instr_trace = optarg; continue;
           case 29: args.copy_ram_offset = parse_ramsize(optarg); continue;
           case 30: args.cst_file = optarg; continue;
+          case 31: args.auto_checkpoint = true;
+#ifndef CONFIG_NO_DIFFTEST
+            difftest_auto_cpt = true;
+#endif
+            continue;
         }
         // fall through
       default: print_help(argv[0]); exit(0);

--- a/src/test/csrc/common/args.h
+++ b/src/test/csrc/common/args.h
@@ -68,6 +68,7 @@ struct CommonArgs {
   bool dump_coverage = false;
   bool image_as_footprints = false;
   bool overwrite_nbytes_autoset = false;
+  bool auto_checkpoint = false;
 };
 
 CommonArgs parse_args(int argc, const char *argv[]);

--- a/src/test/csrc/common/lightsss.cpp
+++ b/src/test/csrc/common/lightsss.cpp
@@ -23,6 +23,8 @@ ForkShareMemory::ForkShareMemory() {
   info->notgood = false;
   info->endCycles = 0;
   info->oldest = 0;
+  info->do_cpt = false;
+  info->cpt_filepath[0] = '\0';
 }
 
 ForkShareMemory::~ForkShareMemory() {

--- a/src/test/csrc/common/lightsss.h
+++ b/src/test/csrc/common/lightsss.h
@@ -18,6 +18,7 @@
 #define __LIGHTSSS_H
 
 #include "common.h"
+#include <cstring>
 #include <deque>
 #include <list>
 #include <signal.h>
@@ -32,6 +33,8 @@ typedef struct shinfo {
   bool notgood;
   uint64_t endCycles;
   pid_t oldest;
+  bool do_cpt;
+  char cpt_filepath[256];
 } shinfo;
 
 class ForkShareMemory {
@@ -67,6 +70,17 @@ public:
   int do_clear();
   uint64_t get_end_cycles() {
     return forkshm.info->endCycles;
+  }
+  bool get_do_cpt() {
+    return forkshm.info->do_cpt;
+  }
+  const char *get_cpt_filepath() {
+    return forkshm.info->cpt_filepath;
+  }
+  void set_cpt_request(const char *filepath) {
+    forkshm.info->do_cpt = true;
+    strncpy(forkshm.info->cpt_filepath, filepath, sizeof(forkshm.info->cpt_filepath) - 1);
+    forkshm.info->cpt_filepath[sizeof(forkshm.info->cpt_filepath) - 1] = '\0';
   }
 };
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -139,7 +139,14 @@ int difftest_step() {
   for (int i = 0; i < NUM_CORES; i++) {
     if (int ret = difftest[i]->step()) {
       switch (ret) {
-        case DiffTestChecker::STATE_DIFF: difftest[i]->display();
+        case DiffTestChecker::STATE_DIFF:
+          difftest[i]->display();
+          // When --enable-fork is active, the fork child (at the earlier snapshot)
+          // handles checkpoint generation. Skip triggering it from the parent here.
+          if (difftest_auto_cpt && !cpt_from_fork && difftest[i]->proxy) {
+            const char *base_filepath = create_noop_filename("");
+            difftest[i]->proxy->trigger_checkpoint(base_filepath);
+          }
         case DiffTestChecker::STATE_ERROR: return STATE_ABORT;
         default: // STATE_TRAP
           return difftest[i]->get_trap_code();

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -23,6 +23,8 @@
 
 uint8_t *ref_golden_mem = NULL;
 const char *difftest_ref_so = NULL;
+bool difftest_auto_cpt = false;
+bool cpt_from_fork = false;
 
 #define check_and_assert(func)                             \
   do {                                                     \

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -158,7 +158,8 @@ public:
   f(ref_sync_custom_mflushpwr, difftest_sync_custom_mflushpwr, void, bool)                                  \
   f(ref_get_vec_load_vdNum, difftest_get_vec_load_vdNum, int, )                                             \
   f(ref_get_vec_load_dual_goldenmem_reg, difftest_get_vec_load_dual_goldenmem_reg, void*, )                 \
-  f(ref_update_vec_load_goldenmen, difftest_update_vec_load_pmem, void, )
+  f(ref_update_vec_load_goldenmen, difftest_update_vec_load_pmem, void, )                                   \
+  f(ref_trigger_checkpoint, difftest_trigger_checkpoint, void, const char *)
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
 /* clang-format on */
@@ -395,6 +396,17 @@ public:
     return ref_status ? ref_status() : 0;
   }
 
+  inline void trigger_checkpoint(const char *base_filepath) {
+    if (ref_trigger_checkpoint) {
+      ref_trigger_checkpoint(base_filepath);
+    } else {
+      printf(
+          "[ERROR] --auto-checkpoint is enabled but the REF (.so) does not support "
+          "trigger_checkpoint. Please rebuild NEMU with checkpoint support.\n");
+      exit(1);
+    }
+  }
+
 private:
   RefProxyConfig config;
 
@@ -468,6 +480,8 @@ struct InterruptDelegate {
 };
 
 extern const char *difftest_ref_so;
+extern bool difftest_auto_cpt;
+extern bool cpt_from_fork;
 extern uint8_t *ref_golden_mem;
 
 #define REPORT_DIFFERENCE(name, pc_val, right_val, wrong_val) \

--- a/src/test/csrc/emu/emu.cpp
+++ b/src/test/csrc/emu/emu.cpp
@@ -234,6 +234,12 @@ Emulator::~Emulator() {
   if (args.enable_fork && !is_fork_child()) {
     bool need_wakeup = trapCode != STATE_GOODTRAP && trapCode != STATE_LIMIT_EXCEEDED && trapCode != STATE_SIG;
     if (need_wakeup) {
+#ifndef CONFIG_NO_DIFFTEST
+      if (difftest_auto_cpt) {
+        const char *base_filepath = create_noop_filename("");
+        lightsss->set_cpt_request(base_filepath);
+      }
+#endif // CONFIG_NO_DIFFTEST
       lightsss->wakeup_child(cycles);
     } else {
       lightsss->do_clear();
@@ -758,5 +764,17 @@ void Emulator::fork_child_init() {
     difftest[i]->proxy->set_debug(true);
   }
 #endif
+
+  // Generate checkpoint from the fork snapshot state if requested
+  if (lightsss->get_do_cpt()) {
+    const char *base_filepath = lightsss->get_cpt_filepath();
+    FORK_PRINTF("Generating checkpoint from fork snapshot: %s_memory_.gz\n", base_filepath)
+    for (int i = 0; i < NUM_CORES; i++) {
+      if (difftest[i]->proxy) {
+        difftest[i]->proxy->trigger_checkpoint(base_filepath);
+        break; // checkpoint covers all cores' shared NEMU memory
+      }
+    }
+  }
 #endif // CONFIG_NO_DIFFTEST
 }


### PR DESCRIPTION
Add an --auto-checkpoint option that asks the REF to dump a checkpoint when difftest reports a mismatch.

Without --enable-fork, generate the checkpoint after the mismatch is detected. With --enable-fork, wake the fork child and generate the checkpoint from the fork snapshot instead.

Route the request through RefProxy and pass a checkpoint base path to the REF.