### PR TITLE
fix(mma): handle lazy operand retrieval failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build the fuzzing corpus - riscv-arch-test
         run: |
             cd $GITHUB_WORKSPACE/..
-            git clone https://github.com/OpenXiangShan/riscv-arch-test.git
+            git clone -b main --single-branch https://github.com/OpenXiangShan/riscv-arch-test.git
             cd riscv-arch-test/riscv-test-suite
             make build_I CROSS=riscv64-linux-gnu- RISCV_ARCH=rv64gc -j2
             rm build/*.elf build/*.txt

--- a/config/config.h
+++ b/config/config.h
@@ -20,7 +20,12 @@
 #include "difftest-state.h"
 
 #if defined(CPU_NUTSHELL)
+#elif defined(CPU_XIANGSHAN_YQH)
+#elif defined(CPU_XIANGSHAN_NH)
+#elif defined(CPU_XIANGSHAN_KMHV2)
+#elif defined(CPU_XIANGSHAN_KMHV3)
 #elif defined(CPU_XIANGSHAN)
+#define CPU_XIANGSHAN_KMHV3
 #elif defined(CPU_ROCKET_CHIP)
 #else
 // This is the default CPU
@@ -32,7 +37,8 @@
 // -----------------------------------------------------------------------
 
 // emulated memory size (Byte)
-#if defined(CPU_XIANGSHAN)
+#if defined(CPU_XIANGSHAN_YQH) || defined(CPU_XIANGSHAN_NH) || defined(CPU_XIANGSHAN_KMHV2) || \
+    defined(CPU_XIANGSHAN_KMHV3)
 #define DEFAULT_EMU_RAM_SIZE 0x7ff80000000UL // from 0x8000_0000 to 0x800_0000_0000, (8192-2)GB memory
 #else
 #define DEFAULT_EMU_RAM_SIZE (8 * 1024 * 1024 * 1024UL) // 8 GB
@@ -46,7 +52,8 @@ extern uint64_t FIRST_INST_ADDRESS;
 // first valid instruction's address, difftest starts from this instruction
 #if defined(CPU_NUTSHELL)
 #define _FIRST_INST_ADDRESS 0x80000000UL
-#elif defined(CPU_XIANGSHAN) || defined(CPU_ROCKET_CHIP)
+#elif defined(CPU_XIANGSHAN_YQH) || defined(CPU_XIANGSHAN_NH) || defined(CPU_XIANGSHAN_KMHV2) || \
+    defined(CPU_XIANGSHAN_KMHV3) || defined(CPU_ROCKET_CHIP)
 #define _FIRST_INST_ADDRESS 0x10000000UL
 #endif
 

--- a/src/test/csrc/common/flash.cpp
+++ b/src/test/csrc/common/flash.cpp
@@ -61,7 +61,7 @@ void init_flash(const char *flash_bin) {
   Info("Using simulated %luB flash\n", flash_dev.size);
 
   if (!flash_bin) {
-#ifdef CPU_XIANGSHAN
+#if defined(CPU_XIANGSHAN_KMHV2) || defined(CPU_XIANGSHAN_KMHV3)
     /** no specified flash_path, use defualt 6 instructions */
     // csrrsi x0, mnstatus, 8     # 0x74446073 set mnstatus.nmie
     // addiw  t0, zero, 1         # 0x0010029b
@@ -74,13 +74,14 @@ void init_flash(const char *flash_bin) {
     flash_dev.base[2] = 0x0002806701f29293;
     flash_dev.img_size = 3 * sizeof(uint64_t);
 #else
+    /** no specified flash_path, use defualt 3 instructions */
     // addiw   t0,zero,1
     // slli    to,to,  0x1f
     // jr      t0
     flash_dev.base[0] = 0x01f292930010029b;
     flash_dev.base[1] = 0x00028067;
     flash_dev.img_size = 2 * sizeof(uint64_t);
-#endif
+#endif // CPU_XIANGSHAN_KMHV2 || CPU_XIANGSHAN_KMHV3
     return;
   }
 

