### PR TITLE
feat(MMU): add ptehelper DPI model

### DIFF
--- a/src/test/csrc/common/golden.cpp
+++ b/src/test/csrc/common/golden.cpp
@@ -23,31 +23,288 @@
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
 
-uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level) {
+static constexpr uint8_t MODE_BARE = 0;
+static constexpr uint8_t MODE_SV39X4 = 8;
+static constexpr uint8_t MODE_SV48X4 = 9;
+static constexpr uint8_t VPN_BITS_PER_LEVEL = 9;
+static constexpr uint8_t GPADDR_BITS_SV39X4 = 41;
+static constexpr uint8_t GPADDR_BITS_SV48X4 = 50;
+
+/**
+ * Read PTE from memory (physical address)
+ * Uses goldenmem in difftest mode, pmem_read otherwise
+ */
+static inline uint64_t read_pte(uint64_t pte_addr) {
+  uint64_t pte_val;
+#ifdef CONFIG_NO_DIFFTEST
+  pte_val = pmem_read(pte_addr);
+#else
+  read_goldenmem(pte_addr, &pte_val, 8);
+#endif // CONFIG_NO_DIFFTEST
+  return pte_val;
+}
+
+static inline bool pte_is_leaf(const PTE &pte) {
+  return pte.v && (pte.r || pte.x || pte.w);
+}
+
+static inline bool pte_is_next(const PTE &pte) {
+  return pte.v && !pte.r && !pte.x && !pte.w;
+}
+
+static inline bool pte_has_pbmt_fault(const PTE &pte, bool pbmte) {
+  return pte.pbmt == 3 || (!pbmte && pte.pbmt != 0);
+}
+
+static inline bool pte_is_legal_napot(const PTE &pte, uint8_t level) {
+  return level == 0 && pte.n && (pte.ppn & 0xf) == 0x8;
+}
+
+static inline bool pte_has_napot_fault(const PTE &pte, uint8_t level) {
+  return pte.n && !pte_is_legal_napot(pte, level);
+}
+
+static inline bool pte_has_unaligned_fault(const PTE &pte, uint8_t level) {
+  if (!pte_is_leaf(pte) || level == 0) {
+    return false;
+  }
+  uint64_t ppn_mask = (1ull << (VPN_BITS_PER_LEVEL * level)) - 1;
+  return (pte.ppn & ppn_mask) != 0;
+}
+
+static inline bool pte_has_vs_stage_fault(const PTE &pte, uint8_t level, bool pbmte) {
+  if (pte.rsvd != 0 || pte_has_pbmt_fault(pte, pbmte)) {
+    return true;
+  }
+  if (pte_is_next(pte)) {
+    return pte.u || pte.a || pte.d || pte.n || pte.pbmt != 0;
+  }
+  return !pte.v || (!pte.r && pte.w) || (!pte_is_leaf(pte) && level == 0) || pte_has_napot_fault(pte, level) ||
+         pte_has_unaligned_fault(pte, level);
+}
+
+static inline bool pte_has_g_stage_fault(const PTE &pte, uint8_t level, bool pbmte) {
+  return pte_has_vs_stage_fault(pte, level, pbmte) || (pte_is_leaf(pte) && (!pte.u || !pte.a));
+}
+
+static inline bool gpa_high_bits_invalid(uint8_t mode, uint64_t gpaddr) {
+  if (mode == MODE_SV39X4) {
+    return (gpaddr >> GPADDR_BITS_SV39X4) != 0;
+  }
+  if (mode == MODE_SV48X4) {
+    return (gpaddr >> GPADDR_BITS_SV48X4) != 0;
+  }
+  return false;
+}
+
+static inline void set_pte_helper_result(uint64_t *pte, uint8_t *level, uint64_t *s1_pte, uint64_t *s2_pte,
+                                         uint8_t *s1_level, const PTE &result_pte, uint8_t result_level,
+                                         uint64_t result_s1_pte = 0, uint64_t result_s2_pte = 0,
+                                         uint8_t result_s1_level = 0) {
+  *pte = result_pte.val;
+  *level = result_level;
+  *s1_pte = result_s1_pte;
+  *s2_pte = result_s2_pte;
+  *s1_level = result_s1_level;
+}
+
+/**
+ * G-Stage page table walk (GPA -> HPA)
+ * Implementation aligned with do_s2xlate() in tlb.cpp
+ *
+ * @param hgatp  HGATP register value
+ * @param gpaddr Guest physical address to translate
+ * @return       r_s2xlate containing PTE and level
+ */
+static r_s2xlate do_g_stage(Hgatp *hgatp, uint64_t gpaddr, bool pbmte) {
+  PTE pte;
+  uint64_t hpaddr;
+  uint8_t level;
+  uint64_t pg_base = hgatp->ppn << 12;
+  r_s2xlate result;
+
+  // If hgatp.mode == 0, G-stage is disabled, return GPA directly
+  if (hgatp->mode == MODE_BARE) {
+    result.pte.val = 0;
+    result.pte.ppn = gpaddr >> 12;
+    result.pte.v = 1;
+    result.pte.r = 1;
+    result.pte.w = 1;
+    result.pte.x = 1;
+    result.pte.u = 1;
+    result.pte.a = 1;
+    result.pte.d = 1;
+    result.level = 0;
+    return result;
+  }
+
+  // Determine max level: Sv39x4 (mode=8) -> 2, Sv48x4 (mode=9) -> 3
+  int max_level = (hgatp->mode == MODE_SV39X4) ? 2 : 3;
+
+  for (level = max_level; level >= 0; level--) {
+    // Use GVPNi macro: top level uses 11 bits, others use 9 bits
+    hpaddr = pg_base + GVPNi(gpaddr, level, max_level) * sizeof(uint64_t);
+    pte.val = read_pte(hpaddr);
+
+    // Stop on fault, leaf PTE, or the last level. Faults must not walk into the next level.
+    if (pte_has_g_stage_fault(pte, level, pbmte) || pte_is_leaf(pte) || level == 0) {
+      break;
+    }
+    pg_base = pte.ppn << 12;
+  }
+
+  result.pte = pte;
+  result.level = level;
+  return result;
+}
+
+/**
+ * Main pte_helper function with H-extension two-stage translation support
+ * Implementation aligned with L1TLBChecker::check() in tlb.cpp
+ *
+ * Translation modes:
+ * - noS2xlate:  Single-stage using satp (host mode)
+ * - onlyStage1: VS-stage only using vsatp (PTE addresses are physical)
+ * - onlyStage2: G-stage only using hgatp (vpn is GPA)
+ * - allStage:   Full two-stage (GVA -> GPA -> HPA)
+ */
+uint8_t pte_helper(uint64_t satp, uint64_t vsatp, uint64_t hgatp, uint8_t mPBMTE, uint8_t hPBMTE, uint64_t vpn,
+                   uint8_t s2xlate, uint64_t *pte, uint8_t *level, uint64_t *s1_pte, uint64_t *s2_pte,
+                   uint8_t *s1_level) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_pte_helper]++;
-  difftest_bytes[perf_pte_helper] += 25;
+  difftest_bytes[perf_pte_helper] += 61;
 #endif // CONFIG_DIFFTEST_PERFCNT
