### PR TITLE
feat(difftest): track vectorized matrix stores

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -255,9 +255,13 @@ class SbufferEvent extends DifftestBaseBundle with HasValid {
 }
 
 class MatrixStoreEvent extends DifftestBaseBundle with HasValid {
+  val reqValid = Bool()
+  val reqEncodedSourceId = UInt(64.W)
   val addr = UInt(64.W)
   val data = Vec(64, UInt(8.W))
   val mask = UInt(64.W)
+  val respValid = Bool()
+  val respEncodedSourceId = UInt(64.W)
 }
 
 class UncacheMMStoreEvent extends DifftestBaseBundle with HasValid {

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -622,6 +622,15 @@ object DifftestModule {
     difftest
   }
 
+  def applyVec[T <: DifftestBundle](
+    gens: Seq[T],
+    dontCare: Boolean = false,
+    delay: Int = 0,
+  ): Seq[T] = {
+    require(gens.nonEmpty, "DifftestModule.applyVec requires at least one lane")
+    gens.map(gen => apply(gen, dontCare, delay))
+  }
+
   def get_current_interfaces(): Seq[(DifftestBundle, Int)] = interfaces.toSeq
 
   def get_command_configs(): Seq[String] = cmdConfigs.toSeq

--- a/src/test/csrc/difftest/checkers.h
+++ b/src/test/csrc/difftest/checkers.h
@@ -19,6 +19,7 @@
 
 #include "common.h"
 #include "diffstate.h"
+#include "matrix_store_tracker.h"
 #include "refproxy.h"
 #include "stopwatch.h"
 
@@ -354,15 +355,22 @@ private:
 #endif // CONFIG_DIFFTEST_SBUFFEREVENT
 
 #ifdef CONFIG_DIFFTEST_MATRIXSTOREEVENT
-class MatrixStoreChecker : public ProbeChecker<DifftestMatrixStoreEvent> {
+class MatrixStoreChecker : public DiffTestChecker {
 public:
-  MatrixStoreChecker(GetProbeFn get_probe, DiffState *state, RefProxy *proxy)
-      : ProbeChecker<DifftestMatrixStoreEvent>(get_probe, state, proxy) {}
+  using GetProbesFn = std::function<DifftestMatrixStoreEvent *()>;
+
+  MatrixStoreChecker(GetProbesFn get_probes, DiffState *state, RefProxy *proxy)
+      : DiffTestChecker(state, proxy), get_probes(std::move(get_probes)) {}
+  ~MatrixStoreChecker() override;
+
+  void replay_snapshot();
+  void replay_restore();
 
 private:
-  bool get_valid(const DifftestMatrixStoreEvent &probe) override;
-  void clear_valid(DifftestMatrixStoreEvent &probe) override;
-  int check(const DifftestMatrixStoreEvent &probe) override;
+  int do_step() override;
+
+  GetProbesFn get_probes;
+  MatrixStoreTracker tracker;
 };
 #endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
 

--- a/src/test/csrc/difftest/checkers/globalmem.cpp
+++ b/src/test/csrc/difftest/checkers/globalmem.cpp
@@ -16,6 +16,7 @@
 
 #include "checkers.h"
 #include "goldenmem.h"
+#include <algorithm>
 
 void dumpGoldenMem(const char *banner, uint64_t addr, uint64_t time) {
 #ifdef DEBUG_REFILL
@@ -65,20 +66,82 @@ int SbufferChecker::check(const DifftestSbufferEvent &probe) {
 
 #ifdef CONFIG_DIFFTEST_MATRIXSTOREEVENT
 
-bool MatrixStoreChecker::get_valid(const DifftestMatrixStoreEvent &probe) {
-  return probe.valid;
+namespace {
+
+const char *matrix_store_status_name(MatrixStoreTrackerStatus status) {
+  switch (status) {
+    case MatrixStoreTrackerStatus::Ok: return "ok";
+    case MatrixStoreTrackerStatus::MalformedTag: return "malformed-tag";
+    case MatrixStoreTrackerStatus::DuplicateRequest: return "duplicate-request";
+    case MatrixStoreTrackerStatus::MissingResponse: return "missing-response";
+  }
+  return "unknown";
 }
 
-void MatrixStoreChecker::clear_valid(DifftestMatrixStoreEvent &probe) {
-  probe.valid = 0;
+void report_matrix_store_failure(const DiffState *state, const MatrixStoreFailure &failure) {
+  eprintf("[DiffTest][MatrixStore] core=%d cycle=%" PRIu64 " lane=%zu operation=%s encoded_id=0x%" PRIx64 " error=%s\n",
+          state->coreid, failure.cycle, failure.lane, failure.isRequest ? "request" : "response",
+          failure.encodedSourceId, matrix_store_status_name(failure.status));
 }
 
-int MatrixStoreChecker::check(const DifftestMatrixStoreEvent &probe) {
-  update_goldenmem(probe.addr, (void *)probe.data, probe.mask, 64);
-  if (probe.addr == state->track_instr) {
-    dumpGoldenMem("Matrix Store", state->track_instr, state->cycle_count);
+} // namespace
+
+MatrixStoreChecker::~MatrixStoreChecker() {
+  if (tracker.empty()) {
+    return;
+  }
+  eprintf("[DiffTest][MatrixStore] core=%d outstanding_requests=%zu at finalization\n", state->coreid, tracker.size());
+  for (const auto &[encodedSourceId, request]: tracker.entries()) {
+    eprintf("[DiffTest][MatrixStore] core=%d live_id=0x%" PRIx64 " request_lane=%zu request_cycle=%" PRIu64
+            " addr=0x%" PRIx64 "\n",
+            state->coreid, encodedSourceId, request.requestLane, request.requestCycle, request.addr);
+  }
+}
+
+int MatrixStoreChecker::do_step() {
+  std::array<MatrixStoreObservation, CONFIG_DIFF_MATRIX_STORE_WIDTH> observations{};
+  DifftestMatrixStoreEvent *probes = get_probes();
+
+  for (size_t lane = 0; lane < observations.size(); lane++) {
+    auto &probe = probes[lane];
+    if (probe.valid) {
+      auto &observation = observations[lane];
+      observation.reqValid = probe.reqValid;
+      observation.reqEncodedSourceId = probe.reqEncodedSourceId;
+      observation.request.addr = probe.addr;
+      std::copy_n(probe.data, observation.request.data.size(), observation.request.data.begin());
+      observation.request.mask = probe.mask;
+      observation.respValid = probe.respValid;
+      observation.respEncodedSourceId = probe.respEncodedSourceId;
+    }
+    probe.valid = 0;
+    probe.reqValid = 0;
+    probe.respValid = 0;
+  }
+
+  MatrixStoreFailure failure;
+  const auto status = tracker.process_cycle(
+      observations, state->cycle_count,
+      [this](MatrixStoreRequest &request) {
+        update_goldenmem(request.addr, request.data.data(), request.mask, 64);
+        if (request.addr == state->track_instr) {
+          dumpGoldenMem("Matrix Store", state->track_instr, state->cycle_count);
+        }
+      },
+      &failure);
+  if (status != MatrixStoreTrackerStatus::Ok) {
+    report_matrix_store_failure(state, failure);
+    return STATE_ERROR;
   }
   return STATE_OK;
+}
+
+void MatrixStoreChecker::replay_snapshot() {
+  tracker.snapshot();
+}
+
+void MatrixStoreChecker::replay_restore() {
+  tracker.restore();
 }
 #endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -369,10 +369,9 @@ void Difftest::init_checkers() {
 #endif // CONFIG_DIFFTEST_SBUFFEREVENT
 
 #ifdef CONFIG_DIFFTEST_MATRIXSTOREEVENT
-  for (int i = 0; i < CONFIG_DIFF_MATRIX_STORE_WIDTH; i++) {
-    checkers.push_back(new MatrixStoreChecker(
-        [this, i]() -> DifftestMatrixStoreEvent & { return dut->matrix_store[i]; }, state, proxy));
-  }
+  matrix_store_checker =
+      new MatrixStoreChecker([this]() -> DifftestMatrixStoreEvent * { return dut->matrix_store; }, state, proxy);
+  checkers.push_back(matrix_store_checker);
 #endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
 
 #ifdef CONFIG_DIFFTEST_ATOMICEVENT
@@ -522,6 +521,11 @@ void Difftest::replay_snapshot() {
   proxy->set_store_log(true);
   goldenmem_store_log_reset();
   goldenmem_set_store_log(true);
+#ifdef CONFIG_DIFFTEST_MATRIXSTOREEVENT
+  if (matrix_store_checker != nullptr) {
+    matrix_store_checker->replay_snapshot();
+  }
+#endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
 }
 
 void Difftest::do_replay() {
@@ -535,6 +539,11 @@ void Difftest::do_replay() {
   proxy->ref_csrcpy(squash_csr_buf, DUT_TO_REF);
   proxy->ref_store_log_restore();
   goldenmem_store_log_restore();
+#ifdef CONFIG_DIFFTEST_MATRIXSTOREEVENT
+  if (matrix_store_checker != nullptr) {
+    matrix_store_checker->replay_restore();
+  }
+#endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
   difftest_replay_head(info.trace_head);
   // clear buffered queue
 #ifdef CONFIG_DIFFTEST_STOREEVENT

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -202,6 +202,9 @@ protected:
   LoadSquashChecker *load_squash_checker = nullptr;
 #endif // CONFIG_DIFFTEST_SQUASH
 #endif // CONFIG_DIFFTEST_LOADEVENT
+#ifdef CONFIG_DIFFTEST_MATRIXSTOREEVENT
+  MatrixStoreChecker *matrix_store_checker = nullptr;
+#endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
 
 #ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
   // MMA verifier instance

--- a/src/test/csrc/difftest/matrix_store_tracker.h
+++ b/src/test/csrc/difftest/matrix_store_tracker.h
@@ -1,0 +1,171 @@
+/***************************************************************************************
+* Copyright (c) 2026 Beijing Institute of Open Source Chip
+*
+* DiffTest is licensed under Mulan PSL v2.
+* You can use this software according to the terms and conditions of the Mulan PSL v2.
+* You may obtain a copy of Mulan PSL v2 at:
+*          http://license.coscl.org.cn/MulanPSL2
+*
+* THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+* EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+* MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+*
+* See the Mulan PSL v2 for more details.
+***************************************************************************************/
+
+#ifndef __MATRIX_STORE_TRACKER_H__
+#define __MATRIX_STORE_TRACKER_H__
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+
+struct MatrixStoreRequest {
+  uint64_t addr = 0;
+  std::array<uint8_t, 64> data{};
+  uint64_t mask = 0;
+  size_t requestLane = 0;
+  uint64_t requestCycle = 0;
+};
+
+struct MatrixStoreObservation {
+  bool reqValid = false;
+  uint64_t reqEncodedSourceId = 0;
+  MatrixStoreRequest request{};
+  bool respValid = false;
+  uint64_t respEncodedSourceId = 0;
+};
+
+enum class MatrixStoreTrackerStatus {
+  Ok,
+  MalformedTag,
+  DuplicateRequest,
+  MissingResponse,
+};
+
+struct MatrixStoreFailure {
+  MatrixStoreTrackerStatus status = MatrixStoreTrackerStatus::Ok;
+  bool isRequest = false;
+  size_t lane = 0;
+  uint64_t cycle = 0;
+  uint64_t encodedSourceId = 0;
+};
+
+class MatrixStoreTracker {
+public:
+  using RequestMap = std::map<uint64_t, MatrixStoreRequest>;
+
+  MatrixStoreTrackerStatus insert(uint64_t encodedSourceId, const MatrixStoreRequest &request) {
+    if (!has_cwrite_tag(encodedSourceId)) {
+      return MatrixStoreTrackerStatus::MalformedTag;
+    }
+    if (liveRequests.find(encodedSourceId) != liveRequests.end()) {
+      return MatrixStoreTrackerStatus::DuplicateRequest;
+    }
+
+    liveRequests.emplace(encodedSourceId, request);
+    return MatrixStoreTrackerStatus::Ok;
+  }
+
+  MatrixStoreTrackerStatus complete(uint64_t encodedSourceId, MatrixStoreRequest &request) {
+    if (!has_cwrite_tag(encodedSourceId)) {
+      return MatrixStoreTrackerStatus::MalformedTag;
+    }
+
+    const auto entry = liveRequests.find(encodedSourceId);
+    if (entry == liveRequests.end()) {
+      return MatrixStoreTrackerStatus::MissingResponse;
+    }
+    request = entry->second;
+    liveRequests.erase(entry);
+    return MatrixStoreTrackerStatus::Ok;
+  }
+
+  template <size_t LaneCount, typename CompletionFn>
+  MatrixStoreTrackerStatus process_cycle(const std::array<MatrixStoreObservation, LaneCount> &observations,
+                                         uint64_t cycle, CompletionFn &&onCompletion,
+                                         MatrixStoreFailure *failure = nullptr) {
+    for (size_t lane = 0; lane < LaneCount; lane++) {
+      const auto &observation = observations[lane];
+      if (!observation.respValid) {
+        continue;
+      }
+
+      MatrixStoreRequest request;
+      const auto status = complete(observation.respEncodedSourceId, request);
+      if (status != MatrixStoreTrackerStatus::Ok) {
+        set_failure(failure, status, false, lane, cycle, observation.respEncodedSourceId);
+        return status;
+      }
+      onCompletion(request);
+    }
+
+    for (size_t lane = 0; lane < LaneCount; lane++) {
+      const auto &observation = observations[lane];
+      if (!observation.reqValid) {
+        continue;
+      }
+
+      MatrixStoreRequest request = observation.request;
+      request.requestLane = lane;
+      request.requestCycle = cycle;
+      const auto status = insert(observation.reqEncodedSourceId, request);
+      if (status != MatrixStoreTrackerStatus::Ok) {
+        set_failure(failure, status, true, lane, cycle, observation.reqEncodedSourceId);
+        return status;
+      }
+    }
+    return MatrixStoreTrackerStatus::Ok;
+  }
+
+  void snapshot() {
+    replaySnapshot = liveRequests;
+  }
+
+  void restore() {
+    liveRequests = replaySnapshot;
+  }
+
+  void clear() {
+    liveRequests.clear();
+    replaySnapshot.clear();
+  }
+
+  size_t size() const {
+    return liveRequests.size();
+  }
+
+  bool empty() const {
+    return liveRequests.empty();
+  }
+
+  const RequestMap &entries() const {
+    return liveRequests;
+  }
+
+private:
+  static constexpr uint64_t CWriteTag = 3;
+  static constexpr uint64_t SourceTagMask = 7;
+
+  static bool has_cwrite_tag(uint64_t encodedSourceId) {
+    return (encodedSourceId & SourceTagMask) == CWriteTag;
+  }
+
+  static void set_failure(MatrixStoreFailure *failure, MatrixStoreTrackerStatus status, bool isRequest, size_t lane,
+                          uint64_t cycle, uint64_t encodedSourceId) {
+    if (failure == nullptr) {
+      return;
+    }
+    failure->status = status;
+    failure->isRequest = isRequest;
+    failure->lane = lane;
+    failure->cycle = cycle;
+    failure->encodedSourceId = encodedSourceId;
+  }
+
+  RequestMap liveRequests;
+  RequestMap replaySnapshot;
+};
+
+#endif // __MATRIX_STORE_TRACKER_H__


### PR DESCRIPTION
- Add vectorized  CStore event production and request/response source metadata
- Correlate all CStore req/resp by full encoded source ID per core
- Process CStore responses before requests and update golden memory exactly once
- Preserve pending CStores across replay and report correlation failures