### PR TITLE
fix(fpga_sim): load simv workload before hostReset

### DIFF
--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -106,6 +106,10 @@ static bool run_external_cmd(const char *cmd, const char *tag) {
 
 void fpga_init() {
   xdma_device = new FpgaXdma();
+#ifdef FPGA_SIM
+  xdma_sim_set_workload(args.image);
+#endif // FPGA_SIM
+
   xdma_device->fpga_io(HOST_IO_RESET, true);
   xdma_device->fpga_io(HOST_IO_DIFFTEST_ENABLE, args.enable_diff);
   xdma_device->fpga_io(HOST_IO_ILA_TRIGGER, false);
@@ -124,9 +128,7 @@ void fpga_init() {
 
   init_device();
 
-#ifdef FPGA_SIM
-  xdma_sim_set_workload(args.image);
-#else
+#ifndef FPGA_SIM
   if (fpga_ddr_load_cmd) {
     if (!run_external_cmd(fpga_ddr_load_cmd, "DDR load")) {
       exit(0);

--- a/src/test/csrc/fpga_sim/xdma_sim.cpp
+++ b/src/test/csrc/fpga_sim/xdma_sim.cpp
@@ -99,6 +99,7 @@ typedef struct {
   pthread_cond_t accepted_cond;
   bool valid;
   bool accepted;
+  bool closed;
   char workload[WORKLOAD_PATH_SIZE];
 } xdma_workload_shm;
 
@@ -271,6 +272,7 @@ public:
       pthread_cond_wait(&shm_ptr->accepted_cond, &shm_ptr->lock);
     }
 
+    shm_ptr->closed = false;
     strcpy(shm_ptr->workload, workload);
     shm_ptr->accepted = false;
     shm_ptr->valid = true;
@@ -282,24 +284,39 @@ public:
     return 0;
   }
 
-  int get_workload(char *workload, size_t size) {
+  int wait_workload(char *workload, size_t size) {
     if (workload == nullptr || size == 0) {
       return -1;
     }
 
     pthread_mutex_lock(&shm_ptr->lock);
-    if (!shm_ptr->valid) {
+    while (!shm_ptr->valid && !shm_ptr->closed) {
+      pthread_cond_wait(&shm_ptr->accepted_cond, &shm_ptr->lock);
+    }
+    if (shm_ptr->closed) {
       pthread_mutex_unlock(&shm_ptr->lock);
       return 0;
     }
 
     strncpy(workload, shm_ptr->workload, size - 1);
     workload[size - 1] = '\0';
+    pthread_mutex_unlock(&shm_ptr->lock);
+    return 1;
+  }
+
+  void complete_workload() {
+    pthread_mutex_lock(&shm_ptr->lock);
     shm_ptr->valid = false;
     shm_ptr->accepted = true;
     pthread_cond_broadcast(&shm_ptr->accepted_cond);
     pthread_mutex_unlock(&shm_ptr->lock);
-    return 1;
+  }
+
+  void cancel() {
+    pthread_mutex_lock(&shm_ptr->lock);
+    shm_ptr->closed = true;
+    pthread_cond_broadcast(&shm_ptr->accepted_cond);
+    pthread_mutex_unlock(&shm_ptr->lock);
   }
 };
 
@@ -380,8 +397,16 @@ int xdma_sim_set_workload(const char *workload) {
   return workload_sim->set_workload(workload);
 }
 
-int xdma_sim_get_workload(char *workload, size_t size) {
-  return workload_sim->get_workload(workload, size);
+int xdma_sim_wait_workload(char *workload, size_t size) {
+  return workload_sim->wait_workload(workload, size);
+}
+
+void xdma_sim_complete_workload() {
+  workload_sim->complete_workload();
+}
+
+void xdma_sim_cancel_workload() {
+  workload_sim->cancel();
 }
 
 extern "C" void v_xdma_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {

--- a/src/test/csrc/fpga_sim/xdma_sim.h
+++ b/src/test/csrc/fpga_sim/xdma_sim.h
@@ -28,6 +28,8 @@ int xdma_sim_read(int channel, char *buf, size_t size);
 int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size);
 int xdma_sim_axilite_write(uint32_t addr, uint32_t data, uint8_t strb);
 int xdma_sim_set_workload(const char *workload);
-int xdma_sim_get_workload(char *workload, size_t size);
+int xdma_sim_wait_workload(char *workload, size_t size);
+void xdma_sim_complete_workload();
+void xdma_sim_cancel_workload();
 
 #endif // __XDMA_SIM_H__

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -37,11 +37,19 @@
 #include "remote_bitbang.h"
 #ifdef FPGA_SIM
 #include "xdma_sim.h"
+#include <pthread.h>
 #endif // FPGA_SIM
 
 static bool has_reset = false;
 static char *workload_list = NULL;
 static CommonArgs args;
+
+#ifdef FPGA_SIM
+static struct {
+  pthread_t thread;
+  bool started;
+} workload_loader;
+#endif // FPGA_SIM
 
 enum {
   SIMV_RUN,
@@ -185,11 +193,41 @@ extern "C" void set_simjtag() {
 }
 
 #ifdef FPGA_SIM
-extern "C" void simv_load_workload() {
+static void *fpga_sim_workload_thread_main(void *) {
   char workload[4096];
-  if (xdma_sim_get_workload(workload, sizeof(workload))) {
+  while (true) {
+    int ret = xdma_sim_wait_workload(workload, sizeof(workload));
+    if (ret <= 0) {
+      break;
+    }
     load_ram_image(workload);
+    xdma_sim_complete_workload();
   }
+  return nullptr;
+}
+
+static void start_fpga_sim_workload_thread() {
+  if (workload_loader.started) {
+    return;
+  }
+
+  int ret = pthread_create(&workload_loader.thread, nullptr, fpga_sim_workload_thread_main, nullptr);
+  if (ret != 0) {
+    errno = ret;
+    perror("XDMA_SIM: Failed to create workload loader thread");
+    exit(-1);
+  }
+  workload_loader.started = true;
+}
+
+static void stop_fpga_sim_workload_thread() {
+  if (!workload_loader.started) {
+    return;
+  }
+
+  xdma_sim_cancel_workload();
+  pthread_join(workload_loader.thread, nullptr);
+  workload_loader.started = false;
 }
 #endif // FPGA_SIM
 
@@ -210,6 +248,7 @@ extern "C" uint8_t simv_init() {
 #endif
 #ifdef FPGA_SIM
   xdma_sim_workload_open(false);
+  start_fpga_sim_workload_thread();
 #else
   if (args.gcpt_restore != NULL) {
     overwrite_ram(args.gcpt_restore, args.overwrite_nbytes);
@@ -288,6 +327,10 @@ void simv_finish() {
     goldenmem_finish();
   }
 #endif // CONFIG_NO_DIFFTEST
+
+#ifdef FPGA_SIM
+  stop_fpga_sim_workload_thread();
+#endif // FPGA_SIM
 
   finish_device();
   delete simMemory;

--- a/src/test/vsrc/vcs/DifftestEndpoint.sv
+++ b/src/test/vsrc/vcs/DifftestEndpoint.sv
@@ -56,9 +56,6 @@ import "DPI-C" function void set_seed(longint seed);
 import "DPI-C" function void set_random_mem();
 import "DPI-C" function void set_simjtag();
 import "DPI-C" function byte simv_init();
-`ifdef FPGA_SIM
-import "DPI-C" function void simv_load_workload();
-`endif // FPGA_SIM
 import "DPI-C" function void set_max_instrs(longint mc);
 import "DPI-C" function longint get_stuck_limit();
 import "DPI-C" function void set_overwrite_nbytes(longint len);
@@ -303,11 +300,6 @@ always @(posedge clock) begin
         end
       end
     end
-`ifdef FPGA_SIM
-    if (difftest_hostCtrl_reset) begin
-      simv_load_workload();
-    end
-`endif // FPGA_SIM
   end
 end
 


### PR DESCRIPTION
PR #881 loads the host-provided workload by hardware polling simv_get_workload during hostReset. That makes the host-side workload write depend on the reset, unlike real jtag-write-ddr in FPGA.

This change replace HW polling with SW thread, to support writing workload before hostReset.