### PR TITLE
fix(topdown): fix GSIM topdown helper linkage

### DIFF
--- a/src/main/scala/plugin/topdown/TopdownDPI.scala
+++ b/src/main/scala/plugin/topdown/TopdownDPI.scala
@@ -79,8 +79,6 @@ private[topdown] object TopdownDPI {
 
   def gsimPaddedWidth(width: Int): Int = ((width + 63) / 64) * 64
 
-  def gsimBitIntType(width: Int): String = s"unsigned _BitInt(${gsimPaddedWidth(width)})"
-
   private val commonInfoFields = Seq("valid", "robIdx", "robFlag", "cancelSource", "issued")
   val iqInfoFields: Seq[String] = commonInfoFields ++ Seq("pipeNum", "srcReady", "futype")
   val extendedIQInfoFields: Seq[String] = Seq("idealIssueTime")
@@ -104,7 +102,12 @@ private[topdown] object TopdownDPI {
     }
   }
 
-  def iqHelperVerilog(moduleName: String, dpiFuncName: String): String =
+  def iqHelperVerilog(
+    moduleName: String,
+    dpiFuncName: String,
+    inPaddedWidth: Int,
+    outPaddedWidth: Int,
+  ): String =
     s"""
        |module $moduleName #(
        |  parameter integer ENTRY_NUM = 1,
@@ -112,11 +115,12 @@ private[topdown] object TopdownDPI {
        |  parameter integer OUT_WIDTH = $extendedIQInfoWidth
        |) (
        |  input                         clock,
-       |  input  [ENTRY_NUM*INFO_WIDTH-1:0] in,
-       |  output reg [ENTRY_NUM*OUT_WIDTH-1:0] out
+       |  input  [${inPaddedWidth - 1}:0] in,
+       |  output reg [${outPaddedWidth - 1}:0] out
        |);
        |
        |  wire _unused_clock = clock;
+       |  reg [ENTRY_NUM*OUT_WIDTH-1:0] dpi_out;
        |
        |`ifndef SYNTHESIS
        |  import "DPI-C" function void $dpiFuncName(
@@ -128,28 +132,37 @@ private[topdown] object TopdownDPI {
        |  always @(*) begin
        |    /* verilator lint_off WIDTHCONCAT */
        |    out = '0;
+       |    dpi_out = '0;
        |    /* verilator lint_on WIDTHCONCAT */
        |`ifndef SYNTHESIS
        |    $dpiFuncName(
-       |      in,
-       |      out
+       |      in[ENTRY_NUM*INFO_WIDTH-1:0],
+       |      dpi_out
        |    );
        |`endif // SYNTHESIS
+       |    out[ENTRY_NUM*OUT_WIDTH-1:0] = dpi_out;
        |  end
        |
        |endmodule
        |""".stripMargin
 