-  uint64_t pg_base = satp << 12, pte_addr;
-  PTE *pte_p = (PTE *)pte;
-  for (*level = 0; *level < 3; (*level)++) {
-    pte_addr = pg_base + VPNi(vpn, *level) * sizeof(uint64_t);
-#ifdef CONFIG_NO_DIFFTEST
-    pte_p->val = pmem_read(pte_addr);
-#else
-    read_goldenmem(pte_addr, &pte_p->val, 8);
-#endif // CONFIG_NO_DIFFTEST
-    pg_base = pte_p->ppn << 12;
-    // pf
-    if (!pte_p->v) {
-      return 1;
+
+  PTE result_pte;
+  uint64_t paddr;
+  uint8_t result_level;
+  r_s2xlate g_result;
+
+  Satp *satp_p = (Satp *)&satp;
+  Vsatp *vsatp_p = (Vsatp *)&vsatp;
+  Hgatp *hgatp_p = (Hgatp *)&hgatp;
+
+  uint8_t hasS2xlate = (s2xlate != noS2xlate);
+  uint8_t onlyS2 = (s2xlate == onlyStage2);
+  uint8_t hasAllStage = (s2xlate == allStage);
+  uint8_t stage1PBMTE = hasS2xlate ? hPBMTE : mPBMTE;
+
+  // Select satp based on translation mode
+  uint64_t pg_base = (hasS2xlate ? vsatp_p->ppn : satp_p->ppn) << 12;
+  int mode = hasS2xlate ? vsatp_p->mode : satp_p->mode;
+  int max_level = (mode == MODE_SV39X4) ? 2 : 3;
+
+  if (onlyS2) {
+    // G-Stage only: vpn is treated as GPA
+    if (gpa_high_bits_invalid(hgatp_p->mode, vpn << 12)) {
+      result_pte.val = 0;
+      set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, 0);
+      return PF_G_STAGE;
     }
-    // leaf pte
-    if (pte_p->r || pte_p->x) {
-      return 0;
+
+    g_result = do_g_stage(hgatp_p, vpn << 12, mPBMTE);
+    result_pte = g_result.pte;
+    result_level = g_result.level;
+
+    // Check for G-stage page fault, including PBMTE-gated PBMT legality.
+    if (pte_has_g_stage_fault(result_pte, result_level, mPBMTE)) {
+      set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, result_level);
+      return PF_G_STAGE;
+    }
+  } else {
+    // VS-stage walk (with optional G-stage for PTE addresses)
+    for (result_level = max_level; result_level >= 0; result_level--) {
+      paddr = pg_base + VPNi(vpn, result_level) * sizeof(uint64_t);
+
+      if (hasAllStage) {
+        // Translate PTE address through G-stage
+        if (gpa_high_bits_invalid(hgatp_p->mode, paddr)) {
+          result_pte.val = 0;
+          set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, 0);
+          return PF_G_STAGE;
+        }
+
+        g_result = do_g_stage(hgatp_p, paddr, mPBMTE);
+
+        // Check for G-stage page fault during PTE access, including PBMTE-gated PBMT legality.
+        if (pte_has_g_stage_fault(g_result.pte, g_result.level, mPBMTE)) {
+          set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, g_result.pte, g_result.level, 0, g_result.pte.val,
+                                0);
+          return PF_G_STAGE;
+        }
+
+        // Calculate HPA from G-stage result (handle superpage)
+        uint64_t pg_mask = ((1ull << VPNiSHFT(g_result.level)) - 1);
+        if (pte_is_legal_napot(g_result.pte, g_result.level)) {
+          pg_mask = ((1ull << NAPOTSHFT) - 1);
+        }
+        pg_base = (g_result.pte.ppn << 12 & ~pg_mask) | (paddr & pg_mask & ~PAGE_MASK);
+        paddr = pg_base | (paddr & PAGE_MASK);
+      }
+
+      result_pte.val = read_pte(paddr);
+      bool stage_fault = pte_has_vs_stage_fault(result_pte, result_level, stage1PBMTE);
+      if (!stage_fault) {
+        pg_base = result_pte.ppn << 12;
+      }
+
+      // Stop on fault, leaf PTE, or the last level. Faults must not walk into the next level.
+      if (stage_fault || pte_is_leaf(result_pte) || result_level == 0) {
+        break;
+      }
+    }
+
+    // Check for VS-stage page fault, including PBMTE-gated PBMT legality.
+    if (pte_has_vs_stage_fault(result_pte, result_level, stage1PBMTE)) {
+      set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, result_level,
+                            hasAllStage ? result_pte.val : 0, 0, hasAllStage ? result_level : 0);
+      return PF_VS_STAGE;
+    }
+
+    // Save VS-stage PTE and level before G-stage final translation overwrites them
+    if (hasAllStage) {
+      *s1_pte = result_pte.val;
+      *s1_level = result_level;
+    }
+
+    // Handle superpage: calculate final pg_base
+    if (result_level > 0 && result_pte.v) {
+      uint64_t pg_mask = ((1ull << VPNiSHFT(result_level)) - 1);
+      pg_base = (result_pte.ppn << 12 & ~pg_mask) | (vpn << 12 & pg_mask & ~PAGE_MASK);
+    } else if (pte_is_legal_napot(result_pte, result_level)) {
+      uint64_t pg_mask = ((1ull << NAPOTSHFT) - 1);
+      pg_base = (result_pte.ppn << 12 & ~pg_mask) | (vpn << 12 & pg_mask & ~PAGE_MASK);
+    }
+
+    // Final G-stage translation for the leaf PTE's PPN
+    if (hasAllStage && result_pte.v) {
+      if (gpa_high_bits_invalid(hgatp_p->mode, pg_base)) {
+        PTE fault_pte;
+        fault_pte.val = 0;
+        set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, fault_pte, 0, *s1_pte, 0, *s1_level);
+        return PF_G_STAGE;
+      }
+
+      g_result = do_g_stage(hgatp_p, pg_base, mPBMTE);
+
+      // Check for final G-stage page fault, including PBMTE-gated PBMT legality.
+      if (pte_has_g_stage_fault(g_result.pte, g_result.level, mPBMTE)) {
+        set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, g_result.pte, g_result.level, *s1_pte,
+                              g_result.pte.val, *s1_level);
+        return PF_G_STAGE;
+      }
+
+      result_pte = g_result.pte;
+      result_level = g_result.level;
+      // save G-stage PTE for allStage mode
+      *s2_pte = g_result.pte.val;
     }
   }
