### PR TITLE
feat(fpga_sim): pass simv workload path from host

### DIFF
--- a/scripts/fpga_sim/cosim.sh
+++ b/scripts/fpga_sim/cosim.sh
@@ -53,7 +53,7 @@ if [[ "${WAVE}" -eq 1 ]]; then
   WAVE_ARGS="+dump-wave"
 fi
 
-./build/simv +workload="${WORKLOAD}" +e=0 +diff="${DIFF}" ${WAVE_ARGS} &
+./build/simv +e=0 +diff="${DIFF}" ${WAVE_ARGS} &
 SIMV_PID=$!
 
 set +e # disable exit to get exitCode

--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -36,6 +36,12 @@ void init_ram(const char *image, uint64_t ram_size, bool random_mem, uint32_t se
   simMemory = new MmapMemory(image, ram_size, random_mem, seed);
 }
 
+void load_ram_image(const char *image) {
+  auto *mem = dynamic_cast<MmapMemory *>(simMemory);
+  assert(mem);
+  mem->load_image(image);
+}
+
 static uint64_t random_init_memory(void *ram, uint64_t memory_size, uint32_t seed) {
   uint64_t state = seed;
 
@@ -304,6 +310,10 @@ MmapMemory::MmapMemory(const char *image, uint64_t n_bytes, bool random_mem, uin
   //new end
 #endif
 
+  load_image(image);
+}
+
+void MmapMemory::load_image(const char *image) {
   if (image == NULL) {
     img_size = 0;
     return;

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -138,6 +138,7 @@ private:
 public:
   MmapMemory(const char *image, uint64_t n_bytes, bool random_mem, uint32_t seed);
   virtual ~MmapMemory();
+  void load_image(const char *image);
   void clone(std::function<void(void *, uint64_t)> func, bool skip_zero = false) {
     uint64_t n_bytes = skip_zero ? img_size : get_size();
     func(ram, n_bytes);
@@ -215,6 +216,7 @@ public:
 extern SimMemory *simMemory;
 // This is to initialize the common mmap RAM
 void init_ram(const char *image, uint64_t n_bytes, bool random_mem = false, uint32_t seed = 0);
+void load_ram_image(const char *image);
 void overwrite_ram(const char *gcpt_restore, uint64_t overwrite_nbytes);
 void copy_ram(uint64_t copy_ram_offset);
 uint64_t parse_ramsize(const char *ramsize_str);

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -124,7 +124,9 @@ void fpga_init() {
 
   init_device();
 
-#ifndef FPGA_SIM
+#ifdef FPGA_SIM
+  xdma_sim_set_workload(args.image);
+#else
   if (fpga_ddr_load_cmd) {
     if (!run_external_cmd(fpga_ddr_load_cmd, "DDR load")) {
       exit(0);

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -76,6 +76,7 @@ FpgaXdma::FpgaXdma()
   }
 #ifdef FPGA_SIM
   xdma_sim_axilite_open(true);
+  xdma_sim_workload_open(true);
 #endif // FPGA_SIM
 #ifdef CONFIG_USE_XDMA_H2C
   xdma_h2c_fd = open(XDMA_H2C_DEVICE, O_WRONLY);
@@ -93,6 +94,7 @@ FpgaXdma::~FpgaXdma() {
   for (int i = 0; i < CONFIG_DMA_CHANNELS; i++) {
     xdma_sim_close(i);
   }
+  xdma_sim_workload_close(true);
   xdma_sim_axilite_close(true);
 #endif // FPGA_SIM
 }
@@ -101,11 +103,8 @@ FpgaXdma::~FpgaXdma() {
 void FpgaXdma::device_write(bool is_bypass, const char *workload, uint64_t addr, uint64_t value) {
 #ifdef FPGA_SIM
   if (is_bypass) {
-    // FPGA_SIM already passes the workload to simv through +workload. Keep the
-    // host API shape but avoid a duplicate per-byte DPI DDR load path.
-    (void)workload;
-    printf("[fpga-host] FPGA_SIM uses simv +workload for DDR init; skip XDMA bypass load\n");
-    return;
+    fprintf(stderr, "[fpga-host] FPGA_SIM XDMA bypass write is unsupported\n");
+    exit(-1);
   }
   if (xdma_sim_axilite_write(static_cast<uint32_t>(addr), static_cast<uint32_t>(value), 0xf) != 0) {
     fprintf(stderr, "[fpga-host] FPGA_SIM AXI-Lite command queue is full, addr=0x%lx value=0x%lx\n", addr, value);

--- a/src/test/csrc/fpga_sim/xdma_sim.cpp
+++ b/src/test/csrc/fpga_sim/xdma_sim.cpp
@@ -29,7 +29,8 @@
 #include "svdpi.h"
 #endif // FPGA_HOST
 
-#define BUFFER_SIZE 65536
+#define BUFFER_SIZE        65536
+#define WORKLOAD_PATH_SIZE 4096
 
 template <typename T> class xdma_shm_device {
 private:
@@ -92,6 +93,14 @@ typedef struct {
   uint32_t data;
   uint8_t strb;
 } xdma_axilite_shm;
+
+typedef struct {
+  pthread_mutex_t lock;
+  pthread_cond_t accepted_cond;
+  bool valid;
+  bool accepted;
+  char workload[WORKLOAD_PATH_SIZE];
+} xdma_workload_shm;
 
 class xdma_sim : private xdma_shm_device<xdma_shm> {
 private:
@@ -232,9 +241,72 @@ public:
   }
 };
 
+class xdma_workload_sim : private xdma_shm_device<xdma_workload_shm> {
+private:
+  static const char *path() {
+    return "/xdma_sim_workload";
+  }
+
+public:
+  xdma_workload_sim(bool is_host) : xdma_shm_device(path(), sizeof(xdma_workload_shm), is_host, "workload") {
+    if (is_host) {
+      pthread_mutexattr_t attr;
+      pthread_mutexattr_init(&attr);
+      pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+      pthread_mutex_init(&shm_ptr->lock, &attr);
+      pthread_condattr_t cattr;
+      pthread_condattr_init(&cattr);
+      pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED);
+      pthread_cond_init(&shm_ptr->accepted_cond, &cattr);
+    }
+  }
+
+  int set_workload(const char *workload) {
+    if (workload == nullptr || strlen(workload) >= WORKLOAD_PATH_SIZE) {
+      return -1;
+    }
+
+    pthread_mutex_lock(&shm_ptr->lock);
+    while (shm_ptr->valid) {
+      pthread_cond_wait(&shm_ptr->accepted_cond, &shm_ptr->lock);
+    }
+
+    strcpy(shm_ptr->workload, workload);
+    shm_ptr->accepted = false;
+    shm_ptr->valid = true;
+    pthread_cond_broadcast(&shm_ptr->accepted_cond);
+    while (!shm_ptr->accepted) {
+      pthread_cond_wait(&shm_ptr->accepted_cond, &shm_ptr->lock);
+    }
+    pthread_mutex_unlock(&shm_ptr->lock);
+    return 0;
+  }
+
+  int get_workload(char *workload, size_t size) {
+    if (workload == nullptr || size == 0) {
+      return -1;
+    }
+
+    pthread_mutex_lock(&shm_ptr->lock);
+    if (!shm_ptr->valid) {
+      pthread_mutex_unlock(&shm_ptr->lock);
+      return 0;
+    }
+
+    strncpy(workload, shm_ptr->workload, size - 1);
+    workload[size - 1] = '\0';
+    shm_ptr->valid = false;
+    shm_ptr->accepted = true;
+    pthread_cond_broadcast(&shm_ptr->accepted_cond);
+    pthread_mutex_unlock(&shm_ptr->lock);
+    return 1;
+  }
+};
+
 // API for shared XDMA Dev
 xdma_sim *xsim[8] = {nullptr};
 xdma_axilite_sim *axilite_sim = nullptr;
+xdma_workload_sim *workload_sim = nullptr;
 static pthread_mutex_t xsim_lock = PTHREAD_MUTEX_INITIALIZER;
 
 #ifndef FPGA_HOST
@@ -284,8 +356,32 @@ void xdma_sim_axilite_close(bool is_host) {
   pthread_mutex_unlock(&xsim_lock);
 }
 
+void xdma_sim_workload_open(bool is_host) {
+  pthread_mutex_lock(&xsim_lock);
+  if (workload_sim == nullptr) {
+    workload_sim = new xdma_workload_sim(is_host);
+  }
+  pthread_mutex_unlock(&xsim_lock);
+}
+
+void xdma_sim_workload_close(bool is_host) {
+  (void)is_host;
+  pthread_mutex_lock(&xsim_lock);
+  delete workload_sim;
+  workload_sim = nullptr;
+  pthread_mutex_unlock(&xsim_lock);
+}
+
 int xdma_sim_axilite_write(uint32_t addr, uint32_t data, uint8_t strb) {
   return axilite_sim->write(addr, data, strb);
+}
+
+int xdma_sim_set_workload(const char *workload) {
+  return workload_sim->set_workload(workload);
+}
+
+int xdma_sim_get_workload(char *workload, size_t size) {
+  return workload_sim->get_workload(workload, size);
 }
 
 extern "C" void v_xdma_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {

--- a/src/test/csrc/fpga_sim/xdma_sim.h
+++ b/src/test/csrc/fpga_sim/xdma_sim.h
@@ -22,8 +22,12 @@ void xdma_sim_open(int channel, bool is_host);
 void xdma_sim_close(int channel);
 void xdma_sim_axilite_open(bool is_host);
 void xdma_sim_axilite_close(bool is_host);
+void xdma_sim_workload_open(bool is_host);
+void xdma_sim_workload_close(bool is_host);
 int xdma_sim_read(int channel, char *buf, size_t size);
 int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size);
 int xdma_sim_axilite_write(uint32_t addr, uint32_t data, uint8_t strb);
+int xdma_sim_set_workload(const char *workload);
+int xdma_sim_get_workload(char *workload, size_t size);
 
 #endif // __XDMA_SIM_H__

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -184,6 +184,15 @@ extern "C" void set_simjtag() {
   enable_simjtag = true;
 }
 
+#ifdef FPGA_SIM
+extern "C" void simv_load_workload() {
+  char workload[4096];
+  if (xdma_sim_get_workload(workload, sizeof(workload))) {
+    load_ram_image(workload);
+  }
+}
+#endif // FPGA_SIM
+
 extern "C" uint8_t simv_init() {
   if (workload_list != NULL) {
     if (switch_workload())
@@ -199,12 +208,16 @@ extern "C" uint8_t simv_init() {
 #ifdef WITH_DRAMSIM3
   dramsim3_init(nullptr, nullptr);
 #endif
+#ifdef FPGA_SIM
+  xdma_sim_workload_open(false);
+#else
   if (args.gcpt_restore != NULL) {
     overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);
   }
   if (args.copy_ram_offset) {
     copy_ram(args.copy_ram_offset);
   }
+#endif // FPGA_SIM
 
   init_flash(args.flash_bin);
 
@@ -281,6 +294,7 @@ void simv_finish() {
   simMemory = nullptr;
 
 #ifdef FPGA_SIM
+  xdma_sim_workload_close(false);
   xdma_sim_close(0);
 #endif //FPGA_SIM
 }

--- a/src/test/vsrc/fpga_sim/xdma_wrapper.v
+++ b/src/test/vsrc/fpga_sim/xdma_wrapper.v
@@ -22,7 +22,7 @@
 //   - AXI4-Lite replays fpga-host BAR writes into the Chisel ConfigBar.
 //
 // H2C/DDRs are intentionally not modeled here; BOARD=sim keeps RAM/MMIO inside
-// SimTop and the workload still enters through the existing simv +workload path.
+// SimTop and the host asks simv to load DDR through XDMA_SIM shared memory.
 module xdma_wrapper(
   input pcie_clock,
   input axilite_clock,

--- a/src/test/vsrc/vcs/DifftestEndpoint.sv
+++ b/src/test/vsrc/vcs/DifftestEndpoint.sv
@@ -24,6 +24,13 @@ module DifftestEndpoint(
   output wire        workload_switch,
 `endif // ENABLE_WORKLOAD_SWITCH
 
+`ifdef FPGA_SIM
+  input  wire        difftest_hostCtrl_reset,
+  input  wire        difftest_hostCtrl_diffEnable,
+  input  wire        difftest_hostCtrl_ilaTrigger,
+  input  wire        difftest_hostCtrl_enableSquash,
+`endif // FPGA_SIM
+
   /* DifftestTopIO */
   output wire [63:0] difftest_logCtrl_begin,
   output wire [63:0] difftest_logCtrl_end,
@@ -49,6 +56,9 @@ import "DPI-C" function void set_seed(longint seed);
 import "DPI-C" function void set_random_mem();
 import "DPI-C" function void set_simjtag();
 import "DPI-C" function byte simv_init();
+`ifdef FPGA_SIM
+import "DPI-C" function void simv_load_workload();
+`endif // FPGA_SIM
 import "DPI-C" function void set_max_instrs(longint mc);
 import "DPI-C" function longint get_stuck_limit();
 import "DPI-C" function void set_overwrite_nbytes(longint len);
@@ -293,6 +303,11 @@ always @(posedge clock) begin
         end
       end
     end
+`ifdef FPGA_SIM
+    if (difftest_hostCtrl_reset) begin
+      simv_load_workload();
+    end
+`endif // FPGA_SIM
   end
 end
 

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -255,6 +255,12 @@ DifftestEndpoint difftest(
 `ifdef ENABLE_WORKLOAD_SWITCH
   .workload_switch(workload_switch),
 `endif // ENABLE_WORKLOAD_SWITCH
+`ifdef FPGA_SIM
+  .difftest_hostCtrl_reset(host_ctrl_reset),
+  .difftest_hostCtrl_diffEnable(host_ctrl_diff_enable),
+  .difftest_hostCtrl_ilaTrigger(host_ctrl_ila_trigger),
+  .difftest_hostCtrl_enableSquash(host_ctrl_enable_squash),
+`endif // FPGA_SIM
   .difftest_logCtrl_begin(difftest_logCtrl_begin),
   .difftest_logCtrl_end(difftest_logCtrl_end),
   .difftest_logCtrl_level(difftest_logCtrl_level),


### PR DESCRIPTION
Previously, fpga-sim passed the workload to simv with +workload, so simv loaded the image during initialization.

This change makes FPGA_SIM follow the FPGA host workload load flow, where `simv` only load workload during hostReset.

To support this, `host` will write workload path to shared memory, and wait until `simv` read it. The `simv` will polls the shared memory during HostReset is asserted, and loads the image from the accepted path.