### PR TITLE
feat(Batch): apply skidBuffer to break ready timing path

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -19,7 +19,7 @@ import chisel3._
 import chisel3.util._
 import difftest._
 import difftest.gateway.GatewayConfig
-import difftest.util.{LookupTree, PipelineConnect}
+import difftest.util.{LookupTree, PipelineConnect, SkidBufferConnect}
 
 import scala.collection.mutable.ListBuffer
 
@@ -160,6 +160,7 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, con
   val in_group_single = in_group.filter(_.size == 1).toSeq
   val in_group_multi = in_group.filterNot(_.size == 1).toSeq
   val sorted = in_group_single.sortBy(getGroupDataWidth).reverse ++ in_group_multi.sortBy(getGroupDataWidth)
+  val groupDataWidths = sorted.map(getGroupDataWidth)
   val clusterMaxDataChunks = sorted.map(getGroupDataChunks)
   val stepMaxDataChunks = clusterMaxDataChunks.sum
   val stepMaxPayloadChunks = param.StepInfoChunks + stepMaxDataChunks
@@ -168,7 +169,7 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, con
 
   // Stage 1: compact valid bundles inside each cluster and collect per-cluster stats.
   class GroupBundle extends Bundle {
-    val data = MixedVec(sorted.map(getGroupDataWidth).map(group_w => UInt(group_w.W)))
+    val data = MixedVec(groupDataWidths.map(group_w => UInt(group_w.W)))
     val info = Vec(param.StepGroupSize, UInt(param.infoWidth.W))
     val status = Vec(param.StepGroupSize, new BatchStats(param))
     val trace_info = Option.when(config.hasReplay)(new DiffTraceInfo(config))
@@ -191,9 +192,10 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, con
   }
 
   // Stage 2: build the chunk-aligned step payload from info and cluster data.
-  // This pipeline register is held while Batch scans the payload beats.
+  // This register is held while Batch scans the payload beats.
+  // Ready backpressure chain is cut off by skidBuffer for timing
   val delay_grouped = Wire(Decoupled(new GroupBundle))
-  PipelineConnect(grouped, delay_grouped, delay_grouped.fire)
+  SkidBufferConnect(grouped, delay_grouped, splitDepth = 2)
 
   val delay_group_data = delay_grouped.bits.data
   val delay_group_info = delay_grouped.bits.info

--- a/src/main/scala/util/SkidBufferConnect.scala
+++ b/src/main/scala/util/SkidBufferConnect.scala
@@ -1,0 +1,76 @@
+/***************************************************************************************
+ * Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.util
+
+import chisel3._
+import chisel3.util._
+
+object SkidBufferConnect {
+  def apply[T <: Data](left: DecoupledIO[T], right: DecoupledIO[T], splitDepth: Int = 0): T = {
+    require(splitDepth >= 0)
+    val full = RegInit(false.B)
+    val hold = !full && left.valid && !right.ready
+
+    left.ready := !full
+    right.valid := left.valid || full
+    connectBits(left.bits, right.bits, hold, full, splitDepth)
+
+    when(full) {
+      when(right.ready) {
+        full := false.B
+      }
+    }.otherwise {
+      when(left.valid && !right.ready) {
+        full := true.B
+      }
+    }
+
+    right.bits
+  }
+
+  def apply[T <: Data](left: DecoupledIO[T], splitDepth: Int): DecoupledIO[T] = {
+    val right = Wire(Decoupled(chiselTypeOf(left.bits)))
+    apply(left, right, splitDepth)
+    right
+  }
+
+  def apply[T <: Data](left: DecoupledIO[T]): DecoupledIO[T] = apply(left, splitDepth = 0)
+
+  private def connectBits(left: Data, right: Data, hold: Bool, useHeld: Bool, depth: Int): Unit = {
+    (left, right) match {
+      case (leftVec: Vec[_], rightVec: Vec[_]) if depth > 0 =>
+        require(leftVec.length == rightVec.length)
+        leftVec.zip(rightVec).foreach { case (leftElem, rightElem) =>
+          connectBits(leftElem, rightElem, hold, useHeld, depth - 1)
+        }
+      case (leftRecord: Record, rightRecord: Record) if depth > 0 =>
+        leftRecord.elements.foreach { case (name, leftElem) =>
+          connectBits(leftElem, rightRecord.elements(name), hold, useHeld, depth - 1)
+        }
+      case _ =>
+        connectLeaf(left, right, hold, useHeld)
+    }
+  }
+
+  private def connectLeaf(left: Data, right: Data, hold: Bool, useHeld: Bool): Unit = {
+    val held = Reg(chiselTypeOf(left))
+    when(hold) {
+      held := left
+    }
+    right := Mux(useHeld, held, left)
+  }
+}


### PR DESCRIPTION
This change insert a skidBuffer between same-group cluster and cross-group collector, so as to break ready backpressure chain for better timing.