-  return 1;
+
+  set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, result_level, hasAllStage ? *s1_pte : 0,
+                        hasAllStage ? *s2_pte : 0, hasAllStage ? *s1_level : 0);
+  return PF_NONE;
 }
 
 enum {

--- a/src/test/csrc/common/golden.cpp
+++ b/src/test/csrc/common/golden.cpp
@@ -23,31 +23,299 @@
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
 
-uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level) {
+static constexpr uint8_t MODE_BARE = 0;
+static constexpr uint8_t MODE_SV39X4 = 8;
+static constexpr uint8_t MODE_SV48X4 = 9;
+static constexpr uint8_t VPN_BITS_PER_LEVEL = 9;
+static constexpr uint8_t GPADDR_BITS_SV39X4 = 41;
+static constexpr uint8_t GPADDR_BITS_SV48X4 = 50;
+
+/**
+ * Read PTE from memory (physical address)
+ * Uses goldenmem in difftest mode, pmem_read otherwise
+ */
+static inline uint64_t read_pte(uint64_t pte_addr) {
+  uint64_t pte_val;
+#ifdef CONFIG_NO_DIFFTEST
+  pte_val = pmem_read(pte_addr);
+#else
+  if (pmem == nullptr)
+    return 0;
+  read_goldenmem(pte_addr, &pte_val, 8);
+#endif // CONFIG_NO_DIFFTEST
+  return pte_val;
+}
+
+static inline bool pte_is_leaf(const PTE &pte) {
+  return pte.v && (pte.r || pte.x || pte.w);
+}
+
+static inline bool pte_is_next(const PTE &pte) {
+  return pte.v && !pte.r && !pte.x && !pte.w;
+}
+
+static inline bool pte_has_pbmt_fault(const PTE &pte, bool pbmte) {
+  return pte.pbmt == 3 || (!pbmte && pte.pbmt != 0);
+}
+
+static inline bool pte_is_legal_napot(const PTE &pte, uint8_t level) {
+  return level == 0 && pte.n && (pte.ppn & 0xf) == 0x8;
+}
+
+static inline bool pte_has_napot_fault(const PTE &pte, uint8_t level) {
+  return pte.n && !pte_is_legal_napot(pte, level);
+}
+
+static inline bool pte_has_unaligned_fault(const PTE &pte, uint8_t level) {
+  if (!pte_is_leaf(pte) || level == 0) {
+    return false;
+  }
+  uint64_t ppn_mask = (1ull << (VPN_BITS_PER_LEVEL * level)) - 1;
+  return (pte.ppn & ppn_mask) != 0;
+}
+
+static inline bool pte_has_vs_stage_fault(const PTE &pte, uint8_t level, bool pbmte) {
+  if (pte.rsvd != 0 || pte_has_pbmt_fault(pte, pbmte)) {
+    return true;
+  }
+  if (pte_is_next(pte)) {
+    return pte.u || pte.a || pte.d || pte.n || pte.pbmt != 0;
+  }
+  return !pte.v || (!pte.r && pte.w) || (!pte_is_leaf(pte) && level == 0) || pte_has_napot_fault(pte, level) ||
+         pte_has_unaligned_fault(pte, level);
+}
+
+static inline bool pte_has_g_stage_fault(const PTE &pte, uint8_t level, bool pbmte) {
+  return pte_has_vs_stage_fault(pte, level, pbmte) || (pte_is_leaf(pte) && (!pte.u || !pte.a));
+}
+
+static inline bool pte_has_g_stage_implicit_load_fault(const PTE &pte, uint8_t level, bool pbmte) {
+  return pte_has_g_stage_fault(pte, level, pbmte) || (pte_is_leaf(pte) && !pte.r);
+}
+
+static inline bool gpa_high_bits_invalid(uint8_t mode, uint64_t gpaddr) {
+  if (mode == MODE_SV39X4) {
+    return (gpaddr >> GPADDR_BITS_SV39X4) != 0;
+  }
+  if (mode == MODE_SV48X4) {
+    return (gpaddr >> GPADDR_BITS_SV48X4) != 0;
+  }
+  return false;
+}
+
+static inline void set_pte_helper_result(uint64_t *pte, uint8_t *level, uint64_t *s1_pte, uint64_t *s2_pte,
+                                         uint8_t *s1_level, const PTE &result_pte, uint8_t result_level,
+                                         uint64_t result_s1_pte = 0, uint64_t result_s2_pte = 0,
+                                         uint8_t result_s1_level = 0) {
+  *pte = result_pte.val;
+  *level = result_level;
+  *s1_pte = result_s1_pte;
+  *s2_pte = result_s2_pte;
+  *s1_level = result_s1_level;
+}
+
+/**
+ * G-Stage page table walk (GPA -> HPA)
+ * Implementation aligned with do_s2xlate() in tlb.cpp
+ *
+ * @param hgatp  HGATP register value
+ * @param gpaddr Guest physical address to translate
+ * @return       r_s2xlate containing PTE and level
+ */
+static r_s2xlate do_g_stage(Hgatp *hgatp, uint64_t gpaddr, bool pbmte) {
+  PTE pte;
+  uint64_t hpaddr;
+  uint8_t level;
+  uint64_t pg_base = hgatp->ppn << 12;
+  r_s2xlate result;
+
+  // If hgatp.mode == 0, G-stage is disabled, return GPA directly
+  if (hgatp->mode == MODE_BARE) {
+    result.pte.val = 0;
+    result.pte.ppn = gpaddr >> 12;
+    result.pte.v = 1;
+    result.pte.r = 1;
+    result.pte.w = 1;
+    result.pte.x = 1;
+    result.pte.u = 1;
+    result.pte.a = 1;
+    result.pte.d = 1;
+    result.level = 0;
+    return result;
+  }
+
+  // Determine max level: Sv39x4 (mode=8) -> 2, Sv48x4 (mode=9) -> 3
+  int max_level = (hgatp->mode == MODE_SV39X4) ? 2 : 3;
+
+  for (level = max_level; level >= 0; level--) {
+    // Use GVPNi macro: top level uses 11 bits, others use 9 bits
+    hpaddr = pg_base + GVPNi(gpaddr, level, max_level) * sizeof(uint64_t);
+    pte.val = read_pte(hpaddr);
+
+    // Stop on fault, leaf PTE, or the last level. Faults must not walk into the next level.
+    if (pte_has_g_stage_fault(pte, level, pbmte) || pte_is_leaf(pte) || level == 0) {
+      break;
+    }
+    pg_base = pte.ppn << 12;
+  }
+
+  result.pte = pte;
+  result.level = level;
+  return result;
+}
+
+/**
+ * Main pte_helper function with H-extension two-stage translation support
+ * Implementation aligned with L1TLBChecker::check() in tlb.cpp
+ *
+ * Translation modes:
+ * - noS2xlate:  Single-stage using satp (host mode)
+ * - onlyStage1: VS-stage only using vsatp (PTE addresses are physical)
+ * - onlyStage2: G-stage only using hgatp (vpn is GPA)
+ * - allStage:   Full two-stage (GVA -> GPA -> HPA)
+ */
+uint8_t pte_helper(uint64_t satp, uint64_t vsatp, uint64_t hgatp, uint8_t mPBMTE, uint8_t hPBMTE, uint64_t vpn,
+                   uint8_t s2xlate, uint64_t *pte, uint8_t *level, uint64_t *s1_pte, uint64_t *s2_pte,
+                   uint8_t *s1_level) {
 #ifdef CONFIG_DIFFTEST_PERFCNT
   difftest_calls[perf_pte_helper]++;
-  difftest_bytes[perf_pte_helper] += 25;
+  difftest_bytes[perf_pte_helper] += 61;
 #endif // CONFIG_DIFFTEST_PERFCNT
-  uint64_t pg_base = satp << 12, pte_addr;
-  PTE *pte_p = (PTE *)pte;
-  for (*level = 0; *level < 3; (*level)++) {
-    pte_addr = pg_base + VPNi(vpn, *level) * sizeof(uint64_t);
-#ifdef CONFIG_NO_DIFFTEST
-    pte_p->val = pmem_read(pte_addr);
-#else
-    read_goldenmem(pte_addr, &pte_p->val, 8);
-#endif // CONFIG_NO_DIFFTEST
-    pg_base = pte_p->ppn << 12;
-    // pf
-    if (!pte_p->v) {
-      return 1;
+
+  PTE result_pte;
+  PTE s1_gpa_pte = {};
+  uint64_t paddr;
+  uint8_t result_level;
+  uint8_t s1_gpa_level = 0;
+  r_s2xlate g_result;
+
+  Satp *satp_p = (Satp *)&satp;
+  Vsatp *vsatp_p = (Vsatp *)&vsatp;
+  Hgatp *hgatp_p = (Hgatp *)&hgatp;
+
+  uint8_t hasS2xlate = (s2xlate != noS2xlate);
+  uint8_t onlyS2 = (s2xlate == onlyStage2);
+  uint8_t hasAllStage = (s2xlate == allStage);
+  uint8_t stage1PBMTE = hasS2xlate ? hPBMTE : mPBMTE;
+
+  if (hasAllStage) {
+    // A zero-permission PTE marks the VS root before any VS-level PTE has been read.
+    s1_gpa_pte.ppn = vsatp_p->ppn;
+  }
+
+  // Select satp based on translation mode
+  uint64_t pg_base = (hasS2xlate ? vsatp_p->ppn : satp_p->ppn) << 12;
+  int mode = hasS2xlate ? vsatp_p->mode : satp_p->mode;
+  int max_level = (mode == MODE_SV39X4) ? 2 : 3;
+
+  if (onlyS2) {
+    // G-Stage only: vpn is treated as GPA
+    if (gpa_high_bits_invalid(hgatp_p->mode, vpn << 12)) {
+      result_pte.val = 0;
+      set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, 0);
+      return PF_G_STAGE;
     }
-    // leaf pte
-    if (pte_p->r || pte_p->x) {
-      return 0;
+
+    g_result = do_g_stage(hgatp_p, vpn << 12, mPBMTE);
+    result_pte = g_result.pte;
+    result_level = g_result.level;
+
+    // Check for G-stage page fault, including PBMTE-gated PBMT legality.
+    if (pte_has_g_stage_fault(result_pte, result_level, mPBMTE)) {
+      set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, result_level);
+      return PF_G_STAGE;
+    }
+  } else {
+    // VS-stage walk (with optional G-stage for PTE addresses)
+    for (result_level = max_level; result_level >= 0; result_level--) {
+      paddr = pg_base + VPNi(vpn, result_level) * sizeof(uint64_t);
+
+      if (hasAllStage) {
+        // Translate PTE address through G-stage
+        if (gpa_high_bits_invalid(hgatp_p->mode, paddr)) {
+          result_pte.val = 0;
+          set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, 0, s1_gpa_pte.val, 0, s1_gpa_level);
+          return PF_G_STAGE;
+        }
+
+        g_result = do_g_stage(hgatp_p, paddr, mPBMTE);
+
+        // Check for G-stage page fault during PTE access, including PBMTE-gated PBMT legality.
+        if (pte_has_g_stage_implicit_load_fault(g_result.pte, g_result.level, mPBMTE)) {
+          set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, g_result.pte, g_result.level, s1_gpa_pte.val,
+                                g_result.pte.val, s1_gpa_level);
+          return PF_G_STAGE;
+        }
+
+        // Calculate HPA from G-stage result (handle superpage)
+        uint64_t pg_mask = ((1ull << VPNiSHFT(g_result.level)) - 1);
+        if (pte_is_legal_napot(g_result.pte, g_result.level)) {
+          pg_mask = ((1ull << NAPOTSHFT) - 1);
+        }
+        pg_base = (g_result.pte.ppn << 12 & ~pg_mask) | (paddr & pg_mask & ~PAGE_MASK);
+        paddr = pg_base | (paddr & PAGE_MASK);
+      }
+
+      result_pte.val = read_pte(paddr);
+      bool stage_fault = pte_has_vs_stage_fault(result_pte, result_level, stage1PBMTE);
+      if (!stage_fault) {
+        pg_base = result_pte.ppn << 12;
+        if (hasAllStage) {
+          s1_gpa_pte = result_pte;
+          s1_gpa_level = result_level;
+        }
+      }
+
+      // Stop on fault, leaf PTE, or the last level. Faults must not walk into the next level.
+      if (stage_fault || pte_is_leaf(result_pte) || result_level == 0) {
+        break;
+      }
+    }
+
+    // Check for VS-stage page fault, including PBMTE-gated PBMT legality.
+    if (pte_has_vs_stage_fault(result_pte, result_level, stage1PBMTE)) {
+      set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, result_level,
+                            hasAllStage ? result_pte.val : 0, 0, hasAllStage ? result_level : 0);
+      return PF_VS_STAGE;
+    }
+
+    // Handle superpage: calculate final pg_base
+    if (result_level > 0 && result_pte.v) {
+      uint64_t pg_mask = ((1ull << VPNiSHFT(result_level)) - 1);
+      pg_base = (result_pte.ppn << 12 & ~pg_mask) | (vpn << 12 & pg_mask & ~PAGE_MASK);
+    } else if (pte_is_legal_napot(result_pte, result_level)) {
+      uint64_t pg_mask = ((1ull << NAPOTSHFT) - 1);
+      pg_base = (result_pte.ppn << 12 & ~pg_mask) | (vpn << 12 & pg_mask & ~PAGE_MASK);
+    }
+
+    // Final G-stage translation for the leaf PTE's PPN
+    if (hasAllStage && result_pte.v) {
+      if (gpa_high_bits_invalid(hgatp_p->mode, pg_base)) {
+        PTE fault_pte;
+        fault_pte.val = 0;
+        set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, fault_pte, 0, s1_gpa_pte.val, 0, s1_gpa_level);
+        return PF_G_STAGE;
+      }
+
+      g_result = do_g_stage(hgatp_p, pg_base, mPBMTE);
+
+      // Check for final G-stage page fault, including PBMTE-gated PBMT legality.
+      if (pte_has_g_stage_fault(g_result.pte, g_result.level, mPBMTE)) {
+        set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, g_result.pte, g_result.level, s1_gpa_pte.val,
+                              g_result.pte.val, s1_gpa_level);
+        return PF_G_STAGE;
+      }
+
+      result_pte = g_result.pte;
+      result_level = g_result.level;
+      // save G-stage PTE for allStage mode
+      *s2_pte = g_result.pte.val;
     }
   }
