### PR TITLE
Save ChiselDB before LightSSS failure replay

### DIFF
--- a/src/test/csrc/emu/emu.cpp
+++ b/src/test/csrc/emu/emu.cpp
@@ -219,6 +219,10 @@ Emulator::Emulator(int argc, const char *argv[])
 Emulator::~Emulator() {
   // Simulation ends here, do clean up & display jobs
 
+#ifdef ENABLE_CHISEL_DB
+  bool db_saved_before_fork_replay = false;
+#endif
+
 #if VM_COVERAGE == 1
   // we dump coverage into files at the end
   // since we are not sure when an emu will stop
@@ -236,6 +240,12 @@ Emulator::~Emulator() {
 
   if (args.enable_fork && !is_fork_child()) {
     bool need_wakeup = trapCode != STATE_GOODTRAP && trapCode != STATE_LIMIT_EXCEEDED && trapCode != STATE_SIG;
+#ifdef ENABLE_CHISEL_DB
+    if (args.dump_db && need_wakeup) {
+      save_db(db_filename());
+      db_saved_before_fork_replay = true;
+    }
+#endif
     if (need_wakeup) {
       lightsss->wakeup_child(cycles);
     } else {
@@ -271,7 +281,7 @@ Emulator::~Emulator() {
   }
 
 #ifdef ENABLE_CHISEL_DB
-  if (args.dump_db) {
+  if (args.dump_db && !db_saved_before_fork_replay) {
     save_db(db_filename());
   }
 #endif


### PR DESCRIPTION
## Root cause

ChiselDB stores records in an in-memory SQLite database and only exports them from `Emulator::~Emulator()`. With LightSSS fork debugging enabled, the parent waits for the replay child before reaching `save_db()`. If the replay child hangs, the parent is eventually killed and the database is lost.

## Change

Save the parent ChiselDB database before waking the LightSSS replay child on failure. Track whether that early save occurred so the destructor does not save the same database again if replay returns.

The existing final-save path remains in place for:

- non-fork runs
- successful fork-enabled runs
- fork replay children

## Impact

Failed simulations retain the parent ChiselDB records even when the replay child does not terminate.

## Validation

- Confirmed the branch is one commit ahead of `master` and modifies only `src/test/csrc/emu/emu.cpp`.
- Checked preprocessor/path behavior with and without `ENABLE_CHISEL_DB`, for fork parents, fork children, and non-fork runs.
- Full build and a hanging LightSSS replay were not run locally because this workspace does not contain a difftest checkout; CI or maintainer testing is still required.