### PR TITLE
fix(fpga): use banked async FIFO for C2H packets

### DIFF
--- a/src/main/scala/fpga/DifftestMemCtrl.scala
+++ b/src/main/scala/fpga/DifftestMemCtrl.scala
@@ -28,9 +28,10 @@ object H2CAXIs2MemState extends ChiselEnum {
   val sIdle, sReadPayload, sAddr, sData, sResp, sDone = Value
 }
 
-class AsyncClockFIFO[T <: Data](gen: T, depth: Int) extends Module {
+class AsyncClockFIFO[T <: Data](gen: T, depth: Int, bankWidth: Int = 0) extends Module {
   require(isPow2(depth), s"AsyncClockFIFO depth must be power-of-two, got $depth")
   require(depth >= 4, s"AsyncClockFIFO depth must be at least 4, got $depth")
+  require(bankWidth >= 0, s"AsyncClockFIFO bankWidth must be non-negative, got $bankWidth")
 
   val io = IO(new Bundle {
     val enqClock = Input(Clock())
@@ -40,9 +41,48 @@ class AsyncClockFIFO[T <: Data](gen: T, depth: Int) extends Module {
 
   private val idxWidth = log2Ceil(depth)
   private val ptrWidth = idxWidth + 1
-  private val mem = Mem(depth, gen)
+  private val dataWidth = io.enq.bits.asUInt.getWidth
+  private val useBankedMem = bankWidth > 0 && bankWidth < dataWidth
+  private val numBanks = if (useBankedMem) (dataWidth + bankWidth - 1) / bankWidth else 0
+  private val bankedWidth = if (useBankedMem) numBanks * bankWidth else 0
+  private val bankPadWidth = if (useBankedMem) bankedWidth - dataWidth else 0
+  private val mem = if (useBankedMem) None else Some(Mem(depth, gen))
+  private val memBanks =
+    if (useBankedMem) Some(Seq.fill(numBanks)(Mem(depth, UInt(bankWidth.W)))) else None
 
   private def binToGray(x: UInt): UInt = (x >> 1) ^ x
+
+  private def readMem(addr: UInt): T = {
+    val out = Wire(chiselTypeOf(io.deq.bits))
+    if (useBankedMem) {
+      val bankOut = Wire(Vec(numBanks, UInt(bankWidth.W)))
+      memBanks.get.zipWithIndex.foreach { case (bank, i) =>
+        bankOut(i) := bank.read(addr)
+      }
+      out := bankOut.asUInt(dataWidth - 1, 0).asTypeOf(out)
+    } else {
+      out := mem.get.read(addr)
+    }
+    out
+  }
+
+  private def writeMem(addr: UInt, data: T): Unit = {
+    if (useBankedMem) {
+      val dataUInt = data.asUInt
+      val writePayload =
+        if (bankPadWidth > 0) {
+          Cat(0.U(bankPadWidth.W), dataUInt)
+        } else {
+          dataUInt
+        }
+      val writeBanks = writePayload.asTypeOf(Vec(numBanks, UInt(bankWidth.W)))
+      memBanks.get.zipWithIndex.foreach { case (bank, i) =>
+        bank.write(addr, writeBanks(i))
+      }
+    } else {
+      mem.get.write(addr, data)
+    }
+  }
 
   private val rdPtrBin = RegInit(0.U(ptrWidth.W))
   private val rdPtrGray = RegInit(0.U(ptrWidth.W))
@@ -57,7 +97,7 @@ class AsyncClockFIFO[T <: Data](gen: T, depth: Int) extends Module {
   private val empty = wrPtrGraySync === rdPtrGray
 
   io.deq.valid := !empty
-  io.deq.bits := mem(rdPtrBin(idxWidth - 1, 0))
+  io.deq.bits := readMem(rdPtrBin(idxWidth - 1, 0))
   when(io.deq.fire) {
     val next = rdPtrBin + 1.U
     rdPtrBin := next
@@ -75,7 +115,7 @@ class AsyncClockFIFO[T <: Data](gen: T, depth: Int) extends Module {
 
     io.enq.ready := !full
     when(io.enq.fire) {
-      mem.write(wrPtrBin(idxWidth - 1, 0), io.enq.bits)
+      writeMem(wrPtrBin(idxWidth - 1, 0), io.enq.bits)
       wrPtrBin := wrPtrBinNext
       wrPtrGray := wrPtrGrayNext
     }

--- a/src/main/scala/fpga/Host.scala
+++ b/src/main/scala/fpga/Host.scala
@@ -20,7 +20,7 @@ import chisel3._
 import chisel3.util._
 import difftest.common.AXI4Stream
 import difftest.gateway.FpgaDiffIO
-import difftest.util.{Delayer, PipelineConnect}
+import difftest.util.PipelineConnect
 
 class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module {
   val io = IO(new Bundle {
@@ -36,108 +36,66 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
   val payload_width = axis_send_len * axis_width
   val payload_pad_width = payload_width - difftest_width - pkt_id_w
   val fifo_depth = 16
-  val fifo_addr_width = log2Ceil(fifo_depth)
-
-  // FIFO implementation using banked SyncReadMem.
-  // Each bank is one AXI beat wide, so the read side can keep the original
-  // packet-to-AXIS slicing order while reducing the width of every memory.
-  val bank_width = axis_width
-  val num_banks = (difftest_width + bank_width - 1) / bank_width
-  val banked_width = num_banks * bank_width
-  val bank_pad_width = banked_width - difftest_width
-  val fifo_banks = Seq.fill(num_banks)(SyncReadMem(fifo_depth, UInt(bank_width.W)))
-
-  // Define counters that are accessible in both clock domains
-  val wr_cnt = RegInit(0.U(64.W))
-  val rd_cnt = withClock(io.pcie_clock) { RegInit(0.U(64.W)) }
-
-  // Write clock domain (using default clock)
-  val wr_ptr = RegInit(0.U(fifo_addr_width.W))
-  val rd_cnt_sync = Delayer(rd_cnt, 2) // Synchronize read counter to write clock domain
-  val wr_occupancy = wr_cnt - rd_cnt_sync // Calculate occupancy in write clock domain
-
-  // Write side (difftest side)
-  val fifo_not_full = wr_occupancy < (fifo_depth - 1).U
-  io.difftest.ready := fifo_not_full // Backpressure: stall difftest when FIFO is nearly full
-  val wr_en = io.difftest.fire
-
-  when(wr_en) {
-    val writePayload =
-      if (bank_pad_width > 0) {
-        Cat(0.U(bank_pad_width.W), io.difftest.bits)
-      } else {
-        io.difftest.bits
-      }
-    val writeBanks = writePayload.asTypeOf(Vec(num_banks, UInt(bank_width.W)))
-    for (i <- 0 until num_banks) {
-      fifo_banks(i).write(wr_ptr, writeBanks(i))
-    }
-    wr_ptr := wr_ptr + 1.U
-    wr_cnt := wr_cnt + 1.U // Increment write counter
-  }
 
   // Read clock domain
   withClock(io.pcie_clock) {
-    val rd_ptr = RegInit(0.U(fifo_addr_width.W))
-    val wr_cnt_sync = Delayer(wr_cnt, 2) // Synchronize write counter to read clock domain
-    val rd_occupancy = wr_cnt_sync - rd_cnt // Calculate occupancy in read clock domain
+    val fifo = Module(new AsyncClockFIFO(UInt(difftest_width.W), fifo_depth, axis_width))
+    fifo.io.enqClock := clock
+    fifo.io.enq <> io.difftest
 
-    val inTransfer = RegInit(false.B)
+    val rangeActive = RegInit(false.B)
+    val packetValid = RegInit(false.B)
     val packetBeats = RegInit(VecInit(Seq.fill(axis_send_len)(0.U(axis_width.W))))
     val sendCnt = RegInit(0.U(log2Ceil(axis_send_len).W))
     val sendLast = sendCnt === (axis_send_len - 1).U
     val counter = RegInit(0.U(3.W)) // 0 to 7
     val currentPktID = RegInit(0.U(pkt_id_w.W))
     val sendPacketEnd = counter === (numPacketPerRange - 1).U
-    // Read from FIFO banks and reconstruct the original packet payload.
-    val fifoBankOut = Wire(Vec(num_banks, UInt(bank_width.W)))
-    for (i <- 0 until num_banks) {
-      fifoBankOut(i) := fifo_banks(i).read(rd_ptr)
-    }
-    val fifo_out = fifoBankOut.asUInt(difftest_width - 1, 0)
+
+    val startTransfer = !rangeActive && fifo.io.deq.valid
+    val loadPacket = fifo.io.deq.valid && (!rangeActive || !packetValid)
+
     val packetPayload =
       if (payload_pad_width > 0) {
-        Cat(0.U(payload_pad_width.W), fifo_out, currentPktID)
+        Cat(0.U(payload_pad_width.W), fifo.io.deq.bits, currentPktID)
       } else {
-        Cat(fifo_out, currentPktID)
+        Cat(fifo.io.deq.bits, currentPktID)
       }
     val packetPayloadBeats = packetPayload.asTypeOf(Vec(axis_send_len, UInt(axis_width.W)))
-    val startTransfer = !inTransfer && rd_occupancy >= numPacketPerRange.U
-    val loadNextPacket = startTransfer || (io.axis.fire && sendLast && !sendPacketEnd)
 
-    // Start transfer when we have data available
-    when(loadNextPacket) {
-      packetBeats := packetPayloadBeats
-      rd_ptr := rd_ptr + 1.U
-      rd_cnt := rd_cnt + 1.U // Increment read counter
-    }
+    fifo.io.deq.ready := loadPacket
 
     when(startTransfer) {
-      inTransfer := true.B
+      rangeActive := true.B
+      counter := 0.U
+    }
+
+    when(loadPacket) {
+      packetBeats := packetPayloadBeats
+      packetValid := true.B
       sendCnt := 0.U
-    }.elsewhen(inTransfer) {
-      when(io.axis.fire) {
-        when(sendLast) {
-          sendCnt := 0.U
-          when(sendPacketEnd) {
-            // Last data in range, finish transfer
-            inTransfer := false.B
-            counter := 0.U
-            currentPktID := currentPktID + 1.U // Increment ID for next range
-          }.otherwise {
-            counter := counter + 1.U
-          }
+    }.elsewhen(packetValid && io.axis.fire) {
+      when(sendLast) {
+        packetValid := false.B
+        sendCnt := 0.U
+        when(sendPacketEnd) {
+          // Last packet in range, finish transfer
+          rangeActive := false.B
+          counter := 0.U
+          currentPktID := currentPktID + 1.U // Increment ID for next range
         }.otherwise {
-          sendCnt := sendCnt + 1.U
+          counter := counter + 1.U
         }
+      }.otherwise {
+        sendCnt := sendCnt + 1.U
       }
     }
 
     // AXI output
-    io.axis.valid := inTransfer
+    io.axis.valid := packetValid
     io.axis.bits.data := packetBeats(sendCnt)
     io.axis.bits.keep := Fill(axis_width / 8, 1.U(1.W))
-    io.axis.bits.last := inTransfer && sendLast && sendPacketEnd
+    io.axis.bits.last := packetValid && sendLast && sendPacketEnd
   }
 }
 


### PR DESCRIPTION
Difftest2AXIs crosses C2H packets from the DUT clock into the XDMA stream clock. The previous banked FIFO synchronized binary read and write counters across the two domains and used them to derive occupancy, which can mis-handle packets when timing or backpressure changes.

Reuse the gray-pointer AsyncClockFIFO for this CDC boundary and keep packet slicing plus packet ID generation in the PCIe clock domain. This makes C2H transfer depend on FIFO valid/ready instead of cross-domain binary occupancy.

Allow AsyncClockFIFO to split wide payload storage into banks. C2H uses the AXI-stream width as the bank width, preserving the timing benefit of banked storage while sharing one full/empty state across all banks.