-  return 1;
+
+  set_pte_helper_result(pte, level, s1_pte, s2_pte, s1_level, result_pte, result_level,
+                        hasAllStage ? s1_gpa_pte.val : 0, hasAllStage ? *s2_pte : 0, hasAllStage ? s1_gpa_level : 0);
+  return PF_NONE;
 }
 
 enum {

--- a/src/test/csrc/common/golden.h
+++ b/src/test/csrc/common/golden.h
@@ -16,44 +16,121 @@
 
 /**
  * Headers for C/C++ REF models
+ * Shared definitions for golden.cpp and tlb.cpp
  */
 #ifndef __GOLDEN_H__
 #define __GOLDEN_H__
 
 #include "common.h"
 
-// REF Models
-extern "C" uint8_t pte_helper(uint64_t satp, uint64_t vpn, uint64_t *pte, uint8_t *level);
-extern "C" uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask);
+/**
+ * Page table walk constants
+ */
+#define PAGE_SHIFT 12
+#define PAGE_SIZE  (1ul << PAGE_SHIFT)
+#define PAGE_MASK  (PAGE_SIZE - 1)
 
+/**
+ * Two-stage translation mode constants
+ * Aligned with MMUConst.scala definitions
+ */
+#define noS2xlate  0 // Single-stage translation using satp
+#define onlyStage1 1 // VS-stage only using vsatp
+#define onlyStage2 2 // G-stage only using hgatp
+#define allStage   3 // Full two-stage translation (GVA -> GPA -> HPA)
+
+/**
+ * Page fault type constants
+ * Return values from pte_helper function
+ */
+#define PF_NONE     0 // No page fault, translation successful
+#define PF_VS_STAGE 1 // VS-stage page fault
+#define PF_G_STAGE  2 // G-stage page fault (guest page fault)
+
+/**
+ * Page table index extraction macros
+ */
+#define VPNiSHFT(i) (12 + 9 * (i))
+#define NAPOTSHFT   (12 + 4) // only support 64kb page
+
+// Extract VPN index at level i from VPN (9 bits each level)
+#define VPNi(vpn, i) (((vpn) >> (9 * (i))) & 0x1ff)
+
+// Extract GPN index for G-stage (11 bits for top level in Sv39x4/Sv48x4)
+#define GVPNi(addr, i, max) (((addr) >> (9 * (i) + 12)) & ((i == 3 || (i == 2 && max == 2)) ? 0x7ff : 0x1ff))
+
+/**
+ * Page Table Entry (PTE) structure
+ * RISC-V Sv39/Sv48 format
+ */
 typedef union PageTableEntry {
   struct {
-    uint32_t v : 1;
-    uint32_t r : 1;
-    uint32_t w : 1;
-    uint32_t x : 1;
-    uint32_t u : 1;
-    uint32_t g : 1;
-    uint32_t a : 1;
-    uint32_t d : 1;
-    uint32_t rsw : 2;
-    uint64_t ppn : 44;
-    uint32_t rsvd : 7;
-    uint32_t pbmt : 2;
-    uint32_t n : 1;
+    uint64_t v : 1;    // Valid bit
+    uint64_t r : 1;    // Read permission
+    uint64_t w : 1;    // Write permission
+    uint64_t x : 1;    // Execute permission
+    uint64_t u : 1;    // User mode accessible
+    uint64_t g : 1;    // Global mapping
+    uint64_t a : 1;    // Accessed bit
+    uint64_t d : 1;    // Dirty bit
+    uint64_t rsw : 2;  // Reserved for software
+    uint64_t ppn : 44; // Physical page number
+    uint64_t rsvd : 7; // Reserved
+    uint64_t pbmt : 2; // Page-based memory type
+    uint64_t n : 1;    // NAPOT bit
   };
   struct {
-    uint32_t difftest_v : 1;
-    uint32_t difftest_perm : 7;
-    uint32_t difftest_rsw : 2;
+    uint64_t difftest_v : 1;
+    uint64_t difftest_perm : 7;
+    uint64_t difftest_rsw : 2;
     uint64_t difftest_ppn : 44;
-    uint32_t difftest_rsvd : 7;
-    uint32_t difftest_pbmt : 2;
-    uint32_t difftest_n : 1;
+    uint64_t difftest_rsvd : 7;
+    uint64_t difftest_pbmt : 2;
+    uint64_t difftest_n : 1;
   };
   uint64_t val;
 } PTE;
 