--- a/src/test/csrc/common/golden.cpp
+++ b/src/test/csrc/common/golden.cpp
@@ -64,11 +64,8 @@ enum {
   M_XA_MAXU = 15
 };
 
-uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
-#ifdef CONFIG_DIFFTEST_PERFCNT
-  difftest_calls[perf_amo_helper]++;
-  difftest_bytes[perf_amo_helper] += 18;
-#endif // CONFIG_DIFFTEST_PERFCNT
+#ifdef CPU_XIANGSHAN_KMHV3
+static uint64_t amo_helper_kmhv3(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
   const unsigned byte_offset = mask == 0 ? 0 : __builtin_ctz(mask);
   const unsigned bytes = __builtin_popcount(mask);
   const uint8_t contiguous_mask = bytes == 8 ? 0xff : ((1U << bytes) - 1) << byte_offset;
@@ -121,4 +118,79 @@ uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
   result = (rdata & ~(value_mask << bit_shift)) | ((result & value_mask) << bit_shift);
   pmem_write(aligned_addr, result);
   return rop << bit_shift;
+}
+#else
+#define SEXT32(data)      ((uint64_t)(data) | ((data >> 31) ? (0xffffffffUL << 32) : 0))
+#define GET_LOWER32(data) ((data) & ((1UL << 32) - 1))
+#define GET_UPPER32(data) ((data) >> 32)
+
+static uint64_t amo_helper_legacy(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
+  if (addr % 8 == 4 && mask == 0xf0) {
+    addr -= 4;
+  } else if (addr % 8 != 0) {
+    printf("warning: amo address %lx not naturally aligned to %x!!\n", addr, mask);
+  }
+  if (mask != 0xff && mask != 0xf && mask != 0xf0) {
+    printf("warning: amo data mask %x not aligned to 32-bit\n", mask);
+  }
+  static uint64_t lr_addr = 0, lr_valid = 0;
+  uint64_t rdata = pmem_read(addr);
+  uint64_t upper_r = GET_UPPER32(rdata), upper_w = GET_UPPER32(wdata);
+  uint64_t lower_r = GET_LOWER32(rdata), lower_w = GET_LOWER32(wdata);
+  uint64_t rop = (mask == 0xff) ? rdata : (mask == 0xf) ? lower_r : upper_r;
+  uint64_t wop = (mask == 0xff) ? wdata : (mask == 0xf) ? lower_w : upper_w;
+  uint64_t result = 0;
+  switch (cmd) {
+    case M_XA_SWAP: result = wop; break;
+    case M_XLR:
+      result = rdata;
+      lr_valid = 1;
+      lr_addr = addr;
+      break;
+    // always succeed
+    case M_XSC:
+      rop = !(lr_valid && lr_addr == addr);
+      lr_valid = 0;
+      result = wop;
+      break;
+    case M_XA_ADD: result = wop + rop; break;
+    case M_XA_XOR: result = wop ^ rop; break;
+    case M_XA_OR: result = wop | rop; break;
+    case M_XA_AND: result = wop & rop; break;
+    case M_XA_MIN:
+      if (mask == 0xff)
+        result = ((int64_t)wop > (int64_t)rop) ? rop : wop;
+      else
+        result = ((int32_t)((uint32_t)wop) > (int32_t)((uint32_t)rop)) ? rop : wop;
+      break;
+    case M_XA_MAX:
+      if (mask == 0xff)
+        result = ((int64_t)wop > (int64_t)rop) ? wop : rop;
+      else
+        result = ((int32_t)((uint32_t)wop) > (int32_t)((uint32_t)rop)) ? wop : rop;
+      break;
+    case M_XA_MINU: result = (wop > rdata) ? rop : wop; break;
+    case M_XA_MAXU: result = (wop > rdata) ? wop : rop; break;
+    default: printf("unknown atomic op %d!!\n", cmd); break;
+  }
+  if (mask == 0xf) {
+    result = (upper_r << 32) | (result & 0xffffffffUL);
+  } else if (mask == 0xf0) {
+    result = (result << 32) | lower_r;
+  }
+  pmem_write(addr, result);
+  return (mask == 0xf0) ? rop << 32 : rop;
+}
+#endif
+
+uint64_t amo_helper(uint8_t cmd, uint64_t addr, uint64_t wdata, uint8_t mask) {
+#ifdef CONFIG_DIFFTEST_PERFCNT
+  difftest_calls[perf_amo_helper]++;
+  difftest_bytes[perf_amo_helper] += 18;
+#endif // CONFIG_DIFFTEST_PERFCNT
+#ifdef CPU_XIANGSHAN_KMHV3
+  return amo_helper_kmhv3(cmd, addr, wdata, mask);
+#else
+  return amo_helper_legacy(cmd, addr, wdata, mask);
+#endif
 }

