### PR TITLE
fix(SimTop): only filter DUT AXI when isFPGA

### DIFF
--- a/src/main/scala/SimTop.scala
+++ b/src/main/scala/SimTop.scala
@@ -79,7 +79,7 @@ trait HasDiffTestInterfaces extends ImplicitClock with ImplicitReset { this: Raw
     val memPorts = difftestMemIO.toSeq.flatMap { memIO =>
       memIO.cpu +: memIO.mem.toSeq
     }
-    def memPortFilter(data: Data): Boolean = memPorts.contains(data)
+    def memPortFilter(data: Data): Boolean = memPorts.contains(data) && DifftestModule.isFPGA
     def portFilter(port: (String, Data)): Boolean = {
       memPortFilter(port._2) ||
       port._1.contains("bore") || // Internal port created by BoringUtils, connected to difftest only


### PR DESCRIPTION
Sometime we need dummy DiffTop with only DUT and difftest ports, but not contains GatewayEndpoint, such as using config.H In such top, axi ports should also be copied and wiring to top.