### PR TITLE
feat(emu): dump checkpoint on abort

### DIFF
--- a/src/test/csrc/common/args.cpp
+++ b/src/test/csrc/common/args.cpp
@@ -98,6 +98,7 @@ static inline void print_help(const char *file) {
   printf("      --copy-ram=OFFSET      duplicate the memory at OFFSET\n");
   printf("      --splitview-log=PATH   write splitview uart.log, host.log, and all.log under PATH\n");
   printf("      --random-mem           initialize memory from --seed\n");
+  printf("      --auto-checkpoint      save checkpoint to $NOOP_HOME/build/ on difftest error\n");
   printf("  -h, --help                 print program help info\n");
   printf("\n");
 }
@@ -143,6 +144,7 @@ CommonArgs parse_args(int argc, const char *argv[]) {
     { "copy-ram",          1, NULL,  0  },
     { "cst-file",          1, NULL,  0  },
     { "random-mem",        0, NULL,  0  },
+    { "auto-checkpoint",   0, NULL,  0  },
     { "splitview-log",     1, NULL, OPT_SPLITVIEW_LOG },
     { "db-path",           1, NULL, OPT_DB_PATH },
     { "seed",              1, NULL, 's' },
@@ -257,6 +259,7 @@ CommonArgs parse_args(int argc, const char *argv[]) {
           case 29: args.copy_ram_offset = parse_ramsize(optarg); continue;
           case 30: args.cst_file = optarg; continue;
           case 31: args.random_mem = true; continue;
+          case 32: args.auto_checkpoint = true; continue;
         }
         // fall through
       default: print_help(argv[0]); exit(0);

--- a/src/test/csrc/common/args.h
+++ b/src/test/csrc/common/args.h
@@ -71,6 +71,7 @@ struct CommonArgs {
   bool dump_coverage = false;
   bool image_as_footprints = false;
   bool overwrite_nbytes_autoset = false;
+  bool auto_checkpoint = false;
 };
 
 CommonArgs parse_args(int argc, const char *argv[]);

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -158,7 +158,8 @@ public:
   f(ref_sync_custom_mflushpwr, difftest_sync_custom_mflushpwr, void, bool)                                  \
   f(ref_get_vec_load_vdNum, difftest_get_vec_load_vdNum, int, )                                             \
   f(ref_get_vec_load_dual_goldenmem_reg, difftest_get_vec_load_dual_goldenmem_reg, void*, )                 \
-  f(ref_update_vec_load_goldenmen, difftest_update_vec_load_pmem, void, )
+  f(ref_update_vec_load_goldenmen, difftest_update_vec_load_pmem, void, )                                   \
+  f(ref_trigger_checkpoint, difftest_trigger_checkpoint, void, const char *)
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
 /* clang-format on */
@@ -393,6 +394,11 @@ public:
 
   inline int get_status() {
     return ref_status ? ref_status() : 0;
+  }
+
+  inline void trigger_checkpoint(const char *base_filepath) {
+    assert(ref_trigger_checkpoint);
+    ref_trigger_checkpoint(base_filepath);
   }
 
 private:

--- a/src/test/csrc/emu/emu.cpp
+++ b/src/test/csrc/emu/emu.cpp
@@ -244,6 +244,10 @@ Emulator::~Emulator() {
     delete lightsss;
   }
 
+#ifndef CONFIG_NO_DIFFTEST
+  trigger_auto_checkpoint();
+#endif
+
   // warning: this function may still simulate the circuit
   // simulator resources must be released after this function
   display_stats();
@@ -289,6 +293,28 @@ Emulator::~Emulator() {
 
   delete dut_ptr;
 }
+
+#ifndef CONFIG_NO_DIFFTEST
+void Emulator::dump_checkpoint_from_ref() {
+  if (NUM_CORES != 1) {
+    Info("Skip checkpoint generation: multicore checkpoint is not supported yet.\n");
+    return;
+  }
+  const char *base_filepath = create_noop_filename("");
+  Info("Generating checkpoint: %s\n", base_filepath);
+  difftest[0]->proxy->trigger_checkpoint(base_filepath);
+}
+
+void Emulator::trigger_auto_checkpoint() {
+  if (!args.auto_checkpoint || args.enable_fork) {
+    return;
+  }
+  if (trapCode != STATE_ABORT) {
+    return;
+  }
+  dump_checkpoint_from_ref();
+}
+#endif
 
 inline void Emulator::reset_ncycles(size_t cycles) {
   if (args.trace_name && args.trace_is_read) {
@@ -529,7 +555,8 @@ int Emulator::tick() {
     stuck_timer++;
     if (stuck_timer >= Difftest::stuck_limit) {
       Info("No difftest check for more than %lu cycles, maybe get stuck.", Difftest::stuck_limit);
-      return STATE_ABORT;
+      trapCode = STATE_ABORT;
+      return trapCode;
     }
   }
 
@@ -746,6 +773,12 @@ void Emulator::snapshot_load(const char *filename) {
 
 void Emulator::fork_child_init() {
   dut_ptr->atClone();
+
+#ifndef CONFIG_NO_DIFFTEST
+  if (args.auto_checkpoint) {
+    dump_checkpoint_from_ref();
+  }
+#endif
 
   FORK_PRINTF("the oldest checkpoint start to dump wave and dump nemu log...\n")
 

--- a/src/test/csrc/emu/emu.h
+++ b/src/test/csrc/emu/emu.h
@@ -47,6 +47,10 @@ private:
   inline void single_cycle();
   void trigger_stat_dump();
   void display_stats();
+#ifndef CONFIG_NO_DIFFTEST
+  void dump_checkpoint_from_ref();
+  void trigger_auto_checkpoint();
+#endif
 
   inline const char *logdb_filename() {
     return create_noop_filename(".db");


### PR DESCRIPTION
Add --auto-checkpoint to request checkpoint generation from the REF NEMU when simulation aborts.

For normal non-fork runs, trigger checkpoint dumping from the emulator teardown path when trapCode is STATE_ABORT. For fork runs, let the fork child dump a checkpoint from the fork snapshot state while keeping waveform dumping enabled.

Set trapCode to STATE_ABORT on stuck timeout so the teardown path can use the same trigger condition.

The checkpoint path is generated in emu.cpp with create_noop_filename(), matching the existing waveform/output naming style.