### PR TITLE
fix: fix gcc14+ warnings

### DIFF
--- a/src/test/csrc/common/common.cpp
+++ b/src/test/csrc/common/common.cpp
@@ -43,7 +43,8 @@ void xs_assert_v2(const char *filename, long long line) {
 
 void sig_handler(int signo) {
   static const char msg[] = "[common] SIGINT captured\n";
-  write(STDERR_FILENO, msg, sizeof(msg) - 1);
+  ssize_t ret = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+  (void)ret; // suppress unused variable warning
   if (signal_num != 0)
     exit(0);
   signal_num = signo;

--- a/src/test/csrc/difftest/difftrace.cpp
+++ b/src/test/csrc/difftest/difftrace.cpp
@@ -1,4 +1,5 @@
 #include "difftrace.h"
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -43,27 +44,36 @@ template <typename T> bool DiffTrace<T>::read_next(T *trace) {
 }
 
 template <typename T> void DiffTrace<T>::next_file_name(char *file_name) {
-  memset(file_name, 0, 128);
+  memset(file_name, 0, PATH_MAX);
   static uint64_t trace_index = 0;
-  char dirname[128];
+  char dirname[PATH_MAX];
+  int ret = 0;
   if (strchr(trace_name, '/')) {
-    snprintf(dirname, 128, "%s", trace_name);
+    ret = snprintf(dirname, sizeof(dirname), "%s", trace_name);
   } else {
     char *noop_home = getenv("NOOP_HOME");
-    snprintf(dirname, 128, "%s/%s", noop_home, trace_name);
+    ret = snprintf(dirname, sizeof(dirname), "%s/%s", noop_home, trace_name);
+  }
+  if (ret < 0 || ret >= (int)sizeof(dirname)) {
+    printf("Directory name is too long: %s\n", trace_name);
+    exit(0);
   }
   mkdir(dirname, 0755);
 #ifndef CONFIG_IOTRACE_ZSTD
-  const char *prefix = "bin";
+  const char *suffix = "bin";
 #else
-  const char *prefix = "zstd";
+  const char *suffix = "zstd";
 #endif // CONFIG_IOTRACE_ZSTD
-  snprintf(file_name, 128, "%s/%lu.%s", dirname, trace_index, prefix);
+  ret = snprintf(file_name, PATH_MAX, "%s/%lu.%s", dirname, trace_index, suffix);
+  if (ret < 0 || ret >= PATH_MAX) {
+    printf("File name is too long: %s/%lu.%s\n", dirname, trace_index, suffix);
+    exit(0);
+  }
   trace_index++;
 }
 
 template <typename T> bool DiffTrace<T>::trace_file_next() {
-  static char *filename = (char *)malloc(128);
+  static char *filename = (char *)malloc(PATH_MAX);
 #ifdef CONFIG_IOTRACE_ZSTD
   if (trace_zstd->need_load_new_file == true && is_read) {
     next_file_name(filename);

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -216,18 +216,16 @@ int RefProxy::compare(DiffTestState *dut) {
 void RefProxy::display(DiffTestState *dut) {
   if (dut) {
     const uint64_t diff_pc = (dut->commit[0].valid ? dut->commit[0].pc : dut->trap.pc);
-#define PROXY_COMPARE_AND_DISPLAY(field, field_names)                         \
-  do {                                                                        \
-    _Pragma("GCC diagnostic push")                                            \
-    _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")          \
-    uint64_t *_ptr_dut = (uint64_t *)(&((dut)->regs.field));                  \
-    uint64_t *_ptr_ref = (uint64_t *)(&(state.field));                        \
-    _Pragma("GCC diagnostic pop")                                             \
-    for (size_t i = 0; i < sizeof(state.field) / sizeof(uint64_t); i++) {     \
-      if (_ptr_dut[i] != _ptr_ref[i]) {                                       \
-        REPORT_DIFFERENCE(field_names[i], diff_pc, _ptr_ref[i], _ptr_dut[i]); \
-      }                                                                       \
-    }                                                                         \
+#define PROXY_COMPARE_AND_DISPLAY(field, field_names)                                                   \
+  do {                                                                                                  \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")     \
+        uint64_t *_ptr_dut = (uint64_t *)(&((dut)->regs.field));                                        \
+    uint64_t *_ptr_ref = (uint64_t *)(&(state.field));                                                  \
+    _Pragma("GCC diagnostic pop") for (size_t i = 0; i < sizeof(state.field) / sizeof(uint64_t); i++) { \
+      if (_ptr_dut[i] != _ptr_ref[i]) {                                                                 \
+        REPORT_DIFFERENCE(field_names[i], diff_pc, _ptr_ref[i], _ptr_dut[i]);                           \
+      }                                                                                                 \
+    }                                                                                                   \
   } while (0);
 
     PROXY_COMPARE_AND_DISPLAY(xrf, regs_name_int)

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -218,9 +218,12 @@ void RefProxy::display(DiffTestState *dut) {
     const uint64_t diff_pc = (dut->commit[0].valid ? dut->commit[0].pc : dut->trap.pc);
 #define PROXY_COMPARE_AND_DISPLAY(field, field_names)                         \
   do {                                                                        \
+    _Pragma("GCC diagnostic push")                                            \
+    _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")          \
     uint64_t *_ptr_dut = (uint64_t *)(&((dut)->regs.field));                  \
     uint64_t *_ptr_ref = (uint64_t *)(&(state.field));                        \
-    for (int i = 0; i < sizeof(state.field) / sizeof(uint64_t); i++) {        \
+    _Pragma("GCC diagnostic pop")                                             \
+    for (size_t i = 0; i < sizeof(state.field) / sizeof(uint64_t); i++) {     \
       if (_ptr_dut[i] != _ptr_ref[i]) {                                       \
         REPORT_DIFFERENCE(field_names[i], diff_pc, _ptr_ref[i], _ptr_dut[i]); \
       }                                                                       \

--- a/src/test/csrc/emu/emu.cpp
+++ b/src/test/csrc/emu/emu.cpp
@@ -132,7 +132,10 @@ Emulator::Emulator(int argc, const char *argv[])
     if (args.overwrite_nbytes_autoset) {
       FILE *fp = fopen(args.gcpt_restore, "rb");
       fseek(fp, 4, SEEK_SET);
-      fread(&args.overwrite_nbytes, sizeof(uint32_t), 1, fp);
+      if (fread(&args.overwrite_nbytes, sizeof(uint32_t), 1, fp) != 1) {
+        printf("Failed to read overwrite_nbytes from gcpt_restore file %s\n", args.gcpt_restore);
+        assert(0);
+      }
       fclose(fp);
     }
     overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);

--- a/src/test/csrc/plugin/spikedasm/spikedasm.cpp
+++ b/src/test/csrc/plugin/spikedasm/spikedasm.cpp
@@ -42,10 +42,14 @@ bool spike_valid() {
 static void execute_dasm_cmd() {
   FILE *ptr = popen(dasm_cmd, "r");
   if (ptr) {
-    fgets(dasm_result, sizeof(dasm_result), ptr);
+    if (fgets(dasm_result, sizeof(dasm_result), ptr) == nullptr) {
+      printf("fgets %s error\n", dasm_cmd);
+      dasm_result[0] = '\0';
+    }
     pclose(ptr);
   } else {
     printf("popen %s error\n", dasm_cmd);
+    dasm_result[0] = '\0';
   }
 }
 


### PR DESCRIPTION
```
In function ‘int snprintf(char*, size_t, const char*, ...)’,
    inlined from ‘void DiffTrace<T>::next_file_name(char*) [with T = DiffTestState]’ at <redacted>/XiangShan/difftest/src/test/csrc/difftest/difftrace.cpp:61:11:
/nix/store/1v9ggwkpb0xy708s11s1g9fhinn3b06r-glibc-2.40-66-dev/include/bits/stdio2.h:68:35: note: ‘__builtin___snprintf_chk’ output between 7 and 153 bytes into a destination of size 128
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
```

from `snprintf(file_name, PATH_MAX, "%s/%lu.%s", dirname, trace_index, prefix)`

This used a 128-byte buffer `dirname` and `file_name` for constructing trace filenames, which could silently truncate paths and potentially overwrite existing files with the same prefix.

i.e. `dirname` can come from `getenv("NOOP_HOME")` (128 at max), plus `trace_index` (20 at max), plus `suffix` (4 at max), plus `/` and `.`, 154 bytes in total.

This commit increases buffer size to system's `PATH_MAX`, and checks `snprintf`'s return value to warn and exit on truncation.

Also renames variable `prefix` to `suffix` for clarity.

---

```
<redacted>/XiangShan/difftest/src/test/csrc/plugin/spikedasm/spikedasm.cpp: In function ‘void execute_dasm_cmd()’:
<redacted>/XiangShan/difftest/src/test/csrc/plugin/spikedasm/spikedasm.cpp:45:10: warning: ignoring return value of ‘char* fgets(char*, int, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   45 |     fgets(dasm_result, sizeof(dasm_result), ptr);
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

`fgets` might fail and returns NULL.

This commit checks the return value, and explictly set `dasm_result[0]` to `\0` if popen or fgets failed to prevent using wrong data.

---

```
<redacted>/XiangShan/difftest/src/test/csrc/difftest/refproxy.cpp: In member function ‘void RefProxy::display(DiffTestState*)’:
<redacted>/XiangShan/difftest/src/test/csrc/difftest/refproxy.cpp:222:39: warning: taking address of packed member of ‘ref_state_t’ may result in an unaligned pointer value [-Waddress-of-packed-member]
  222 |     uint64_t *_ptr_ref = (uint64_t *)(&(state.field));                        \
      |                                      ~^~~~~~~~~~~~~~~
<redacted>/XiangShan/difftest/src/test/csrc/difftest/refproxy.cpp:230:5: note: in expansion of macro ‘PROXY_COMPARE_AND_DISPLAY’
  230 |     PROXY_COMPARE_AND_DISPLAY(xrf, regs_name_int)
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
```

`state` is a struct with `__attribute__((packed))`, but we intentionally convert its member pointer (i.e. `state.field`) to `uint64_t *` to iteratively access values (i.e. `state.field.value[]`).

So this commit simply ignored this warning.

---

```
<redacted>/XiangShan/difftest/src/test/csrc/emu/emu.cpp: In constructor ‘Emulator::Emulator(int, const char**)’:
<redacted>/XiangShan/difftest/src/test/csrc/emu/emu.cpp:135:12: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  135 |       fread(&args.overwrite_nbytes, sizeof(uint32_t), 1, fp);
      |       ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Similar to `fgets` warning above, but here is loading checkpoint, this commit adds check and abort if `fread` failed.

---

```
<redacted>/XiangShan/difftest/src/test/csrc/common/common.cpp: In function ‘void sig_handler(int)’:
<redacted>/XiangShan/difftest/src/test/csrc/common/common.cpp:46:8: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   46 |   write(STDERR_FILENO, msg, sizeof(msg) - 1);
      |   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Also similar, but here is in sig handler and we are writing warning message to STDERR, we cannot write another warning message if the first write is already failed. So this commit simply `(void)ret` to suppress warning.

---