--- a/src/test/csrc/difftest/checkers.h
+++ b/src/test/csrc/difftest/checkers.h
@@ -184,7 +184,8 @@ public:
 #endif // CONFIG_DIFFTEST_SQUASH
 #if defined(CPU_NUTSHELL) || defined(CPU_ROCKET_CHIP)
   static const uint64_t first_commit_limit = 1000;
-#elif defined(CPU_XIANGSHAN)
+#elif defined(CPU_XIANGSHAN_YQH) || defined(CPU_XIANGSHAN_NH) || defined(CPU_XIANGSHAN_KMHV2) || \
+    defined(CPU_XIANGSHAN_KMHV3)
   static const uint64_t first_commit_limit = 15000;
 #endif
   static const uint64_t stuck_commit_limit = first_commit_limit * timeout_scale;
@@ -397,6 +398,8 @@ private:
   bool get_valid(const DifftestAtomicEvent &probe) override;
   void clear_valid(DifftestAtomicEvent &probe) override;
   int check(const DifftestAtomicEvent &probe) override;
+  int check_legacy(const DifftestAtomicEvent &probe);
+  int check_kmhv3(const DifftestAtomicEvent &probe);
 };
 #endif // CONFIG_DIFFTEST_ATOMICEVENT
 

--- a/src/test/csrc/difftest/checkers/globalmem.cpp
+++ b/src/test/csrc/difftest/checkers/globalmem.cpp
@@ -179,6 +179,159 @@ int AtomicChecker::check(const DifftestAtomicEvent &probe) {
     dumpGoldenMem("Atmoic", state->track_instr, state->cycle_count);
   }
 
