### PR TITLE
fix(fpga): make XDMA H2C workload size-driven

### DIFF
--- a/src/main/scala/fpga/DifftestMemCtrl.scala
+++ b/src/main/scala/fpga/DifftestMemCtrl.scala
@@ -102,6 +102,7 @@ class H2CAXIs2Mem(
   val io = IO(new Bundle {
     val pcie_clock = Input(Clock())
     val enable = Input(Bool())
+    val sizeMB = Input(UInt(32.W))
     val axis = Flipped(new AXI4Stream(axisWidth))
     val axi = new AXI4Bundle(addrWidth, dataWidth, idWidth, userWidth)
     val done = Output(Bool())
@@ -114,7 +115,6 @@ class H2CAXIs2Mem(
   private val chunkWidth = log2Ceil(chunksPerAxis).max(1)
   private val burstWidth = log2Ceil(chunksPerAxis + 1).max(1)
   private val beatBytes = dataWidth / 8
-  private val axisBytes = axisWidth / 8
 
   private val fifo = Module(new AsyncClockFIFO(new AXI4StreamBundle(axisWidth), fifoDepth))
   private val enableSync = withClockAndReset(io.pcie_clock, reset) {
@@ -128,17 +128,13 @@ class H2CAXIs2Mem(
 
   private val state = RegInit(sIdle)
   private val addr = RegInit(baseAddr.U(addrWidth.W))
+  private val beatsLeft = RegInit(0.U((addrWidth + 1).W))
   private val payload = Reg(UInt(axisWidth.W))
-  private val payloadKeep = Reg(UInt(axisBytes.W))
-  private val payloadLast = RegInit(false.B)
   private val chunk = RegInit(0.U(chunkWidth.W))
   private val burstBeats = RegInit(0.U(burstWidth.W))
   private val burstBeat = RegInit(0.U(burstWidth.W))
   private val payloadWords = payload.asTypeOf(Vec(chunksPerAxis, UInt(dataWidth.W)))
-  private val payloadKeeps = payloadKeep.asTypeOf(Vec(chunksPerAxis, UInt(beatBytes.W)))
-  private val validBytes = PopCount(fifo.io.deq.bits.keep.asBools)
-  private val beatsFromKeep = (validBytes + (beatBytes - 1).U) >> log2Ceil(beatBytes)
-  private val beatsInPayload = beatsFromKeep(burstWidth - 1, 0)
+  private val beatsInPayload = chunksPerAxis.U(burstWidth.W)
 
   io.axi.aw.valid := state === sAddr
   io.axi.aw.bits := 0.U.asTypeOf(io.axi.aw.bits)
@@ -149,7 +145,7 @@ class H2CAXIs2Mem(
 
   io.axi.w.valid := state === sData
   io.axi.w.bits.data := payloadWords(chunk)
-  io.axi.w.bits.strb := payloadKeeps(chunk)
+  io.axi.w.bits.strb := Fill(beatBytes, 1.U(1.W))
   io.axi.w.bits.last := burstBeat === burstBeats - 1.U
 
   io.axi.b.ready := state === sResp
@@ -163,22 +159,23 @@ class H2CAXIs2Mem(
   when(!io.enable) {
     state := sIdle
     addr := baseAddr.U(addrWidth.W)
+    beatsLeft := (io.sizeMB << (20 - log2Ceil(beatBytes))).asUInt
   }.otherwise {
     switch(state) {
       is(sIdle) {
-        when(fifo.io.deq.valid) {
+        when(beatsLeft === 0.U) {
+          state := sDone
+        }.elsewhen(fifo.io.deq.valid) {
           state := sReadPayload
         }
       }
       is(sReadPayload) {
         when(fifo.io.deq.fire) {
           payload := fifo.io.deq.bits.data
-          payloadKeep := fifo.io.deq.bits.keep
-          payloadLast := fifo.io.deq.bits.last
           chunk := 0.U
           burstBeat := 0.U
-          burstBeats := beatsInPayload
-          state := Mux(beatsInPayload === 0.U, Mux(fifo.io.deq.bits.last, sDone, sReadPayload), sAddr)
+          burstBeats := Mux(beatsLeft > beatsInPayload, beatsInPayload, beatsLeft(burstWidth - 1, 0))
+          state := sAddr
         }
       }
       is(sAddr) {
@@ -199,7 +196,8 @@ class H2CAXIs2Mem(
       }
       is(sResp) {
         when(io.axi.b.fire) {
-          state := Mux(payloadLast, sDone, sReadPayload)
+          beatsLeft := beatsLeft - burstBeats.asTypeOf(beatsLeft)
+          state := Mux(beatsLeft === burstBeats.asTypeOf(beatsLeft), sDone, sReadPayload)
         }
       }
       is(sDone) {
@@ -260,6 +258,7 @@ class DifftestMemCtrl(
 
   h2c.io.pcie_clock := io.pcie_clock
   h2c.io.enable := io.ctrl.memH2C
+  h2c.io.sizeMB := io.ctrl.h2cSizeMB
   h2c.io.axis <> io.h2c
 
   io.ctrl.memStatus := MuxCase(

--- a/src/main/scala/fpga/XDMAConfigBar.scala
+++ b/src/main/scala/fpga/XDMAConfigBar.scala
@@ -33,6 +33,7 @@ import difftest.common.AXI4LiteBundle
   *   - 0x1c: HOST_IO_MEM_INIT
   *   - 0x20: HOST_IO_MEM_CPU
   *   - 0x24: HOST_IO_MEM_H2C
+  *   - 0x28: HOST_IO_H2C_SIZE_MB
   */
 class XDMAHostCtrlIO extends Bundle {
   val reset = Bool()
@@ -47,11 +48,13 @@ class XDMAMemCtrlIO extends Bundle {
   val memCPU = Output(Bool())
   val seed = Output(UInt(32.W))
   val ramSizeMB = Output(UInt(32.W))
+  val h2cSizeMB = Output(UInt(32.W))
   val memStatus = Input(UInt(2.W))
 }
 
 private object XDMAConfigReg extends Enumeration {
-  val CfgReset, HostReset, DiffEnable, IlaTrigger, EnableSquash, Seed, RamSizeMB, MemInit, MemCPU, MemH2C = Value
+  val CfgReset, HostReset, DiffEnable, IlaTrigger, EnableSquash, Seed, RamSizeMB, MemInit, MemCPU, MemH2C, H2CSizeMB =
+    Value
 }
 
 class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Module {
@@ -77,6 +80,7 @@ class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Mo
   io.memCtrl.memCPU := regfile(XDMAConfigReg.MemCPU.id)(0)
   io.memCtrl.seed := regfile(XDMAConfigReg.Seed.id)
   io.memCtrl.ramSizeMB := regfile(XDMAConfigReg.RamSizeMB.id)
+  io.memCtrl.h2cSizeMB := regfile(XDMAConfigReg.H2CSizeMB.id)
   io.cfgReset := regfile(XDMAConfigReg.CfgReset.id)(0)
 
   private def mergeByByte(oldData: UInt, newData: UInt, strb: UInt): UInt = {

--- a/src/test/csrc/common/ram.cpp
+++ b/src/test/csrc/common/ram.cpp
@@ -18,6 +18,7 @@
 #include "common.h"
 #include "compress.h"
 #include "elfloader.h"
+#include <cstring>
 #include <iostream>
 #ifdef CONFIG_DIFFTEST_PERFCNT
 #include "perf.h"
@@ -338,6 +339,24 @@ void MmapMemory::load_image(const char *image) {
     img_size = reader->read_all(ram, memory_size);
     delete reader;
   }
+}
+
+uint64_t MmapMemory::pad_img_size(uint64_t align) {
+  if (align == 0) {
+    fprintf(stderr, "invalid image padding alignment: 0\n");
+    exit(1);
+  }
+
+  uint64_t padded_size = ((img_size + align - 1) / align) * align;
+  if (padded_size > memory_size) {
+    fprintf(stderr, "image padding exceeds memory size: image=%lu padded=%lu memory=%lu\n", img_size, padded_size,
+            memory_size);
+    exit(1);
+  }
+
+  memset(reinterpret_cast<uint8_t *>(ram) + img_size, 0, padded_size - img_size);
+  img_size = padded_size;
+  return img_size;
 }
 
 MmapMemory::~MmapMemory() {

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -140,6 +140,7 @@ public:
   MmapMemory(const char *image, uint64_t n_bytes, bool random_mem, uint32_t seed);
   virtual ~MmapMemory();
   void load_image(const char *image);
+  uint64_t pad_img_size(uint64_t align);
   void clone(std::function<void(void *, uint64_t)> func, bool skip_zero = false) {
     uint64_t n_bytes = (skip_zero && !clone_full_mem) ? img_size : get_size();
     func(ram, n_bytes);

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -27,7 +27,9 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <getopt.h>
+#include <inttypes.h>
 #include <mutex>
+#include <stdint.h>
 #include <unistd.h>
 #ifdef FPGA_SIM
 #include "xdma_sim.h"
@@ -117,6 +119,11 @@ void fpga_init() {
   xdma_device->fpga_io(HOST_IO_CFG_RESET, true);
   sleep(1);
 
+  init_ram(args.image, ram_size, args.random_mem, args.seed);
+  init_flash(args.flash_bin);
+
+  init_device();
+
   if (args.random_mem) {
     xdma_device->fpga_io(HOST_IO_SEED, args.seed);
     xdma_device->fpga_io(HOST_IO_RAM_SIZE_MB, ram_size_mb);
@@ -128,9 +135,15 @@ void fpga_init() {
   }
 
 #ifdef CONFIG_USE_XDMA_H2C
+  auto *mem = dynamic_cast<MmapMemory *>(simMemory);
+  assert(mem);
+  uint64_t h2c_size = mem->pad_img_size(1024ull * 1024ull);
+  uint64_t h2c_size_mb = h2c_size / (1024ull * 1024ull);
+  printf("[fpga-host] H2C workload size: %" PRIu64 " bytes (%" PRIu64 "MB)\n", h2c_size, h2c_size_mb);
   uint32_t h2c_start = uptime();
+  xdma_device->fpga_io(HOST_IO_H2C_SIZE_MB, static_cast<uint32_t>(h2c_size_mb));
   xdma_device->fpga_io(HOST_IO_MEM_H2C, true);
-  xdma_device->h2c_load_workload(args.image, ram_size);
+  xdma_device->h2c_load_workload(mem->as_ptr(), h2c_size);
   xdma_device->wait_fpga_io_done(HOST_IO_MEM_H2C, "memory H2C load");
   printf("[fpga-host] H2C load done, elapsed = %ums\n", uptime() - h2c_start);
 #else // CONFIG_USE_XDMA_H2C
@@ -158,11 +171,6 @@ void fpga_init() {
   serial_port = new SerialPort("/dev/ttyUSB0");
   serial_port->start();
 #endif // USE_SERIAL_PORT
-
-  init_ram(args.image, ram_size, args.random_mem, args.seed);
-  init_flash(args.flash_bin);
-
-  init_device();
 
   difftest_init(args.enable_diff, ram_size);
 

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -19,6 +19,7 @@
 #include "ram.h"
 #include <algorithm>
 #include <cstring>
+#include <errno.h>
 #include <execinfo.h>
 #include <fcntl.h>
 #include <fstream>
@@ -123,41 +124,51 @@ void FpgaXdma::wait_fpga_io_done(uint64_t address, const char *tag) {
 }
 
 #ifdef CONFIG_USE_XDMA_H2C
-void FpgaXdma::h2c_load_workload(const char *workload, uint64_t ram_size) {
-  MmapMemory memory(workload, ram_size, false, 0);
-  uint64_t img_size = memory.get_img_size();
-  const uint8_t *image = reinterpret_cast<const uint8_t *>(memory.as_ptr());
-  if (image == nullptr) {
+void FpgaXdma::h2c_load_workload(const void *payload, uint64_t size) {
+  if (payload == nullptr) {
     fprintf(stderr, "[fpga-host] H2C load requires mmap-backed memory image\n");
+    exit(-1);
+  }
+  if (size == 0) {
+    fprintf(stderr, "[fpga-host] H2C workload size must be non-zero\n");
     exit(-1);
   }
 
 #ifdef FPGA_SIM
   uint64_t offset = 0;
-  while (offset < img_size) {
-    size_t beatBytes = std::min<uint64_t>(H2C_AXIS_BYTES, img_size - offset);
+  while (offset < size) {
+    size_t beatBytes = std::min<uint64_t>(H2C_AXIS_BYTES, size - offset);
     char beat[H2C_AXIS_BYTES] = {};
-    memcpy(beat, image + offset, beatBytes);
+    memcpy(beat, reinterpret_cast<const uint8_t *>(payload) + offset, beatBytes);
     uint64_t tkeep = beatBytes == H2C_AXIS_BYTES ? UINT64_MAX : ((1ULL << beatBytes) - 1);
-    if (xdma_sim_h2c_write(0, beat, tkeep, offset + beatBytes >= img_size, sizeof(beat)) != (int)sizeof(beat)) {
+    if (xdma_sim_h2c_write(0, beat, tkeep, offset + beatBytes >= size, sizeof(beat)) != (int)sizeof(beat)) {
       fprintf(stderr, "[fpga-host] FPGA_SIM H2C shared-memory write failed\n");
       exit(-1);
     }
     offset += beatBytes;
   }
-  printf("[fpga-host] FPGA_SIM H2C queued %" PRIu64 " bytes\n", img_size);
+  printf("[fpga-host] FPGA_SIM H2C queued %" PRIu64 " bytes\n", size);
 #else
-  const char *payload = reinterpret_cast<const char *>(image);
-  ssize_t written = write(xdma_h2c_fd, payload, img_size);
-  if (written < 0) {
-    perror("[fpga-host] XDMA H2C write failed");
-    exit(-1);
+  const char *buf = reinterpret_cast<const char *>(payload);
+  uint64_t offset = 0;
+  while (offset < size) {
+    uint64_t remaining = size - offset;
+    size_t request = std::min<uint64_t>(64ull * 1024ull * 1024ull, remaining); // 64MB per XDMA transfer
+    ssize_t written = write(xdma_h2c_fd, buf + offset, request);
+    if (written < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      perror("[fpga-host] XDMA H2C write failed");
+      exit(-1);
+    }
+    if (written == 0) {
+      fprintf(stderr, "[fpga-host] XDMA H2C zero write at offset=%" PRIu64 "\n", offset);
+      exit(-1);
+    }
+    offset += written;
   }
-  if ((size_t)written != img_size) {
-    fprintf(stderr, "[fpga-host] XDMA H2C partial write: %zd/%" PRIu64 " bytes\n", written, img_size);
-    exit(-1);
-  }
-  printf("[fpga-host] XDMA H2C queued %" PRIu64 " bytes\n", img_size);
+  printf("[fpga-host] XDMA H2C queued %" PRIu64 " bytes\n", size);
 #endif // FPGA_SIM
 }
 #endif // CONFIG_USE_XDMA_H2C

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -43,6 +43,7 @@
 #define HOST_IO_MEM_INIT        0x1c
 #define HOST_IO_MEM_CPU         0x20
 #define HOST_IO_MEM_H2C         0x24
+#define HOST_IO_H2C_SIZE_MB     0x28
 
 #define DMA_PACKGE_NUM 8
 // DMA_PADDING (packge_idx(1) + difftest_data) send width to be calculated by mod up
@@ -121,7 +122,7 @@ public:
 
   void wait_fpga_io_done(uint64_t address, const char *tag);
 #ifdef CONFIG_USE_XDMA_H2C
-  void h2c_load_workload(const char *workload, uint64_t ram_size);
+  void h2c_load_workload(const void *payload, uint64_t size);
 #endif
 
 private:


### PR DESCRIPTION
Pass the H2C workload size to hardware through the XDMA config BAR, and let DifftestMemCtrl count the exact number of memory beats to write. This removes the dependency on AXI-Stream TLAST for transfer completion. It allows H2C loading workload larger than 256MB.

Also pad the loaded MmapMemory image to an MB boundary with zero bytes, then reuse the same simMemory contents for H2C loading and difftest.