### PR TITLE
feat(squash): support runtime squash control

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -67,7 +67,7 @@ make SPLITVIEW=0   # disable for emu builds
 
 When enabled and run directly in an interactive terminal, UART output and host logs are shown side by side in the split view. The same streams are also written asynchronously to `build/logs/uart.log`, `build/logs/host.log`, and a combined `build/logs/all.log` by default, and remaining buffered text is drained before normal shutdown completes. Use `--splitview-log=PATH` to write `uart.log`, `host.log`, and `all.log` under a custom directory. Finished interactive splitview sessions keep the final screen visible; press `q` or `Q` to leave. Non-interactive environments keep the normal linear output.
 
-`fpga-host` uses the same build flag as the other targets: pass `SPLITVIEW=1` to enable splitview.
+`fpga-host` uses the same build flag as the other targets: pass `SPLITVIEW=1` to enable splitview. At runtime, pass `--no-squash` to disable squash or `--squash-size=NUM` to set the maximum fused instruction count (`0`-`255`, default `255`).
 
 Key runtime options:
 
@@ -136,6 +136,8 @@ Key runtime options:
 | `+workload=FILE` | Boot image path |
 | `+diff=PATH` | Reference SO for differential testing |
 | `+no-diff` | Run without difftest comparison |
+| `+no-squash` | Disable squash |
+| `+squash-size=NUM` | Set maximum fused instruction count (`0`-`255`, default `255`) |
 | `+max-cycles=NUM` | Maximum simulation cycles |
 | `+max-instrs=NUM` | Maximum instructions |
 | `+ram_size=SIZE` | Simulation memory size, for example `8GB` / `128MB` |

--- a/docs/test.md
+++ b/docs/test.md
@@ -67,7 +67,7 @@ make SPLITVIEW=0   # disable for emu builds
 
 When enabled and run directly in an interactive terminal, UART output and host logs are shown side by side in the split view. The same streams are also written asynchronously to `build/logs/uart.log`, `build/logs/host.log`, and a combined `build/logs/all.log` by default, and remaining buffered text is drained before normal shutdown completes. Use `--splitview-log=PATH` to write `uart.log`, `host.log`, and `all.log` under a custom directory. Finished interactive splitview sessions keep the final screen visible; press `q` or `Q` to leave. Non-interactive environments keep the normal linear output.
 
-`fpga-host` uses the same build flag as the other targets: pass `SPLITVIEW=1` to enable splitview. At runtime, pass `--no-squash` to disable squash or `--squash-size=NUM` to set the maximum fused instruction count (`0`-`255`, default `255`).
+`fpga-host` uses the same build flag as the other targets: pass `SPLITVIEW=1` to enable splitview. At runtime, pass `--no-squash` to disable squash or `--squash-size=NUM` to set the maximum fused instruction count (`0`-`255`, default `255`). Use `--no-squash-after-instr=NUM` to begin with squash enabled and disable it after the specified committed-instruction count. `NUM` accepts an uppercase `K`, `M`, or `B` suffix, such as `6.67B`, and is rounded to the nearest instruction.
 
 Key runtime options:
 

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -155,7 +155,7 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   val updateDependency: Seq[String] = Seq()
 
   // returns Bool indicating whether `this` bundle can be squashed with `base`
-  def supportsSquash(base: DifftestBundle): Bool = supportsSquashBase
+  def supportsSquash(base: DifftestBundle, maxFused: UInt): Bool = supportsSquashBase
   def supportsSquashBase: Bool = if (hasValid) !getValid else true.B
   // returns a seq of Group name of this bundle, Default: REF
   // Only bundles with same GroupName will affect others' squash state.
