### PR TITLE
feat(refproxy): expose checkpoint trigger

### DIFF
--- a/src/test/csrc/common/flash.cpp
+++ b/src/test/csrc/common/flash.cpp
@@ -16,6 +16,7 @@
 
 #include "flash.h"
 #include "common.h"
+#include "compress.h"
 #ifdef CONFIG_DIFFTEST_PERFCNT
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
@@ -85,6 +86,20 @@ void init_flash(const char *flash_bin) {
 
   flash_dev.img_path = (char *)flash_bin;
   Info("use %s as flash bin\n", flash_dev.img_path);
+
+  if (isGzFile(flash_dev.img_path)) {
+    long ret = readFromGz(flash_dev.base, flash_dev.img_path, flash_dev.size, LOAD_SNAPSHOT);
+    assert(ret >= 0);
+    flash_dev.img_size = ret;
+    return;
+  }
+
+  if (isZstdFile(flash_dev.img_path)) {
+    long ret = readFromZstd(flash_dev.base, flash_dev.img_path, flash_dev.size, LOAD_SNAPSHOT);
+    assert(ret >= 0);
+    flash_dev.img_size = ret;
+    return;
+  }
 
   FILE *flash_fp = fopen(flash_dev.img_path, "r");
   if (!flash_fp) {

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -158,7 +158,8 @@ public:
   f(ref_sync_custom_mflushpwr, difftest_sync_custom_mflushpwr, void, bool)                                  \
   f(ref_get_vec_load_vdNum, difftest_get_vec_load_vdNum, int, )                                             \
   f(ref_get_vec_load_dual_goldenmem_reg, difftest_get_vec_load_dual_goldenmem_reg, void*, )                 \
-  f(ref_update_vec_load_goldenmen, difftest_update_vec_load_pmem, void, )
+  f(ref_update_vec_load_goldenmen, difftest_update_vec_load_pmem, void, )                                   \
+  f(ref_trigger_checkpoint, difftest_trigger_checkpoint, void, const char *)
 #define RefFunc(func, ret, ...) ret func(__VA_ARGS__)
 #define DeclRefFunc(this_func, dummy, ret, ...) RefFunc((*this_func), ret, __VA_ARGS__);
 /* clang-format on */
@@ -393,6 +394,11 @@ public:
 
   inline int get_status() {
     return ref_status ? ref_status() : 0;
+  }
+
+  inline void trigger_checkpoint(const char *base_filepath) {
+    assert(ref_trigger_checkpoint);
+    ref_trigger_checkpoint(base_filepath);
   }
 
 private:


### PR DESCRIPTION
Auto checkpointing needs the simulator to ask the REF NEMU shared object to serialize its current architectural state.

Add difftest_trigger_checkpoint to RefProxy and wrap it as trigger_checkpoint(), so emu code can request checkpoint generation through the existing refproxy path.