+#ifdef CPU_XIANGSHAN_KMHV3
+  return check_kmhv3(probe);
+#else
+  return check_legacy(probe);
+#endif
+}
+
+#ifndef CPU_XIANGSHAN_KMHV3
+int AtomicChecker::check_legacy(const DifftestAtomicEvent &probe) {
+
+  // We need to do atmoic operations here so as to update goldenMem
+  if (!(probe.mask == 0xf || probe.mask == 0xf0 || probe.mask == 0xff || probe.mask == 0xffff)) {
+    Info("Unrecognized probe.mask: %lx\n", probe.mask);
+    return STATE_ERROR;
+  }
+
+  if (probe.mask == 0xff) {
+    uint64_t rs = probe.data[0]; // rs2
+    uint64_t t = probe.out[0];   // original value
+    uint64_t cmp = probe.cmp[0]; // rd, probe.data to be compared
+    uint64_t ret;
+    uint64_t mem;
+    read_goldenmem(probe.addr, &mem, 8);
+
+    if (mem != t && probe.fuop != 007 && probe.fuop != 003) { // ignore sc_d & lr_d
+      Info("Core %d atomic instr mismatch goldenMem, mem: 0x%lx, t: 0x%lx, op: 0x%x, addr: 0x%lx\n", state->coreid, mem,
+           t, probe.fuop, probe.addr);
+      return STATE_ERROR;
+    }
+
+    switch (probe.fuop) {
+      case 002:
+      case 003: ret = t; break;
+      // if sc fails(aka probe.out == 1), no update to goldenmem
+      case 006:
+      case 007:
+        if (t == 1)
+          return STATE_OK;
+        ret = rs;
+        break;
+      case 012:
+      case 013: ret = rs; break;
+      case 016:
+      case 017: ret = t + rs; break;
+      case 022:
+      case 023: ret = (t ^ rs); break;
+      case 026:
+      case 027: ret = t & rs; break;
+      case 032:
+      case 033: ret = t | rs; break;
+      case 036:
+      case 037: ret = ((int64_t)t < (int64_t)rs) ? t : rs; break;
+      case 042:
+      case 043: ret = ((int64_t)t > (int64_t)rs) ? t : rs; break;
+      case 046:
+      case 047: ret = (t < rs) ? t : rs; break;
+      case 052:
+      case 053: ret = (t > rs) ? t : rs; break;
+      case 054:
+      case 056:
+      case 057: ret = (t == cmp) ? rs : t; break;
+      default: Info("Unknown atomic fuOpType: 0x%x\n", probe.fuop);
+    }
+    update_goldenmem(probe.addr, &ret, probe.mask, 8);
+  } else if (probe.mask == 0xf || probe.mask == 0xf0) {
+    uint32_t rs = (uint32_t)probe.data[0]; // rs2
+    uint32_t t = (uint32_t)probe.out[0];   // original value
+    uint32_t cmp = (uint32_t)probe.cmp[0]; // rd, probe.data to be compared
+    uint32_t ret;
+    uint32_t mem;
+    uint64_t mem_raw;
+    uint64_t ret_sel;
+    uint64_t aligned_addr = probe.addr & 0xfffffffffffffff8;
+    read_goldenmem(aligned_addr, &mem_raw, 8);
+
+    if (probe.mask == 0xf)
+      mem = (uint32_t)mem_raw;
+    else
+      mem = (uint32_t)(mem_raw >> 32);
+
+    if (mem != t && probe.fuop != 006 && probe.fuop != 002) { // ignore sc_w & lr_w
+      Info("Core %d atomic instr mismatch goldenMem, rawmem: 0x%lx mem: 0x%x, t: 0x%x, op: 0x%x, addr: 0x%lx\n",
+           state->coreid, mem_raw, mem, t, probe.fuop, probe.addr);
+      return STATE_ERROR;
+    }
+    switch (probe.fuop) {
+      case 002:
+      case 003: ret = t; break;
+      // if sc fails(aka probe.out == 1), no update to goldenmem
+      case 006:
+      case 007:
+        if (t == 1)
+          return STATE_OK;
+        ret = rs;
+        break;
+      case 012:
+      case 013: ret = rs; break;
+      case 016:
+      case 017: ret = t + rs; break;
+      case 022:
+      case 023: ret = (t ^ rs); break;
+      case 026:
+      case 027: ret = t & rs; break;
+      case 032:
+      case 033: ret = t | rs; break;
+      case 036:
+      case 037: ret = ((int32_t)t < (int32_t)rs) ? t : rs; break;
+      case 042:
+      case 043: ret = ((int32_t)t > (int32_t)rs) ? t : rs; break;
+      case 046:
+      case 047: ret = (t < rs) ? t : rs; break;
+      case 052:
+      case 053: ret = (t > rs) ? t : rs; break;
+      case 054:
+      case 056:
+      case 057: ret = (t == cmp) ? rs : t; break;
+      default: Info("Unknown atomic fuOpType: 0x%x\n", probe.fuop);
+    }
+    ret_sel = ret;
+    if (probe.mask == 0xf0)
+      ret_sel = (ret_sel << 32);
+    update_goldenmem(aligned_addr, &ret_sel, probe.mask, 8);
+  } else if (probe.mask == 0xffff) {
+    uint64_t meml, memh;
+    uint64_t retl, reth;
+    read_goldenmem(probe.addr, &meml, 8);
+    read_goldenmem(probe.addr + 8, &memh, 8);
+    if (meml != probe.out[0] || memh != probe.out[1]) {
+      Info("Core %d atomic instr mismatch goldenMem, mem: 0x%lx 0x%lx, t: 0x%lx 0x%lx, op: 0x%x, addr: 0x%lx\n",
+           state->coreid, memh, meml, probe.out[1], probe.out[0], probe.fuop, probe.addr);
+      return STATE_ERROR;
+    }
+    switch (probe.fuop) {
+      case 054: {
+        bool success = probe.out[0] == probe.cmp[0] && probe.out[1] == probe.cmp[1];
+        retl = success ? probe.data[0] : probe.out[0];
+        reth = success ? probe.data[1] : probe.out[1];
+        break;
+      }
+      default: Info("Unknown atomic fuOpType: 0x%x\n", probe.fuop);
+    }
+    update_goldenmem(probe.addr, &retl, 0xff, 8);
+    update_goldenmem(probe.addr + 8, &reth, 0xff, 8);
+  } else {
+    return STATE_ERROR;
+  }
+
+  return STATE_OK;
+}
+
+#else
+int AtomicChecker::check_kmhv3(const DifftestAtomicEvent &probe) {
+
   // AMOCAS.Q is the only operation wider than a doubleword.
   if (probe.mask == 0xffff) {
     uint64_t meml, memh;
@@ -269,4 +422,5 @@ int AtomicChecker::check(const DifftestAtomicEvent &probe) {
 
   return STATE_OK;
 }
+#endif // CPU_XIANGSHAN_KMHV3
 #endif // CONFIG_DIFFTEST_ATOMICEVENT

--- a/src/test/csrc/difftest/checkers/load.cpp
+++ b/src/test/csrc/difftest/checkers/load.cpp
@@ -204,6 +204,7 @@ int LOADCHECKCLASS::do_load_check(const DifftestLoadEvent &probe, bool regWen, u
           default: Info("Unknown fuOpType: 0x%x\n", probe.opType); return STATE_ERROR;
         }
       } else if (probe.isAtomic) {
+#ifdef CPU_XIANGSHAN_KMHV3
         switch (probe.opType & 0x7) {
           case 0: len = 1; break; // B
           case 1: len = 2; break; // H
@@ -212,6 +213,13 @@ int LOADCHECKCLASS::do_load_check(const DifftestLoadEvent &probe, bool regWen, u
           case 4: len = 8; break; // Q is committed one XLEN chunk at a time
           default: Info("Unknown atomic size: 0x%x\n", probe.opType); return STATE_ERROR;
         }
+#else
+        if (probe.opType % 2 == 0) {
+          len = 4;
+        } else { // probe.opType % 2 == 1
+          len = 8;
+        }
+#endif // CPU_XIANGSHAN_KMHV3
       }
       read_goldenmem(probe.paddr, &golden, len, &golden_flag);
       if (probe.isLoad) {

--- a/src/test/csrc/difftest/checkers/matrix.cpp
+++ b/src/test/csrc/difftest/checkers/matrix.cpp
@@ -325,7 +325,14 @@ int AmuExecChecker::do_step() {
           // Call get_amu_lazy with buffer pointers
           // Store REF's src1/2/3 in the buffer, and copy DUT's result to REF
           // REF will directly take DUT's result instead of executing the MMA instruction
-          proxy->get_amu_lazy(&amu_event, iter->res, buffer->src1, buffer->src2, buffer->src3);
+          if (proxy->get_amu_lazy(&amu_event, iter->res, buffer->src1, buffer->src2, buffer->src3) != 0) {
+            printf("Failed to get REF operands for MMA verification: core %d, pc 0x%016lx\n", state->coreid,
+                   amu_event.pc);
+            mma_verifier->free_buffer(buffer);
+            delete[] iter->res;
+            iter->res = nullptr;
+            return STATE_ERROR;
+          }
           // Pass buffer to verification thread
           mma_verifier->add_to_verification_queue(buffer);
           delete[] iter->res;


### PR DESCRIPTION
Abort verification when the REF cannot provide MMA operands instead of queuing an uninitialized buffer. Release the verification buffer and software ROB result before returning the error.