@@ -242,11 +242,10 @@ class DiffArchEvent extends ArchEvent with DifftestBundle {
 class DiffInstrCommit(nPhyRegs: Int = 32) extends InstrCommit(nPhyRegs) with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "commit"
 
-  private val maxNumFused = 255
-  override def supportsSquash(base: DifftestBundle): Bool = {
+  override def supportsSquash(base: DifftestBundle, maxFused: UInt): Bool = {
     val that = base.asInstanceOf[DiffInstrCommit]
     val nextNFused = (nFused +& that.nFused) + 1.U
-    !valid || (!skip && (!that.valid || nextNFused <= maxNumFused.U) && !special.asUInt.orR)
+    !valid || (!skip && (!that.valid || nextNFused <= maxFused) && !special.asUInt.orR)
   }
   override def supportsSquashBase: Bool = {
     !valid || (!skip && !special.asUInt.orR)
@@ -546,7 +545,7 @@ private[difftest] class DiffTraceInfo(config: GatewayConfig) extends TraceInfo w
   override val desiredCppName: String = "trace_info"
 
   override val squashGroup: Seq[String] = Seq("REF", "GOLDENMEM")
-  override def supportsSquash(base: DifftestBundle): Bool = {
+  override def supportsSquash(base: DifftestBundle, maxFused: UInt): Bool = {
     val that = base.asInstanceOf[DiffTraceInfo]
     !valid || !that.valid || (trace_size +& that.trace_size <= config.replaySize.U)
   }

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -138,6 +138,7 @@ case class GatewayResult(
   step: Option[UInt] = None,
   fpgaIO: Option[FpgaDiffIO] = None,
   fpgaSquashEnable: Option[Bool] = None,
+  fpgaSquashMaxFused: Option[UInt] = None,
   clockEnable: Option[Bool] = None,
 ) {
   def +(that: GatewayResult): GatewayResult = {
@@ -153,6 +154,7 @@ case class GatewayResult(
       step = if (step.isDefined) step else that.step,
       fpgaIO = if (fpgaIO.isDefined) fpgaIO else that.fpgaIO,
       fpgaSquashEnable = if (fpgaSquashEnable.isDefined) fpgaSquashEnable else that.fpgaSquashEnable,
+      fpgaSquashMaxFused = if (fpgaSquashMaxFused.isDefined) fpgaSquashMaxFused else that.fpgaSquashMaxFused,
       clockEnable = if (clockEnable.isDefined) clockEnable else that.clockEnable,
     )
   }
@@ -238,6 +240,7 @@ object Gateway {
         step = Some(endpoint.step),
         fpgaIO = endpoint.fpgaIO,
         fpgaSquashEnable = endpoint.fpgaSquashEnable,
+        fpgaSquashMaxFused = endpoint.fpgaSquashMaxFused,
         clockEnable = endpoint.clockEnable,
       )
     } else {
@@ -258,6 +261,7 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
   val decoupledIn = Wire(Decoupled(chiselTypeOf(in_bundle)))
   val clockEnable = Option.when(config.hasClockGate)(IO(Output(Bool())))
   val fpgaSquashEnable = Option.when(config.isSquash && config.isFPGA)(IO(Input(Bool())))
+  val fpgaSquashMaxFused = Option.when(config.isSquash && config.isFPGA)(IO(Input(UInt(8.W))))
   // clockEnable should hold with one cycle fire to sample signals
   decoupledIn.valid := !reset.asBool
   clockEnable.foreach { ce =>
@@ -298,7 +302,7 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
   val validated = Validate(replayed, config)
 
   val squashed = if (config.isSquash) {
-    Squash(validated, config, fpgaSquashEnable)
+    Squash(validated, config, fpgaSquashEnable, fpgaSquashMaxFused)
   } else {
     validated
   }

--- a/src/main/scala/SimTop.scala
+++ b/src/main/scala/SimTop.scala
@@ -181,6 +181,7 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
         fpgaHostReset := ctrl.reset
         fpgaDiffEnable := ctrl.diffEnable
         gateway.fpgaSquashEnable.foreach(_ := ctrl.enableSquash)
+        gateway.fpgaSquashMaxFused.foreach(_ := ctrl.squashMaxFused)
 
         cfg.io.memCtrl.memStatus := 0.U
         from_host_axis.viewAs[AXI4Stream].ready := false.B

--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -29,6 +29,7 @@ object Squash {
     bundles: DecoupledIO[MixedVec[Valid[DifftestBundle]]],
     config: GatewayConfig,
     fpgaEnable: Option[Bool] = None,
+    fpgaMaxFused: Option[UInt] = None,
   ): DecoupledIO[MixedVec[Valid[DifftestBundle]]] = {
     val squashInBits = Stamp(bundles.bits)
     val squashIn = Wire(Decoupled(chiselTypeOf(squashInBits)))
@@ -37,6 +38,7 @@ object Squash {
     bundles.ready := squashIn.ready
     val module = Module(new SquashEndpoint(chiselTypeOf(squashInBits).toSeq, config))
     module.fpgaEnable.foreach(_ := fpgaEnable.getOrElse(true.B))
+    module.fpgaMaxFused.foreach(_ := fpgaMaxFused.getOrElse(255.U(8.W)))
     module.in <> squashIn
     module.out
   }
@@ -113,6 +115,7 @@ class Stamper(bundles: Seq[Valid[DifftestBundle]]) extends Module {
 class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig) extends Module {
   val in = IO(Flipped(Decoupled(MixedVec(bundles))))
   val fpgaEnable = Option.when(config.isFPGA)(IO(Input(Bool())))
+  val fpgaMaxFused = Option.when(config.isFPGA)(IO(Input(UInt(8.W))))
   val numCores = in.bits.count(_.bits.isUniqueIdentifier)
 
   val pipelined = Wire(Decoupled(MixedVec(bundles)))
@@ -129,6 +132,7 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
   val timeout_count = RegInit(0.U(32.W))
   val timeout = timeout_count === 200000.U
   val squash_enable = fpgaEnable.getOrElse(control.enable)
+  val maxFused = fpgaMaxFused.getOrElse(control.maxFused)
   val global_tick = !squash_enable || in_replay || timeout
 
   val uniqBundles = bundles.map(_.bits).distinctBy(_.desiredCppName)
@@ -161,6 +165,7 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
     val squasher = Module(new Squasher(chiselTypeOf(s_in.head), s_in.length, numCores, config))
     squasher.in.valid := pipelined.valid
     squasher.in.bits.zip(s_in).foreach { case (dst, src) => dst := src }
+    squasher.maxFused := maxFused
     wt := squasher.want_tick
     val group_tick =
       group_name_vec
@@ -190,6 +195,7 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
 // It will help do squash for bundles with same Class, return tick and state
 class Squasher(bundleType: Valid[DifftestBundle], length: Int, numCores: Int, config: GatewayConfig) extends Module {
   val in = IO(Flipped(Decoupled(Vec(length, bundleType))))
+  val maxFused = IO(Input(UInt(8.W)))
   val want_tick = IO(Output(Bool()))
   val group_tick = IO(Input(Bool()))
   val global_tick = IO(Input(Bool()))
@@ -213,7 +219,7 @@ class Squasher(bundleType: Valid[DifftestBundle], length: Int, numCores: Int, co
   }
 
   // If one of the bundles cannot be squashed, the others are not squashed as well.
-  val supportsSquashVec = VecInit(in.bits.zip(state).map { case (i, s) => i.supportsSquash(s) }.toSeq)
+  val supportsSquashVec = VecInit(in.bits.zip(state).map { case (i, s) => i.supportsSquash(s, maxFused) }.toSeq)
   val supportsSquash = supportsSquashVec.asUInt.andR
 
   // If one of the bundles cannot be the new base, the others are not as well.
@@ -243,6 +249,7 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
   val clock = IO(Input(Clock()))
   val reset = IO(Input(Reset()))
   val enable = IO(Output(Bool()))
+  val maxFused = IO(Output(UInt(8.W)))
 
   setInline(
     "SquashControl.v",
@@ -255,7 +262,8 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |module SquashControl(
        |  input clock,
        |  input reset,
-       |  output enable
+       |  output enable,
+       |  output [7:0] maxFused
        |);
        |
        |`ifndef SYNTHESIS
@@ -266,13 +274,17 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |
        |`ifndef SQUASH_CTRL
        |  assign enable = 1;
+       |  assign maxFused = 8'd255;
        |`else
        |`ifdef DIFFTEST
        |import "DPI-C" context function void set_squash_scope();
        |  reg _enable;
+       |  reg [7:0] _max_fused;
        |  assign enable = _enable;
+       |  assign maxFused = _max_fused;
        |initial begin
        |  _enable = 1;
+       |  _max_fused = 8'd255;
        |  set_squash_scope();
        |end
        |
@@ -280,6 +292,11 @@ class SquashControl(config: GatewayConfig) extends ExtModule with HasExtModuleIn
        |export "DPI-C" function set_squash_enable;
        |function void set_squash_enable(int en);
        |  _enable = en;
+       |endfunction
+       |
+       |export "DPI-C" function set_squash_max_fused;
+       |function void set_squash_max_fused(int value);
+       |  _max_fused = value[7:0];
        |endfunction
        |
        |// For the simulation argument +squash_cycles=N

--- a/src/main/scala/Validate.scala
+++ b/src/main/scala/Validate.scala
@@ -37,7 +37,8 @@ object Validate {
       bundle.bits.asInstanceOf[DiffTestIsInherited].inheritFrom(parent.bits)
     }
     def supportsSquashBase: Bool = bundle.bits.supportsSquashBase
-    def supportsSquash(base: Valid[DifftestBundle]): Bool = bundle.bits.supportsSquash(base.bits)
+    def supportsSquash(base: Valid[DifftestBundle], maxFused: UInt): Bool =
+      bundle.bits.supportsSquash(base.bits, maxFused)
     def squash(base: Valid[DifftestBundle]): Valid[DifftestBundle] = {
       if (!bundle.bits.bits.hasValid) {
         WireInit(Mux(bundle.valid, bundle, base))

--- a/src/main/scala/fpga/XDMAConfigBar.scala
+++ b/src/main/scala/fpga/XDMAConfigBar.scala
@@ -28,18 +28,20 @@ import difftest.common.AXI4LiteBundle
   *   - 0x08: HOST_IO_DIFF_ENABLE
   *   - 0x0c: HOST_IO_ILA_TRIGGER
   *   - 0x10: HOST_IO_SQUASH_ENABLE
-  *   - 0x14: HOST_IO_SEED
-  *   - 0x18: HOST_IO_RAM_SIZE_MB
-  *   - 0x1c: HOST_IO_MEM_INIT
-  *   - 0x20: HOST_IO_MEM_CPU
-  *   - 0x24: HOST_IO_MEM_H2C
-  *   - 0x28: HOST_IO_H2C_SIZE_MB
+  *   - 0x14: HOST_IO_SQUASH_MAX_FUSED
+  *   - 0x18: HOST_IO_SEED
+  *   - 0x1c: HOST_IO_RAM_SIZE_MB
+  *   - 0x20: HOST_IO_MEM_INIT
+  *   - 0x24: HOST_IO_MEM_CPU
+  *   - 0x28: HOST_IO_MEM_H2C
+  *   - 0x2c: HOST_IO_H2C_SIZE_MB
   */
 class XDMAHostCtrlIO extends Bundle {
   val reset = Bool()
   val diffEnable = Bool()
   val ilaTrigger = Bool()
   val enableSquash = Bool()
+  val squashMaxFused = UInt(8.W)
 }
 
 class XDMAMemCtrlIO extends Bundle {
@@ -53,8 +55,8 @@ class XDMAMemCtrlIO extends Bundle {
 }
 
 private object XDMAConfigReg extends Enumeration {
-  val CfgReset, HostReset, DiffEnable, IlaTrigger, EnableSquash, Seed, RamSizeMB, MemInit, MemCPU, MemH2C, H2CSizeMB =
-    Value
+  val CfgReset, HostReset, DiffEnable, IlaTrigger, EnableSquash, SquashMaxFused, Seed, RamSizeMB, MemInit, MemCPU,
+    MemH2C, H2CSizeMB = Value
 }
 
 class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Module {
@@ -69,12 +71,16 @@ class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Mo
 
   private val numRegs = XDMAConfigReg.maxId
   private val idxBits = log2Ceil(numRegs)
-  private val regfile = RegInit(VecInit(Seq.fill(numRegs)(0.U(dataWidth.W))))
+  private val regfile = RegInit(VecInit(Seq.tabulate(numRegs) { idx =>
+    val init = if (idx == XDMAConfigReg.SquashMaxFused.id) 255 else 0
+    init.U(dataWidth.W)
+  }))
 
   io.hostCtrl.reset := regfile(XDMAConfigReg.HostReset.id)(0)
   io.hostCtrl.diffEnable := regfile(XDMAConfigReg.DiffEnable.id)(0)
   io.hostCtrl.ilaTrigger := regfile(XDMAConfigReg.IlaTrigger.id)(0)
   io.hostCtrl.enableSquash := regfile(XDMAConfigReg.EnableSquash.id)(0)
+  io.hostCtrl.squashMaxFused := regfile(XDMAConfigReg.SquashMaxFused.id)(7, 0)
   io.memCtrl.memInit := regfile(XDMAConfigReg.MemInit.id)(0)
   io.memCtrl.memH2C := regfile(XDMAConfigReg.MemH2C.id)(0)
   io.memCtrl.memCPU := regfile(XDMAConfigReg.MemCPU.id)(0)

--- a/src/test/csrc/common/args.cpp
+++ b/src/test/csrc/common/args.cpp
@@ -18,6 +18,7 @@
 #include "ram.h"
 #include "remote_bitbang.h"
 #include "splitview.h"
+#include <cmath>
 #include <getopt.h>
 #ifdef CONFIG_DIFFTEST_IOTRACE
 #include "difftest-iotrace.h"
@@ -28,6 +29,7 @@ enum {
   OPT_DB_PATH,
   OPT_NO_SQUASH,
   OPT_SQUASH_SIZE,
+  OPT_NO_SQUASH_AFTER_INSTR,
 };
 
 static inline long long int atoll_strict(const char *str, const char *arg) {
@@ -36,6 +38,43 @@ static inline long long int atoll_strict(const char *str, const char *arg) {
     exit(EINVAL);
   }
   return atoll(str);
+}
+
+static uint64_t parse_instr_count(const char *str, const char *arg) {
+  char *end = nullptr;
+  long double count = std::strtold(str, &end);
+  if (end == str) {
+    fprintf(stderr, "[ERROR] --%s requires a number followed by an optional K/M/B suffix\n", arg);
+    exit(EINVAL);
+  }
+
+  long double scale = 1.0L;
+  switch (*end) {
+    case '\0': break;
+    case 'K':
+      scale = 1.0e3L;
+      end++;
+      break;
+    case 'M':
+      scale = 1.0e6L;
+      end++;
+      break;
+    case 'B':
+      scale = 1.0e9L;
+      end++;
+      break;
+    default:
+      fprintf(stderr, "[ERROR] --%s requires a number followed by an optional K/M/B suffix\n", arg);
+      exit(EINVAL);
+  }
+
+  long double scaled = count * scale;
+  long double rounded = std::round(scaled);
+  if (*end != '\0' || !std::isfinite(rounded) || scaled < 0 || rounded > static_cast<long double>(UINT64_MAX)) {
+    fprintf(stderr, "[ERROR] --%s is outside the uint64 range\n", arg);
+    exit(EINVAL);
+  }
+  return static_cast<uint64_t>(rounded);
 }
 
 static inline void print_help(const char *file) {
@@ -83,6 +122,7 @@ static inline void print_help(const char *file) {
   printf("      --no-diff              disable differential testing\n");
   printf("      --no-squash            disable squash\n");
   printf("      --squash-size=NUM      set maximum fused instructions, default: 255\n");
+  printf("      --no-squash-after-instr=NUM disable squash after NUM committed instructions\n");
   printf("      --diff=PATH            set the path of REF for differential testing\n");
   printf("      --enable-jtag          enable remote bitbang server\n");
   printf("      --remote-jtag-port     specify remote bitbang port\n");
@@ -151,6 +191,7 @@ CommonArgs parse_args(int argc, const char *argv[]) {
     { "db-path",           1, NULL, OPT_DB_PATH },
     { "no-squash",         0, NULL, OPT_NO_SQUASH },
     { "squash-size",       1, NULL, OPT_SQUASH_SIZE },
+    { "no-squash-after-instr", 1, NULL, OPT_NO_SQUASH_AFTER_INSTR },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "fork-interval",     1, NULL, 'X' },
@@ -287,6 +328,9 @@ CommonArgs parse_args(int argc, const char *argv[]) {
         args.squash_size = static_cast<uint8_t>(squash_size);
         continue;
       }
+      case OPT_NO_SQUASH_AFTER_INSTR:
+        args.no_squash_after_instr = parse_instr_count(optarg, "no-squash-after-instr");
+        continue;
       case 's':
         if (std::string(optarg) != "NO_SEED") {
           args.seed = atoll_strict(optarg, "seed");

--- a/src/test/csrc/common/args.cpp
+++ b/src/test/csrc/common/args.cpp
@@ -26,6 +26,8 @@
 enum {
   OPT_SPLITVIEW_LOG = 1000,
   OPT_DB_PATH,
+  OPT_NO_SQUASH,
+  OPT_SQUASH_SIZE,
 };
 
 static inline long long int atoll_strict(const char *str, const char *arg) {
@@ -79,6 +81,8 @@ static inline void print_help(const char *file) {
   printf("      --cst-file=FILE        load constantin from FILE, stdin, or default init values\n");
   printf("      --enable-fork          enable folking child processes to debug\n");
   printf("      --no-diff              disable differential testing\n");
+  printf("      --no-squash            disable squash\n");
+  printf("      --squash-size=NUM      set maximum fused instructions, default: 255\n");
   printf("      --diff=PATH            set the path of REF for differential testing\n");
   printf("      --enable-jtag          enable remote bitbang server\n");
   printf("      --remote-jtag-port     specify remote bitbang port\n");
@@ -145,6 +149,8 @@ CommonArgs parse_args(int argc, const char *argv[]) {
     { "random-mem",        0, NULL,  0  },
     { "splitview-log",     1, NULL, OPT_SPLITVIEW_LOG },
     { "db-path",           1, NULL, OPT_DB_PATH },
+    { "no-squash",         0, NULL, OPT_NO_SQUASH },
+    { "squash-size",       1, NULL, OPT_SQUASH_SIZE },
     { "seed",              1, NULL, 's' },
     { "max-cycles",        1, NULL, 'C' },
     { "fork-interval",     1, NULL, 'X' },
@@ -271,6 +277,16 @@ CommonArgs parse_args(int argc, const char *argv[]) {
         printf("[WARN] chisel db is not enabled at compile time, ignore --db-path\n");
 #endif
         continue;
+      case OPT_NO_SQUASH: args.enable_squash = false; continue;
+      case OPT_SQUASH_SIZE: {
+        long long squash_size = atoll_strict(optarg, "squash-size");
+        if (squash_size < 0 || squash_size > UINT8_MAX) {
+          fprintf(stderr, "[ERROR] --squash-size must be in range [0, 255]\n");
+          exit(EINVAL);
+        }
+        args.squash_size = static_cast<uint8_t>(squash_size);
+        continue;
+      }
       case 's':
         if (std::string(optarg) != "NO_SEED") {
           args.seed = atoll_strict(optarg, "seed");

--- a/src/test/csrc/common/args.h
+++ b/src/test/csrc/common/args.h
@@ -64,6 +64,8 @@ struct CommonArgs {
   bool enable_snapshot = false;
   bool force_dump_result = false;
   bool enable_diff = true;
+  bool enable_squash = true;
+  uint8_t squash_size = 255;
   bool enable_fork = false;
   bool enable_runahead = false;
   bool dump_db = false;

--- a/src/test/csrc/common/args.h
+++ b/src/test/csrc/common/args.h
@@ -66,6 +66,7 @@ struct CommonArgs {
   bool enable_diff = true;
   bool enable_squash = true;
   uint8_t squash_size = 255;
+  uint64_t no_squash_after_instr = -1;
   bool enable_fork = false;
   bool enable_runahead = false;
   bool dump_db = false;

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -243,6 +243,16 @@ void difftest_squash_enable(int enable) {
   svSetScope(squashScope);
   set_squash_enable(enable);
 }
+
+extern "C" void set_squash_max_fused(int squash_max_fused);
+void difftest_squash_max_fused(int squash_max_fused) {
+  if (squashScope == NULL) {
+    printf("Error: Could not retrieve squash scope, set first\n");
+    assert(squashScope);
+  }
+  svSetScope(squashScope);
+  set_squash_max_fused(squash_max_fused);
+}
 #endif // CONFIG_DIFFTEST_SQUASH && !CONFIG_DIFFTEST_FPGA
 
 #ifdef CONFIG_DIFFTEST_REPLAY

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -280,6 +280,7 @@ void difftest_trace_write(int step);
 #ifdef CONFIG_DIFFTEST_SQUASH
 extern "C" void set_squash_scope();
 extern "C" void difftest_squash_enable(int enable);
+extern "C" void difftest_squash_max_fused(int squash_max_fused);
 #endif // CONFIG_DIFFTEST_SQUASH
 #ifdef CONFIG_DIFFTEST_REPLAY
 extern "C" void set_replay_scope();

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -171,6 +171,14 @@ void fpga_init() {
   xdma_device->fpga_io(HOST_IO_SQUASH_MAX_FUSED, static_cast<uint32_t>(args.squash_size));
   xdma_device->fpga_io(HOST_IO_SQUASH_ENABLE, args.enable_squash);
   printf("[fpga-host] squash enable = %d, size = %u\n", args.enable_squash, static_cast<unsigned>(args.squash_size));
+  if (args.no_squash_after_instr != UINT64_MAX) {
+    if (args.enable_squash) {
+      printf("[fpga-host] squash will be disabled after %" PRIu64 " committed instructions\n",
+             args.no_squash_after_instr);
+    } else {
+      printf("[fpga-host] --no-squash-after-instr is ignored because squash is disabled\n");
+    }
+  }
 #ifndef FPGA_SIM
   usleep(1000);
 #endif // FPGA_SIM
@@ -243,6 +251,17 @@ int fpga_get_result(uint8_t step) {
       return FPGA_GOODTRAP;
     else
       return FPGA_FAIL;
+  }
+  if (args.enable_squash && args.no_squash_after_instr != UINT64_MAX) {
+    for (int i = 0; i < NUM_CORES; i++) {
+      uint64_t instr_count = difftest[i]->get_trap_event()->instrCnt;
+      if (instr_count >= args.no_squash_after_instr) {
+        xdma_device->fpga_io(HOST_IO_SQUASH_ENABLE, false);
+        args.enable_squash = false;
+        printf("[fpga-host] disabled squash at core %d instruction %" PRIu64 "\n", i, instr_count);
+        break;
+      }
+    }
   }
   // Max Instr Limit Check
   if (args.max_instr != -1) {

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -168,7 +168,9 @@ void fpga_init() {
   xdma_device->fpga_io(HOST_IO_MEM_CPU, true);
   xdma_device->fpga_io(HOST_IO_DIFFTEST_ENABLE, args.enable_diff);
   xdma_device->fpga_io(HOST_IO_ILA_TRIGGER, false);
-  xdma_device->fpga_io(HOST_IO_SQUASH_ENABLE, true);
+  xdma_device->fpga_io(HOST_IO_SQUASH_MAX_FUSED, static_cast<uint32_t>(args.squash_size));
+  xdma_device->fpga_io(HOST_IO_SQUASH_ENABLE, args.enable_squash);
+  printf("[fpga-host] squash enable = %d, size = %u\n", args.enable_squash, static_cast<unsigned>(args.squash_size));
 #ifndef FPGA_SIM
   usleep(1000);
 #endif // FPGA_SIM

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -33,17 +33,18 @@
 #include "xdma_sim.h"
 #endif // FPGA_SIM
 
-#define HOST_IO_CFG_RESET       0x0
-#define HOST_IO_RESET           0x4
-#define HOST_IO_DIFFTEST_ENABLE 0x8
-#define HOST_IO_ILA_TRIGGER     0xc
-#define HOST_IO_SQUASH_ENABLE   0x10
-#define HOST_IO_SEED            0x14
-#define HOST_IO_RAM_SIZE_MB     0x18
-#define HOST_IO_MEM_INIT        0x1c
-#define HOST_IO_MEM_CPU         0x20
-#define HOST_IO_MEM_H2C         0x24
-#define HOST_IO_H2C_SIZE_MB     0x28
+#define HOST_IO_CFG_RESET        0x0
+#define HOST_IO_RESET            0x4
+#define HOST_IO_DIFFTEST_ENABLE  0x8
+#define HOST_IO_ILA_TRIGGER      0xc
+#define HOST_IO_SQUASH_ENABLE    0x10
+#define HOST_IO_SQUASH_MAX_FUSED 0x14
+#define HOST_IO_SEED             0x18
+#define HOST_IO_RAM_SIZE_MB      0x1c
+#define HOST_IO_MEM_INIT         0x20
+#define HOST_IO_MEM_CPU          0x24
+#define HOST_IO_MEM_H2C          0x28
+#define HOST_IO_H2C_SIZE_MB      0x2c
 
 #define DMA_PACKGE_NUM 8
 // DMA_PADDING (packge_idx(1) + difftest_data) send width to be calculated by mod up

--- a/src/test/csrc/vcs/vcs_main.cpp
+++ b/src/test/csrc/vcs/vcs_main.cpp
@@ -179,6 +179,20 @@ extern "C" void set_no_diff() {
   args.enable_diff = false;
 }
 
+extern "C" void set_no_squash() {
+  printf("disable squash\n");
+  args.enable_squash = false;
+}
+
+extern "C" void set_squash_size(int size) {
+  if (size < 0 || size > UINT8_MAX) {
+    fprintf(stderr, "[ERROR] +squash-size must be in range [0, 255]\n");
+    exit(EINVAL);
+  }
+  printf("set squash size: %d\n", size);
+  args.squash_size = static_cast<uint8_t>(size);
+}
+
 extern "C" void set_seed(uint64_t seed) {
   args.seed = seed;
   Info("Using seed = %d\n", args.seed);
@@ -258,6 +272,10 @@ extern "C" uint8_t simv_init() {
 
 #ifndef CONFIG_NO_DIFFTEST
   difftest_init(args.enable_diff, ram_size);
+#if defined(CONFIG_DIFFTEST_SQUASH) && !defined(CONFIG_DIFFTEST_FPGA)
+  difftest_squash_enable(args.enable_squash);
+  difftest_squash_max_fused(args.squash_size);
+#endif // CONFIG_DIFFTEST_SQUASH && !CONFIG_DIFFTEST_FPGA
 #endif // CONFIG_NO_DIFFTEST
 
   init_device();

--- a/src/test/vsrc/vcs/DifftestEndpoint.sv
+++ b/src/test/vsrc/vcs/DifftestEndpoint.sv
@@ -29,6 +29,7 @@ module DifftestEndpoint(
   input  wire        difftest_hostCtrl_diffEnable,
   input  wire        difftest_hostCtrl_ilaTrigger,
   input  wire        difftest_hostCtrl_enableSquash,
+  input  wire [ 7:0] difftest_hostCtrl_squashMaxFused,
 `endif // FPGA_SIM
 
   /* DifftestTopIO */
@@ -52,6 +53,8 @@ import "DPI-C" function void set_flash_bin(string bin);
 import "DPI-C" function void set_gcpt_bin(string bin);
 import "DPI-C" function void set_diff_ref_so(string diff_so);
 import "DPI-C" function void set_no_diff();
+import "DPI-C" function void set_no_squash();
+import "DPI-C" function void set_squash_size(int size);
 import "DPI-C" function void set_seed(longint seed);
 import "DPI-C" function void set_random_mem();
 import "DPI-C" function void set_simjtag();
@@ -97,6 +100,7 @@ string workload_list;
 string iotrace_name;
 longint overwrite_nbytes;
 string ram_size;
+integer squash_size;
 
 reg [63:0] max_instrs;
 reg [63:0] max_cycles;
@@ -171,6 +175,12 @@ initial begin
   // disable diff-test
   if ($test$plusargs("no-diff")) begin
     set_no_diff();
+  end
+  if ($test$plusargs("no-squash")) begin
+    set_no_squash();
+  end
+  if ($value$plusargs("squash-size=%d", squash_size)) begin
+    set_squash_size(squash_size);
   end
   if ($value$plusargs("seed=%d", seed)) begin
     set_seed(seed);

--- a/src/test/vsrc/vcs/top.v
+++ b/src/test/vsrc/vcs/top.v
@@ -176,6 +176,7 @@ wire sim_clock;
   wire        host_ctrl_diff_enable;
   wire        host_ctrl_ila_trigger;
   wire        host_ctrl_enable_squash;
+  wire [7:0]  host_ctrl_squash_max_fused;
 
   assign difftest_pcie_clock = clock;
 xdma_clock xclk(
@@ -239,6 +240,7 @@ SimTop sim(
   .difftest_hostCtrl_diffEnable(host_ctrl_diff_enable),
   .difftest_hostCtrl_ilaTrigger(host_ctrl_ila_trigger),
   .difftest_hostCtrl_enableSquash(host_ctrl_enable_squash),
+  .difftest_hostCtrl_squashMaxFused(host_ctrl_squash_max_fused),
   .difftest_to_host_axis_tvalid(c2h_axi_tvalid),
   .difftest_to_host_axis_tready(c2h_axi_tready),
   .difftest_to_host_axis_tdata(c2h_axi_tdata),
@@ -295,6 +297,7 @@ DifftestEndpoint difftest(
   .difftest_hostCtrl_diffEnable(host_ctrl_diff_enable),
   .difftest_hostCtrl_ilaTrigger(host_ctrl_ila_trigger),
   .difftest_hostCtrl_enableSquash(host_ctrl_enable_squash),
+  .difftest_hostCtrl_squashMaxFused(host_ctrl_squash_max_fused),
 `endif // FPGA_SIM
   .difftest_logCtrl_begin(difftest_logCtrl_begin),
   .difftest_logCtrl_end(difftest_logCtrl_end),


### PR DESCRIPTION
## Summary

- make squash enable and maximum fused count runtime-configurable
- route FPGA controls through the XDMA config BAR and add matching VCS controls
- add `--no-squash-after-instr=NUM` to switch from squash to unsquashed execution at a committed-instruction threshold
- accept exact decimal `K`, `M`, and `B` suffixes such as `6.67B`; the switch takes effect after the batch that crosses the threshold

## Validation

- `mill -i difftest.compile difftest.test.compile`
- built `fpga-host` against an existing NutShell generated DiffTest interface
- checked valid and invalid threshold parsing, including overflow and non-integral values
- `make scala-format clang-format`
- `git diff --check`

Full FPGA synthesis and board validation were not rerun.