-#define VPNi(vpn, i) (((vpn) >> (9 * (i))) & 0x1ff)
+/**
+ * Address Translation and Protection (ATP) register structure
+ * Used for satp, vsatp, and hgatp registers
+ */
+typedef union atpStruct {
+  struct {
+    uint64_t ppn : 44;  // Page table base PPN
+    uint32_t asid : 16; // Address space identifier (or VMID for hgatp)
+    uint32_t mode : 4;  // Translation mode (8=Sv39, 9=Sv48)
+  };
+  uint64_t val;
+} Satp, Vsatp, Hgatp;
+
+/**
+ * G-stage translation result structure
+ * Used by do_s2xlate() in tlb.cpp and do_g_stage() in golden.cpp
+ */
+typedef struct {
+  PTE pte;
+  uint8_t level;
+} r_s2xlate;
+
+/**
+ * pte_helper: Software page table walk with H-extension support
+ *
+ * @param satp    Host SATP register (for noS2xlate mode)
+ * @param vsatp   Guest VSATP register (for VS-stage translation)
+ * @param hgatp   Hypervisor HGATP register (for G-stage translation)
+ * @param mPBMTE  MENVCFG.PBMTE state for G-stage translation checks
+ * @param hPBMTE  HENVCFG.PBMTE state for VS-stage translation checks
+ * @param vpn     Virtual page number to translate
+ * @param s2xlate Translation mode (noS2xlate/onlyStage1/onlyStage2/allStage)
+ * @param pte     Output: final PTE value
+ * @param level   Output: page table level (0=4KB, 1=2MB, 2=1GB, 3=512GB)
+ * @return        Page fault type (PF_NONE/PF_VS_STAGE/PF_G_STAGE)
+ */
+extern "C" uint8_t pte_helper(uint64_t satp, uint64_t vsatp, uint64_t hgatp, uint8_t mPBMTE, uint8_t hPBMTE,
+                              uint64_t vpn, uint8_t s2xlate, uint64_t *pte, uint8_t *level, uint64_t *s1_pte,
+                              uint64_t *s2_pte, uint8_t *s1_level);
+
+extern "C" uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask);
 
 #endif // __GOLDEN_H__