-  def robHelperVerilog(moduleName: String, dpiFuncName: String): String =
+  def robHelperVerilog(
+    moduleName: String,
+    dpiFuncName: String,
+    inPaddedWidth: Int,
+    outPaddedWidth: Int,
+  ): String =
     s"""
        |module $moduleName #(
        |  parameter integer IQ_ENTRY_NUM = 1,
        |  parameter integer ROB_ENTRY_NUM = 1,
        |  parameter integer INFO_WIDTH = $robInfoWidth
        |) (
-       |  input  [IQ_ENTRY_NUM*INFO_WIDTH-1:0] in,
-       |  output reg [ROB_ENTRY_NUM*INFO_WIDTH-1:0] out
+       |  input  [${inPaddedWidth - 1}:0] in,
+       |  output reg [${outPaddedWidth - 1}:0] out
        |);
+       |
+       |  reg [ROB_ENTRY_NUM*INFO_WIDTH-1:0] dpi_out;
        |
        |`ifndef SYNTHESIS
        |  import "DPI-C" function void $dpiFuncName(
@@ -161,13 +174,15 @@ private[topdown] object TopdownDPI {
        |  always @(*) begin
        |    /* verilator lint_off WIDTHCONCAT */
        |    out = '0;
+       |    dpi_out = '0;
        |    /* verilator lint_on WIDTHCONCAT */
        |`ifndef SYNTHESIS
        |    $dpiFuncName(
-       |      in,
-       |      out
+       |      in[IQ_ENTRY_NUM*INFO_WIDTH-1:0],
+       |      dpi_out
        |    );
        |`endif // SYNTHESIS
+       |    out[ROB_ENTRY_NUM*INFO_WIDTH-1:0] = dpi_out;
        |  end
        |
        |endmodule

--- a/src/main/scala/plugin/topdown/TopdownDPI.scala
+++ b/src/main/scala/plugin/topdown/TopdownDPI.scala
@@ -77,6 +77,10 @@ private[topdown] object TopdownDPI {
   val extendedIQInfoWidth: Int = (new TopdownExtendedIQInfoDPI).getWidth
   val robInfoWidth: Int = (new TopdownRobInfoDPI).getWidth
 
+  def gsimPaddedWidth(width: Int): Int = ((width + 63) / 64) * 64
+
+  def gsimBitIntType(width: Int): String = s"unsigned _BitInt(${gsimPaddedWidth(width)})"
+
   private val commonInfoFields = Seq("valid", "robIdx", "robFlag", "cancelSource", "issued")
   val iqInfoFields: Seq[String] = commonInfoFields ++ Seq("pipeNum", "srcReady", "futype")
   val extendedIQInfoFields: Seq[String] = Seq("idealIssueTime")

--- a/src/main/scala/plugin/topdown/TopdownIQInfo.scala
+++ b/src/main/scala/plugin/topdown/TopdownIQInfo.scala
@@ -59,6 +59,36 @@ class TopdownIQInfoHelper(val entriesNum: Int)
   private val dpiFuncName: String = s"topdown_iq_info_dpic_$entriesNum"
 
   setInline(s"$desiredName.v", TopdownDPI.iqHelperVerilog(desiredName, dpiFuncName))
+
+  private val inWidth = entriesNum * TopdownDPI.iqInfoWidth
+  private val outWidth = entriesNum * TopdownDPI.extendedIQInfoWidth
+  private val inPaddedWidth = TopdownDPI.gsimPaddedWidth(inWidth)
+  private val outPaddedWidth = TopdownDPI.gsimPaddedWidth(outWidth)
+  private val cppExtModule =
+    s"""
+       |extern "C" void topdown_iq_info_dpic(
+       |  unsigned int entries_num,
+       |  const uint32_t *in_bits,
+       |  uint32_t *out_bits
+       |);
+       |
+       |void $desiredName(
+       |  int ENTRY_NUM,
+       |  int INFO_WIDTH,
+       |  int OUT_WIDTH,
+       |  ${TopdownDPI.gsimBitIntType(inWidth)} in,
+       |  ${TopdownDPI.gsimBitIntType(outWidth)}& out
+       |) {
+       |  constexpr int in_words = ($inPaddedWidth + 31) / 32;
+       |  constexpr int out_words = ($outPaddedWidth + 31) / 32;
+       |  uint32_t in_bits[in_words];
+       |  uint32_t out_bits[out_words] = {};
+       |  std::memcpy(in_bits, &in, sizeof(in_bits));
+       |  topdown_iq_info_dpic(ENTRY_NUM, in_bits, out_bits);
+       |  std::memcpy(&out, out_bits, sizeof(out_bits));
+       |}
+       |""".stripMargin
+  difftest.DifftestModule.createCppExtModule(desiredName, cppExtModule, Some("<cstring>"))
 }
 
 class TopdownIQInfoCollect(val entriesNum: Int) extends Module {

--- a/src/main/scala/plugin/topdown/TopdownIQInfo.scala
+++ b/src/main/scala/plugin/topdown/TopdownIQInfo.scala
@@ -48,22 +48,26 @@ class TopdownIQInfoHelper(val entriesNum: Int)
     )
   )
   with HasBlackBoxInline {
+  private val inWidth = entriesNum * TopdownDPI.iqInfoWidth
+  private val outWidth = entriesNum * TopdownDPI.extendedIQInfoWidth
+  private val inPaddedWidth = TopdownDPI.gsimPaddedWidth(inWidth)
+  private val outPaddedWidth = TopdownDPI.gsimPaddedWidth(outWidth)
+
   val io = IO(new Bundle {
     val clock = Input(Clock())
-    val in = Input(UInt((entriesNum * TopdownDPI.iqInfoWidth).W))
-    val out = Output(UInt((entriesNum * TopdownDPI.extendedIQInfoWidth).W))
+    val in = Input(UInt(inPaddedWidth.W))
+    val out = Output(UInt(outPaddedWidth.W))
   })
 
   override def desiredName: String = s"TopdownIQInfoHelper_$entriesNum"
 
   private val dpiFuncName: String = s"topdown_iq_info_dpic_$entriesNum"
 
-  setInline(s"$desiredName.v", TopdownDPI.iqHelperVerilog(desiredName, dpiFuncName))
+  setInline(
+    s"$desiredName.v",
+    TopdownDPI.iqHelperVerilog(desiredName, dpiFuncName, inPaddedWidth, outPaddedWidth),
+  )
 
-  private val inWidth = entriesNum * TopdownDPI.iqInfoWidth
-  private val outWidth = entriesNum * TopdownDPI.extendedIQInfoWidth
-  private val inPaddedWidth = TopdownDPI.gsimPaddedWidth(inWidth)
-  private val outPaddedWidth = TopdownDPI.gsimPaddedWidth(outWidth)
   private val cppExtModule =
     s"""
        |extern "C" void topdown_iq_info_dpic(
@@ -76,11 +80,11 @@ class TopdownIQInfoHelper(val entriesNum: Int)
        |  int ENTRY_NUM,
        |  int INFO_WIDTH,
        |  int OUT_WIDTH,
-       |  ${TopdownDPI.gsimBitIntType(inWidth)} in,
-       |  ${TopdownDPI.gsimBitIntType(outWidth)}& out
+       |  unsigned _BitInt($inPaddedWidth) in,
+       |  unsigned _BitInt($outPaddedWidth)& out
        |) {
-       |  constexpr int in_words = ($inPaddedWidth + 31) / 32;
-       |  constexpr int out_words = ($outPaddedWidth + 31) / 32;
+       |  constexpr int in_words = $inPaddedWidth / 32;
+       |  constexpr int out_words = $outPaddedWidth / 32;
        |  uint32_t in_bits[in_words];
        |  uint32_t out_bits[out_words] = {};
        |  std::memcpy(in_bits, &in, sizeof(in_bits));
@@ -97,7 +101,9 @@ class TopdownIQInfoCollect(val entriesNum: Int) extends Module {
   val helper = Module(new TopdownIQInfoHelper(entriesNum))
 
   helper.io.clock := clock
-  helper.io.in := VecInit(io.in.map(info => TopdownIQInfoDPI.from(info))).asUInt
-  val out = helper.io.out.asTypeOf(Vec(entriesNum, new TopdownExtendedIQInfoDPI))
+  val packedIn = VecInit(io.in.map(info => TopdownIQInfoDPI.from(info))).asUInt
+  helper.io.in := packedIn.pad(helper.io.in.getWidth)
+  val packedOut = helper.io.out(entriesNum * TopdownDPI.extendedIQInfoWidth - 1, 0)
+  val out = packedOut.asTypeOf(Vec(entriesNum, new TopdownExtendedIQInfoDPI))
   io.out := VecInit(out.map(_.toTopdown))
 }

--- a/src/main/scala/plugin/topdown/TopdownRobInfo.scala
+++ b/src/main/scala/plugin/topdown/TopdownRobInfo.scala
@@ -38,21 +38,25 @@ class TopdownRobInfoHelper(val IQEntriesNum: Int, val RobEntriesNum: Int)
     Map("IQ_ENTRY_NUM" -> IQEntriesNum, "ROB_ENTRY_NUM" -> RobEntriesNum, "INFO_WIDTH" -> TopdownDPI.robInfoWidth)
   )
   with HasBlackBoxInline {
+  private val inWidth = IQEntriesNum * TopdownDPI.robInfoWidth
+  private val outWidth = RobEntriesNum * TopdownDPI.robInfoWidth
+  private val inPaddedWidth = TopdownDPI.gsimPaddedWidth(inWidth)
+  private val outPaddedWidth = TopdownDPI.gsimPaddedWidth(outWidth)
+
   val io = IO(new Bundle {
-    val in = Input(UInt((IQEntriesNum * TopdownDPI.robInfoWidth).W))
-    val out = Output(UInt((RobEntriesNum * TopdownDPI.robInfoWidth).W))
+    val in = Input(UInt(inPaddedWidth.W))
+    val out = Output(UInt(outPaddedWidth.W))
   })
 
   override def desiredName: String = s"TopdownRobInfoHelper_${IQEntriesNum}_${RobEntriesNum}"
 
   private val dpiFuncName: String = s"topdown_rob_info_dpic_${IQEntriesNum}_${RobEntriesNum}"
 
-  setInline(s"$desiredName.v", TopdownDPI.robHelperVerilog(desiredName, dpiFuncName))
+  setInline(
+    s"$desiredName.v",
+    TopdownDPI.robHelperVerilog(desiredName, dpiFuncName, inPaddedWidth, outPaddedWidth),
+  )
 
-  private val inWidth = IQEntriesNum * TopdownDPI.robInfoWidth
-  private val outWidth = RobEntriesNum * TopdownDPI.robInfoWidth
-  private val inPaddedWidth = TopdownDPI.gsimPaddedWidth(inWidth)
-  private val outPaddedWidth = TopdownDPI.gsimPaddedWidth(outWidth)
   private val cppExtModule =
     s"""
        |extern "C" void topdown_rob_info_dpic(
@@ -66,11 +70,11 @@ class TopdownRobInfoHelper(val IQEntriesNum: Int, val RobEntriesNum: Int)
        |  int INFO_WIDTH,
        |  int IQ_ENTRY_NUM,
        |  int ROB_ENTRY_NUM,
-       |  ${TopdownDPI.gsimBitIntType(inWidth)} in,
-       |  ${TopdownDPI.gsimBitIntType(outWidth)}& out
+       |  unsigned _BitInt($inPaddedWidth) in,
+       |  unsigned _BitInt($outPaddedWidth)& out
        |) {
-       |  constexpr int in_words = ($inPaddedWidth + 31) / 32;
-       |  constexpr int out_words = ($outPaddedWidth + 31) / 32;
+       |  constexpr int in_words = $inPaddedWidth / 32;
+       |  constexpr int out_words = $outPaddedWidth / 32;
        |  uint32_t in_bits[in_words];
        |  uint32_t out_bits[out_words] = {};
        |  std::memcpy(in_bits, &in, sizeof(in_bits));
@@ -86,7 +90,9 @@ class TopdownRobInfoCollect(val IQEntriesNum: Int, val RobEntriesNum: Int) exten
 
   val helper = Module(new TopdownRobInfoHelper(IQEntriesNum, RobEntriesNum))
 
-  helper.io.in := VecInit(io.in.map(info => TopdownRobInfoDPI.from(info))).asUInt
-  val out = helper.io.out.asTypeOf(Vec(RobEntriesNum, new TopdownRobInfoDPI))
+  val packedIn = VecInit(io.in.map(info => TopdownRobInfoDPI.from(info))).asUInt
+  helper.io.in := packedIn.pad(helper.io.in.getWidth)
+  val packedOut = helper.io.out(RobEntriesNum * TopdownDPI.robInfoWidth - 1, 0)
+  val out = packedOut.asTypeOf(Vec(RobEntriesNum, new TopdownRobInfoDPI))
   io.out := VecInit(out.map(_.toTopdown))
 }

--- a/src/main/scala/plugin/topdown/TopdownRobInfo.scala
+++ b/src/main/scala/plugin/topdown/TopdownRobInfo.scala
@@ -48,6 +48,37 @@ class TopdownRobInfoHelper(val IQEntriesNum: Int, val RobEntriesNum: Int)
   private val dpiFuncName: String = s"topdown_rob_info_dpic_${IQEntriesNum}_${RobEntriesNum}"
 
   setInline(s"$desiredName.v", TopdownDPI.robHelperVerilog(desiredName, dpiFuncName))
+
+  private val inWidth = IQEntriesNum * TopdownDPI.robInfoWidth
+  private val outWidth = RobEntriesNum * TopdownDPI.robInfoWidth
+  private val inPaddedWidth = TopdownDPI.gsimPaddedWidth(inWidth)
+  private val outPaddedWidth = TopdownDPI.gsimPaddedWidth(outWidth)
+  private val cppExtModule =
+    s"""
+       |extern "C" void topdown_rob_info_dpic(
+       |  unsigned int iq_entries_num,
+       |  unsigned int rob_entries_num,
+       |  const uint32_t *in_bits,
+       |  uint32_t *out_bits
+       |);
+       |
+       |void $desiredName(
+       |  int INFO_WIDTH,
+       |  int IQ_ENTRY_NUM,
+       |  int ROB_ENTRY_NUM,
+       |  ${TopdownDPI.gsimBitIntType(inWidth)} in,
+       |  ${TopdownDPI.gsimBitIntType(outWidth)}& out
+       |) {
+       |  constexpr int in_words = ($inPaddedWidth + 31) / 32;
+       |  constexpr int out_words = ($outPaddedWidth + 31) / 32;
+       |  uint32_t in_bits[in_words];
+       |  uint32_t out_bits[out_words] = {};
+       |  std::memcpy(in_bits, &in, sizeof(in_bits));
+       |  topdown_rob_info_dpic(IQ_ENTRY_NUM, ROB_ENTRY_NUM, in_bits, out_bits);
+       |  std::memcpy(&out, out_bits, sizeof(out_bits));
+       |}
+       |""".stripMargin
+  difftest.DifftestModule.createCppExtModule(desiredName, cppExtModule, Some("<cstring>"))
 }
 
 class TopdownRobInfoCollect(val IQEntriesNum: Int, val RobEntriesNum: Int) extends Module {


### PR DESCRIPTION
	GSIM linked failed with undefined references to TopdownIQInfoHelper_* andTopdownRobInfoHelper_* because topdown IQ/ROB helpers only registered Verilator DPI entry points.

	Register GSIM C++ external-module wrappers for the topdown helpers, pad wide ports to GSIM _BitInt ABI widths, and reuse the existing topdown DPI implementations through uint32_t word-array memcpy.