### PR TITLE
fix(build): make sync commands compatible with uutils coreutils

### DIFF
--- a/pgo.mk
+++ b/pgo.mk
@@ -44,14 +44,14 @@ ifneq ($(PGO_BOLT),1)
 	@stat $(PGO_WORKLOAD) > /dev/null
 	@$(MAKE) $(PGO_CLEAN_OBJ)
 	@mkdir -p $(PGO_DIR)
-	@sync -d $(BUILD_DIR) -d $(PGO_EMU_DIR)
+	@sync -d $(BUILD_DIR) $(PGO_EMU_DIR)
 	@$(MAKE) $(PGO_BUILD_TARGET) \
 					   PGO_CFLAGS="-fprofile-generate=$(PGO_DIR)" \
 					   PGO_LDFLAGS="-fprofile-generate=$(PGO_DIR)"
 	@echo "Training emu with PGO Workload..."
-	@sync -d $(BUILD_DIR) -d $(PGO_EMU_DIR)
+	@sync -d $(BUILD_DIR) $(PGO_EMU_DIR)
 	$(PGO_TARGET) $(PGO_RUN_OPT)
-	@sync -d $(BUILD_DIR) -d $(PGO_EMU_DIR)
+	@sync -d $(BUILD_DIR) $(PGO_EMU_DIR)
 ifdef LLVM_PROFDATA
 # When using LLVM's profile-guided optimization, the raw data can not
 # directly be used in -fprofile-use. We need to use a specific version of
@@ -75,7 +75,7 @@ else # ifdef LLVM_PROFDATA
 endif # ifdef LLVM_PROFDATA
 	@echo "Building emu with PGO profile..."
 	@$(MAKE) $(PGO_CLEAN_OBJ)
-	@sync -d $(BUILD_DIR) -d $(PGO_EMU_DIR)
+	@sync -d $(BUILD_DIR) $(PGO_EMU_DIR)
 	@$(MAKE) $(PGO_BUILD_TARGET) \
 					   PGO_CFLAGS="-fprofile-use=$(PGO_DIR)" \
 					   PGO_LDFLAGS="-fprofile-use=$(PGO_DIR)"
@@ -83,10 +83,10 @@ else # ifneq ($(PGO_BOLT),1)
 	@echo "Building emu..."
 	@$(MAKE) $(PGO_BUILD_TARGET) PGO_LDFLAGS="-Wl,--emit-relocs -fuse-ld=bfd"
 	@mv $(PGO_TARGET) $(PGO_TARGET).pre-bolt
-	@sync -d $(BUILD_DIR) -d $(PGO_EMU_DIR)
+	@sync -d $(BUILD_DIR) $(PGO_EMU_DIR)
 	@echo "Training emu with PGO Workload..."
 	@mkdir -p $(PGO_DIR)
-	@sync -d $(BUILD_DIR) -d $(PGO_EMU_DIR)
+	@sync -d $(BUILD_DIR) $(PGO_EMU_DIR)
 	@((perf record -j any,u -o $(PGO_DIR)/perf.data -- sh -c "\
 		$(PGO_TARGET).pre-bolt $(PGO_RUN_OPT) || true") && \
 		(perf2bolt -p=$(PGO_DIR)/perf.data -o=$(PGO_DIR)/perf.fdata $(PGO_TARGET).pre-bolt || true)) || \
@@ -100,4 +100,4 @@ else # ifneq ($(PGO_BOLT),1)
 		(echo -e "\033[31mBOLT optimization failed, fallback to non-PGO build\033[0m" && \
 		mv $(PGO_TARGET).pre-bolt $(PGO_TARGET))
 endif # ifneq ($(PGO_BOLT),1)
-	@sync -d $(BUILD_DIR) -d $(PGO_EMU_DIR)
+	@sync -d $(BUILD_DIR) $(PGO_EMU_DIR)

--- a/verilator.mk
+++ b/verilator.mk
@@ -123,14 +123,14 @@ EMU_COMPILE_FILTER =
 
 verilator-build-emu:
 ifeq ($(REMOTE),localhost)
-	@sync -d $(BUILD_DIR) -d $(VERILATOR_BUILD_DIR)
+	@sync -d $(BUILD_DIR) $(VERILATOR_BUILD_DIR)
 	$(TIME_CMD) $(MAKE) -s VM_PARALLEL_BUILDS=1 OPT_SLOW="-O0" \
 						OPT_FAST=$(OPT_FAST) \
 						PGO_CFLAGS="$(PGO_CFLAGS)" \
 						PGO_LDFLAGS="$(PGO_LDFLAGS)" \
 						OBJCACHE="$(OBJCACHE)" \
 						-C $(VERILATOR_BUILD_DIR) -f $(VERILATOR_MK) $(EMU_COMPILE_FILTER)
-	@sync -d $(BUILD_DIR) -d $(VERILATOR_BUILD_DIR)
+	@sync -d $(BUILD_DIR) $(VERILATOR_BUILD_DIR)
 else
 	ssh -tt $(REMOTE) 'export NOOP_HOME=$(NOOP_HOME); \
 					   $(MAKE) -C $(NOOP_HOME)/difftest verilator-build-emu \


### PR DESCRIPTION
## Background

I encountered this issue on Ubuntu 26.04 LTS, which uses the Rust-based uutils coreutils implementation by default.

The existing commands interleave the `-d` option with path operands:

```sh
sync -d <build-dir> -d <emu-dir>
```

Although this form is accepted by GNU Coreutils, it is not compatible with uutils coreutils because the second -d appears after an operand. As a result, the Verilator and PGO build flows fail when these commands are executed on Ubuntu 26.04.

## Change

Place the -d option before all path operands:

```
sync -d <build-dir> <emu-dir>
```

The -d option applies to all specified files, so this preserves the existing data-only synchronization behavior while working with both GNU Coreutils and uutils coreutils.

This updates all affected sync invocations in verilator.mk and pgo.mk.