--- a/src/test/csrc/difftest/checkers/tlb.cpp
+++ b/src/test/csrc/difftest/checkers/tlb.cpp
@@ -18,31 +18,8 @@
 #include "golden.h"
 #include "goldenmem.h"
 
-#define PAGE_SHIFT 12
-#define PAGE_SIZE  (1ul << PAGE_SHIFT)
-#define PAGE_MASK  (PAGE_SIZE - 1)
-
-#define noS2xlate           0
-#define onlyStage1          1
-#define onlyStage2          2
-#define allStage            3
-#define VPNiSHFT(i)         (12 + 9 * (i))
-#define GVPNi(addr, i, max) (((addr) >> (9 * (i) + 12)) & ((i == 3 || (i == 2 && max == 2)) ? 0x7ff : 0x1ff))
-#define NAPOTSHFT           (12 + 4) // only support 64kb page
-
-typedef union atpStruct {
-  struct {
-    uint64_t ppn : 44;
-    uint32_t asid : 16;
-    uint32_t mode : 4;
-  };
-  uint64_t val;
-} Satp, Hgatp;
-
-typedef struct {
-  PTE pte;
-  uint8_t level;
-} r_s2xlate;
+// All common definitions (PAGE_*, s2xlate modes, VPNi*, PTE, Satp, Hgatp, r_s2xlate)
+// are now in golden.h to avoid duplicate definitions
 
 static r_s2xlate do_s2xlate(Hgatp *hgatp, uint64_t gpaddr) {
   PTE pte;
@@ -86,7 +63,7 @@ int L1TLBChecker::check(const DifftestL1TLBEvent &probe) {
   bool isNapot = false;
 
   Satp *satp = (Satp *)&probe.satp;
-  Satp *vsatp = (Satp *)&probe.vsatp;
+  Vsatp *vsatp = (Vsatp *)&probe.vsatp;
   Hgatp *hgatp = (Hgatp *)&probe.hgatp;
   uint8_t hasS2xlate = probe.s2xlate != noS2xlate;
   uint8_t onlyS2 = probe.s2xlate == onlyStage2;
@@ -143,10 +120,23 @@ int L1TLBChecker::check(const DifftestL1TLBEvent &probe) {
   }
 
   if (pte.difftest_ppn != ppn) {
-    Info("Warning: l1tlb resp test of core %d failed! vpn = %lx\n", state->coreid, probe.vpn);
-    Info("  REF commits pte.val: 0x%lx, dut s2xlate: %d\n", pte.val, probe.s2xlate);
-    Info("  REF commits ppn 0x%lx, DUT commits ppn 0x%lx\n", pte.difftest_ppn, ppn);
-    Info("  REF commits perm 0x%02x, level %d, pf %d\n", pte.difftest_perm, difftest_level, !pte.difftest_v);
+    Info("Warning: l1tlb resp test of core %d failed! vpn = 0x%lx\n", state->coreid, probe.vpn);
+    Info("  DUT probe signals:\n");
+    Info("    vpn = 0x%lx, ppn = 0x%lx (aligned = 0x%lx)\n", probe.vpn, probe.ppn, ppn);
+    Info("    satp  = 0x%016lx (mode=%d, asid=0x%x, ppn=0x%lx)\n", probe.satp, satp->mode, satp->asid, satp->ppn);
+    Info("    vsatp = 0x%016lx (mode=%d, asid=0x%x, ppn=0x%lx)\n", probe.vsatp, vsatp->mode, vsatp->asid, vsatp->ppn);
+    Info("    hgatp = 0x%016lx (mode=%d, vmid=0x%x, ppn=0x%lx)\n", probe.hgatp, hgatp->mode, hgatp->asid, hgatp->ppn);
+    Info("    s2xlate = %d (%s)\n", probe.s2xlate,
+         probe.s2xlate == noS2xlate    ? "noS2xlate"
+         : probe.s2xlate == onlyStage1 ? "onlyStage1"
+         : probe.s2xlate == onlyStage2 ? "onlyStage2"
+                                       : "allStage");
+    Info("  REF walk result:\n");
+    Info("    pte.val = 0x%016lx (v=%d, r=%d, w=%d, x=%d, u=%d, g=%d, a=%d, d=%d)\n", pte.val, pte.v, pte.r, pte.w,
+         pte.x, pte.u, pte.g, pte.a, pte.d);
+    Info("    ppn = 0x%lx, perm = 0x%02x, level = %d, pf = %d, pbmt = %d, napot = %d\n", pte.difftest_ppn,
+         pte.difftest_perm, difftest_level, !pte.difftest_v, pte.pbmt, (int)isNapot);
+    Info("  Mismatch: REF ppn 0x%lx != DUT ppn 0x%lx (diff = 0x%lx)\n", pte.difftest_ppn, ppn, pte.difftest_ppn ^ ppn);
   }
 
   return STATE_OK;

--- a/src/test/vsrc/common/ref.v
+++ b/src/test/vsrc/common/ref.v
@@ -17,28 +17,68 @@
 `ifndef TB_NO_DPIC
 import "DPI-C" function byte pte_helper (
   input  longint satp,
+  input  longint vsatp,
+  input  longint hgatp,
+  input  byte    mPBMTE,
+  input  byte    hPBMTE,
   input  longint vpn,
+  input  byte    s2xlate,
   output longint pte,
-  output byte    level
+  output byte    level,
+  output longint s1_pte,
+  output longint s2_pte,
+  output byte    s1_level
 );
 `endif // TB_NO_DPIC
 
-module PTEHelper(
+module PteHelper(
   input             clock,
   input             enable,
   input      [63:0] satp,
+  input      [63:0] vsatp,
+  input      [63:0] hgatp,
+  input             mPBMTE,
+  input             hPBMTE,
   input      [63:0] vpn,
-  output reg [63:0] pte,
-  output reg [ 7:0] level,
-  output reg [ 7:0] pf
+  input      [ 7:0] s2xlate,
+  output     [63:0] pte,
+  output     [ 7:0] level,
+  output     [ 7:0] pfType,
+  output     [63:0] s1_pte,
+  output     [63:0] s2_pte,
+  output     [ 7:0] s1_level
 );
-  always @(posedge clock) begin
-    if (enable) begin
+
+  reg [63:0] pte_comb;
+  reg [ 7:0] level_comb;
+  reg [63:0] s1_pte_comb;
+  reg [63:0] s2_pte_comb;
+  reg [ 7:0] s1_level_comb;
+  reg [ 7:0] pf_type_comb;
+
+  always @(*) begin
+    pf_type_comb  = 8'h0;
+    pte_comb      = 64'h0;
+    level_comb    = 8'h0;
+    s1_pte_comb   = 64'h0;
+    s2_pte_comb   = 64'h0;
+    s1_level_comb = 8'h0;
+
 `ifndef TB_NO_DPIC
-      pf <= pte_helper(satp, vpn, pte, level);
-`endif // TB_NO_DPIC
+    if (enable) begin
+      pf_type_comb = pte_helper(satp, vsatp, hgatp, {7'h0, mPBMTE}, {7'h0, hPBMTE},
+                                 vpn, s2xlate, pte_comb, level_comb, s1_pte_comb, s2_pte_comb, s1_level_comb);
     end
+`endif // TB_NO_DPIC
   end
+
+  assign pte      = pte_comb;
+  assign level    = level_comb;
+  assign pfType   = pf_type_comb;
+  assign s1_pte   = s1_pte_comb;
+  assign s2_pte   = s2_pte_comb;
+  assign s1_level = s1_level_comb;
+
 endmodule
 
 `ifndef TB_NO_DPIC


### PR DESCRIPTION
Add a DPI-C page-table helper for XiangShan ptehelper simulation modes. The helper walks satp, vsatp, and hgatp page tables for noS2xlate, onlyStage1, onlyStage2, and allStage requests.

The model supports mPBMTE and hPBMTE, checks PBMT legality, keeps NAPOT PTE encoding visible to RTL, and reports VS-stage or G-stage page faults with stage-specific results. It also stops walks on faulting non-leaf PTEs and rejects out-of-range G-stage addresses.

Validated with XiangShan rvh-test in softTLB and softPTW modes. Both modes pass all rvh-test cases, including PBMT tests.