### PR TITLE
feat(fpga): align 256bit AXIs and bank Diff2AXI for timing

### DIFF
--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -41,9 +41,10 @@ case class GatewayConfig(
   isDelta: Boolean = false,
   isBatch: Boolean = false,
   batchSize: Int = 64,
-  batchChunkBytes: Int = 64,
+  batchChunkBytes: Int = 32,
   batchBeatChunks: Int = 2,
   hasInternalStep: Boolean = false,
+  hostAxisBytes: Int = 32,
   isNonBlock: Boolean = false,
   hasBuiltInPerf: Boolean = false,
   traceDump: Boolean = false,
@@ -88,7 +89,7 @@ case class GatewayConfig(
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
     if (traceDump || traceLoad) macros += "CONFIG_DIFFTEST_IOTRACE"
-    if (isFPGA) macros += "CONFIG_DIFFTEST_FPGA"
+    if (isFPGA) macros ++= Seq("CONFIG_DIFFTEST_FPGA", s"CONFIG_DIFFTEST_HOST_AXIS_BYTES ${hostAxisBytes}")
     macros.toSeq
   }
   def vMacros: Seq[String] = {
@@ -99,7 +100,12 @@ case class GatewayConfig(
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
     if (traceDump || traceLoad) macros += "CONFIG_DIFFTEST_IOTRACE"
-    if (isFPGA) macros += "CONFIG_DIFFTEST_FPGA"
+    if (isFPGA)
+      macros ++= Seq(
+        "CONFIG_DIFFTEST_FPGA",
+        s"CONFIG_DIFFTEST_HOST_AXIS_BYTES ${hostAxisBytes}",
+        s"CONFIG_DIFFTEST_HOST_AXIS_WIDTH ${hostAxisBytes * 8}",
+      )
     if (hasClockGate) macros += "CONFIG_DIFFTEST_CLOCKGATE"
     macros.toSeq
   }
@@ -107,7 +113,7 @@ case class GatewayConfig(
     if (hasReplay) require(isSquash)
     if (hasInternalStep) require(isBatch)
     if (isBatch) require(!hasDutZone)
-    if (isBatch) require(batchChunkBytes >= 64 && isPow2(batchChunkBytes))
+    if (isBatch) require(isPow2(batchChunkBytes))
     if (isBatch) require(batchBeatChunks > 0 && isPow2(batchBeatChunks))
     // Currently Delta depends on Batch to ensure update and sync order
     if (isDelta) require(isBatch)
@@ -157,6 +163,8 @@ object Gateway {
   private var config = GatewayConfig()
 
   def isFPGA: Boolean = config.isFPGA
+  def hostAxisBytes: Int = config.hostAxisBytes
+  def hostAxisWidth: Int = hostAxisBytes * 8
 
   def setConfig(cfg: String): Unit = {
     cfg.foreach {

--- a/src/main/scala/SimTop.scala
+++ b/src/main/scala/SimTop.scala
@@ -30,6 +30,7 @@ import difftest.common.{
   VerilogAXI4StreamRecord,
 }
 import difftest.fpga.{DifftestMemCtrl, HostEndpoint, XDMAConfigBar, XDMAHostCtrlIO}
+import difftest.gateway.Gateway
 
 class DifftestTopIO extends Bundle {
   val exit = Output(UInt(64.W))
@@ -158,7 +159,7 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
         val cfg = Module(new XDMAConfigBar)
         cfgResetReq := cfg.io.cfgReset
         val ctrl = cfg.io.hostCtrl
-        val host = Module(new HostEndpoint(fpgaIO.bits.getWidth))
+        val host = Module(new HostEndpoint(fpgaIO.bits.getWidth, Gateway.hostAxisWidth))
 
         host.io.difftest.valid := fpgaIO.valid && ctrl.diffEnable
         host.io.difftest.bits := fpgaIO.bits
@@ -170,7 +171,7 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
         val to_host_axis = IO(VerilogAXI4StreamRecord.typeOf(toHost))
         to_host_axis.viewAs[AXI4Stream] <> toHost
 
-        val from_host_axis = IO(Flipped(new VerilogAXI4StreamRecord(512)))
+        val from_host_axis = IO(Flipped(new VerilogAXI4StreamRecord(Gateway.hostAxisWidth)))
 
         val cfg_axilite = IO(Flipped(new VerilogAXI4LiteRecord(32, 32)))
         cfg.io.axilite <> cfg_axilite.viewAs[AXI4LiteBundle]
@@ -186,7 +187,7 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
         cpu.difftestMemIO.foreach { case DifftestMemIO(cpuRecord, memRecord) =>
           val cpuAxi = Wire(AXI4Bundle.typeOf(cpuRecord))
           AXI4Bundle.connectRecord(cpuAxi, cpuRecord)
-          val memCtrl = Module(new DifftestMemCtrl(cpuAxi.cloneType, baseAddr = 0x80000000L))
+          val memCtrl = Module(new DifftestMemCtrl(cpuAxi.cloneType, Gateway.hostAxisWidth, baseAddr = 0x80000000L))
           memCtrl.io.ctrl <> cfg.io.memCtrl
           memCtrl.io.pcie_clock := pcie_clock
           memCtrl.io.h2c <> from_host_axis.viewAs[AXI4Stream]

--- a/src/main/scala/fpga/DifftestMemCtrl.scala
+++ b/src/main/scala/fpga/DifftestMemCtrl.scala
@@ -213,6 +213,7 @@ class H2CAXIs2Mem(
 
 class DifftestMemCtrl(
   axiType: AXI4Bundle,
+  hostAxisWidth: Int,
   baseAddr: BigInt,
 ) extends Module {
   private val addrWidth = axiType.addrWidth
@@ -227,7 +228,7 @@ class DifftestMemCtrl(
   val io = IO(new Bundle {
     val ctrl = Flipped(new XDMAMemCtrlIO)
     val pcie_clock = Input(Clock())
-    val h2c = Flipped(new AXI4Stream(512))
+    val h2c = Flipped(new AXI4Stream(hostAxisWidth))
     val cpu = Flipped(new AXI4Bundle(addrWidth, dataWidth, idWidth, userWidth))
     val mem = new AXI4Bundle(addrWidth, dataWidth, idWidth, userWidth)
   })
@@ -255,7 +256,7 @@ class DifftestMemCtrl(
   private val memSrcH2C = io.ctrl.memH2C && !memSrcInit
   private val memSrcCPU = io.ctrl.memCPU && !memSrcInit && !memSrcH2C
   private val memInitAxi = Wire(new AXI4Bundle(addrWidth, dataWidth, idWidth, userWidth))
-  private val h2c = Module(new H2CAXIs2Mem(512, addrWidth, dataWidth, idWidth, userWidth, baseAddr))
+  private val h2c = Module(new H2CAXIs2Mem(hostAxisWidth, addrWidth, dataWidth, idWidth, userWidth, baseAddr))
 
   h2c.io.pcie_clock := io.pcie_clock
   h2c.io.enable := io.ctrl.memH2C

--- a/src/main/scala/fpga/Host.scala
+++ b/src/main/scala/fpga/Host.scala
@@ -38,8 +38,14 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
   val fifo_depth = 16
   val fifo_addr_width = log2Ceil(fifo_depth)
 
-  // FIFO implementation using SyncReadMem
-  val fifo_ram = SyncReadMem(fifo_depth, UInt(difftest_width.W))
+  // FIFO implementation using banked SyncReadMem.
+  // Each bank is one AXI beat wide, so the read side can keep the original
+  // packet-to-AXIS slicing order while reducing the width of every memory.
+  val bank_width = axis_width
+  val num_banks = (difftest_width + bank_width - 1) / bank_width
+  val banked_width = num_banks * bank_width
+  val bank_pad_width = banked_width - difftest_width
+  val fifo_banks = Seq.fill(num_banks)(SyncReadMem(fifo_depth, UInt(bank_width.W)))
 
   // Define counters that are accessible in both clock domains
   val wr_cnt = RegInit(0.U(64.W))
@@ -56,7 +62,16 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
   val wr_en = io.difftest.fire
 
   when(wr_en) {
-    fifo_ram.write(wr_ptr, io.difftest.bits)
+    val writePayload =
+      if (bank_pad_width > 0) {
+        Cat(0.U(bank_pad_width.W), io.difftest.bits)
+      } else {
+        io.difftest.bits
+      }
+    val writeBanks = writePayload.asTypeOf(Vec(num_banks, UInt(bank_width.W)))
+    for (i <- 0 until num_banks) {
+      fifo_banks(i).write(wr_ptr, writeBanks(i))
+    }
     wr_ptr := wr_ptr + 1.U
     wr_cnt := wr_cnt + 1.U // Increment write counter
   }
@@ -74,8 +89,12 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
     val counter = RegInit(0.U(3.W)) // 0 to 7
     val currentPktID = RegInit(0.U(pkt_id_w.W))
     val sendPacketEnd = counter === (numPacketPerRange - 1).U
-    // Read from FIFO
-    val fifo_out = fifo_ram.read(rd_ptr)
+    // Read from FIFO banks and reconstruct the original packet payload.
+    val fifoBankOut = Wire(Vec(num_banks, UInt(bank_width.W)))
+    for (i <- 0 until num_banks) {
+      fifoBankOut(i) := fifo_banks(i).read(rd_ptr)
+    }
+    val fifo_out = fifoBankOut.asUInt(difftest_width - 1, 0)
     val packetPayload =
       if (payload_pad_width > 0) {
         Cat(0.U(payload_pad_width.W), fifo_out, currentPktID)
@@ -124,7 +143,7 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
 
 class HostEndpoint(
   val diffWidth: Int,
-  val axisWidth: Int = 512,
+  val axisWidth: Int,
 ) extends Module {
   val io = IO(new Bundle {
     val difftest = Flipped(new FpgaDiffIO(diffWidth))

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -35,7 +35,7 @@
 #define XDMA_BYPASS     "/dev/xdma0_bypass"
 #define XDMA_C2H_DEVICE "/dev/xdma0_c2h_"
 #define XDMA_H2C_DEVICE "/dev/xdma0_h2c_0"
-static const size_t H2C_AXIS_BYTES = 64;
+static const size_t H2C_AXIS_BYTES = CONFIG_DIFFTEST_HOST_AXIS_BYTES;
 
 void signal_handler(int sig) {
   void *array[20];

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -46,8 +46,10 @@
 
 #define DMA_PACKGE_NUM 8
 // DMA_PADDING (packge_idx(1) + difftest_data) send width to be calculated by mod up
-#define DMA_PACKGE_LEN     (CONFIG_DIFFTEST_BATCH_BYTELEN + 1)
-#define DMA_PACKGE_ALIGNED ((DMA_PACKGE_LEN + 63) / 64 * 64)
+#define DMA_PACKGE_LEN (CONFIG_DIFFTEST_BATCH_BYTELEN + 1)
+#define DMA_PACKGE_ALIGNED                                                                    \
+  ((DMA_PACKGE_LEN + CONFIG_DIFFTEST_HOST_AXIS_BYTES - 1) / CONFIG_DIFFTEST_HOST_AXIS_BYTES * \
+   CONFIG_DIFFTEST_HOST_AXIS_BYTES)
 #define DMA_PACKGE_PADDING (DMA_PACKGE_ALIGNED - DMA_PACKGE_LEN)
 
 typedef struct __attribute__((packed)) {

--- a/src/test/csrc/fpga_sim/xdma_sim.cpp
+++ b/src/test/csrc/fpga_sim/xdma_sim.cpp
@@ -14,6 +14,7 @@
  * See the Mulan PSL v2 for more details.
  ***************************************************************************************/
 #include "xdma_sim.h"
+#include "difftest-state.h"
 #include <assert.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -530,11 +531,11 @@ void xdma_sim_cancel_workload() {
 }
 
 extern "C" void v_xdma_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {
-  xdma_sim_write(channel, axi_tdata, axi_tlast, 64);
+  xdma_sim_write(channel, axi_tdata, axi_tlast, CONFIG_DIFFTEST_HOST_AXIS_BYTES);
 }
 
 extern "C" void v_xdma_c2h_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {
-  xdma_sim_write(channel, axi_tdata, axi_tlast, 64);
+  xdma_sim_write(channel, axi_tdata, axi_tlast, CONFIG_DIFFTEST_HOST_AXIS_BYTES);
 }
 
 #ifndef FPGA_HOST
@@ -554,10 +555,11 @@ extern "C" void v_xdma_h2c_write(const svBitVecVal *axi_tdata, uint64_t axi_tkee
 static void *xdma_h2c_thread_main(void *) {
   xdma_sim_h2c_open(0, false);
   while (!h2c_thread_stop) {
-    svBitVecVal data[16] = {};
+    svBitVecVal data[(CONFIG_DIFFTEST_HOST_AXIS_BYTES + sizeof(svBitVecVal) - 1) / sizeof(svBitVecVal)] = {};
     uint64_t tkeep = 0;
     uint8_t tlast = 0;
-    if (!h2c_sim[0]->wait(reinterpret_cast<char *>(data), &tkeep, &tlast, 64, &h2c_thread_stop)) {
+    if (!h2c_sim[0]->wait(reinterpret_cast<char *>(data), &tkeep, &tlast, CONFIG_DIFFTEST_HOST_AXIS_BYTES,
+                          &h2c_thread_stop)) {
       continue;
     }
 

--- a/src/test/vsrc/fpga_sim/xdma_axi_c2h.v
+++ b/src/test/vsrc/fpga_sim/xdma_axi_c2h.v
@@ -19,7 +19,7 @@
 module xdma_axi_c2h(
   input clock,
   input reset,
-  input [511:0] axi_tdata,
+  input [`CONFIG_DIFFTEST_HOST_AXIS_WIDTH-1:0] axi_tdata,
   input axi_tlast,
   output axi_tready,
   input axi_tvalid
@@ -27,7 +27,7 @@ module xdma_axi_c2h(
 
 import "DPI-C" function void v_xdma_c2h_write(
   input byte channel,
-  input bit [511:0] axi_tdata,
+  input bit [`CONFIG_DIFFTEST_HOST_AXIS_WIDTH-1:0] axi_tdata,
   input bit axi_tlast
 );
 

--- a/src/test/vsrc/fpga_sim/xdma_axi_h2c.v
+++ b/src/test/vsrc/fpga_sim/xdma_axi_h2c.v
@@ -19,8 +19,8 @@
 module xdma_axi_h2c(
   input clock,
   input reset,
-  output reg [511:0] axi_tdata,
-  output reg [63:0] axi_tkeep,
+  output reg [`CONFIG_DIFFTEST_HOST_AXIS_WIDTH-1:0] axi_tdata,
+  output reg [`CONFIG_DIFFTEST_HOST_AXIS_BYTES-1:0] axi_tkeep,
   output reg axi_tlast,
   input axi_tready,
   output reg axi_tvalid
@@ -29,25 +29,25 @@ module xdma_axi_h2c(
 import "DPI-C" context function void v_xdma_h2c_set_scope();
 
 reg        pending_valid;
-reg [511:0] pending_data;
-reg [63:0] pending_keep;
+reg [`CONFIG_DIFFTEST_HOST_AXIS_WIDTH-1:0] pending_data;
+reg [`CONFIG_DIFFTEST_HOST_AXIS_BYTES-1:0] pending_keep;
 reg        pending_last;
 
 initial begin
-  axi_tdata = 512'b0;
-  axi_tkeep = 64'b0;
+  axi_tdata = `CONFIG_DIFFTEST_HOST_AXIS_WIDTH'b0;
+  axi_tkeep = `CONFIG_DIFFTEST_HOST_AXIS_BYTES'b0;
   axi_tlast = 1'b0;
   axi_tvalid = 1'b0;
   pending_valid = 1'b0;
-  pending_data = 512'b0;
-  pending_keep = 64'b0;
+  pending_data = `CONFIG_DIFFTEST_HOST_AXIS_WIDTH'b0;
+  pending_keep = `CONFIG_DIFFTEST_HOST_AXIS_BYTES'b0;
   pending_last = 1'b0;
   v_xdma_h2c_set_scope();
 end
 
 export "DPI-C" task v_xdma_h2c_write;
 task v_xdma_h2c_write(
-  input bit [511:0] data,
+  input bit [`CONFIG_DIFFTEST_HOST_AXIS_WIDTH-1:0] data,
   input longint unsigned keep,
   input bit last,
   output byte unsigned accepted
@@ -68,8 +68,8 @@ endtask
 
 always @(posedge clock) begin
   if (reset) begin
-    axi_tdata <= 512'b0;
-    axi_tkeep <= 64'b0;
+    axi_tdata <= `CONFIG_DIFFTEST_HOST_AXIS_WIDTH'b0;
+    axi_tkeep <= `CONFIG_DIFFTEST_HOST_AXIS_BYTES'b0;
     axi_tlast <= 1'b0;
     axi_tvalid <= 1'b0;
     pending_valid = 1'b0;

--- a/src/test/vsrc/fpga_sim/xdma_wrapper.v
+++ b/src/test/vsrc/fpga_sim/xdma_wrapper.v
@@ -26,13 +26,13 @@ module xdma_wrapper(
   input axilite_clock,
   input reset,
 
-  input [511:0] axi_c2h_tdata,
+  input [`CONFIG_DIFFTEST_HOST_AXIS_WIDTH-1:0] axi_c2h_tdata,
   input         axi_c2h_tlast,
   output        axi_c2h_tready,
   input         axi_c2h_tvalid,
 
-  output [511:0] axi_h2c_tdata,
-  output [63:0]  axi_h2c_tkeep,
+  output [`CONFIG_DIFFTEST_HOST_AXIS_WIDTH-1:0] axi_h2c_tdata,
+  output [`CONFIG_DIFFTEST_HOST_AXIS_BYTES-1:0] axi_h2c_tkeep,
   output         axi_h2c_tlast,
   input          axi_h2c_tready,
   output         axi_h2c_tvalid,


### PR DESCRIPTION
Use a 256-bit AXI-Stream interface to match the XDMA configuration (PCIe x4/x8 is 256-bit), and configure it through Gateway for both hardware parameters and software macros.
Also bank Diff2AXI with a 256-bit beat width to avoid wide memory and improve timing.