### PR TITLE
fix(runtime): support Darwin arm64 hosts

### DIFF
--- a/src/test/csrc/common/lightsss.h
+++ b/src/test/csrc/common/lightsss.h
@@ -22,7 +22,9 @@
 #include <list>
 #include <signal.h>
 #include <sys/ipc.h>
+#if defined(__linux__)
 #include <sys/prctl.h>
+#endif
 #include <sys/shm.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/src/test/csrc/common/mpool.h
+++ b/src/test/csrc/common/mpool.h
@@ -24,7 +24,9 @@
 #include <mutex>
 #include <stdexcept>
 #include <vector>
+#if defined(__x86_64__) || defined(__i386__)
 #include <xmmintrin.h>
+#endif
 
 #define MEMPOOL_SIZE    16384 * 1024 // 16M memory
 #define MEMBLOCK_SIZE   4096         // 4K packge
@@ -86,8 +88,13 @@ class SpinLock {
 
 public:
   void lock() {
-    while (locked.test_and_set(std::memory_order_acquire))
+    while (locked.test_and_set(std::memory_order_acquire)) {
+#if defined(__x86_64__) || defined(__i386__)
       _mm_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+      __asm__ volatile("yield" ::: "memory");
+#endif
+    }
   }
   void unlock() {
     locked.clear(std::memory_order_release);

--- a/src/test/csrc/common/ram.h
+++ b/src/test/csrc/common/ram.h
@@ -141,8 +141,8 @@ public:
   virtual ~MmapMemory();
   void load_image(const char *image);
   uint64_t pad_img_size(uint64_t align);
-  void clone(std::function<void(void *, uint64_t)> func, bool skip_zero = false) {
-    uint64_t n_bytes = (skip_zero && !clone_full_mem) ? img_size : get_size();
+  void clone(std::function<void(void *, size_t)> func, bool skip_zero = false) {
+    size_t n_bytes = (skip_zero && !clone_full_mem) ? img_size : get_size();
     func(ram, n_bytes);
   }
   uint64_t &at(uint64_t index) {
@@ -187,7 +187,7 @@ public:
   FootprintsMemory(const char *footprints_name, uint64_t n_bytes);
   ~FootprintsMemory();
   uint64_t &at(uint64_t index);
-  void clone(std::function<void(void *, uint64_t)> func, bool skip_zero = false) {
+  void clone(std::function<void(void *, size_t)> func, bool skip_zero = false) {
     printf("clone_instant not support by FootprintsMemory\n");
     assert(0);
   }

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -124,8 +124,12 @@ void *AbstractRefProxy::load_handler(const char *env, const char *file_path) {
 
   Info("The reference model is %s\n", difftest_ref_so);
 
+#if defined(__APPLE__)
+  void *so_handler = dlopen(difftest_ref_so, RTLD_LAZY);
+#else
   int mode = RTLD_LAZY | RTLD_DEEPBIND;
   void *so_handler = (NUM_CORES > 1) ? dlmopen(LM_ID_NEWLM, difftest_ref_so, mode) : dlopen(difftest_ref_so, mode);
+#endif
   check_and_assert(so_handler);
 
   if (!use_given_diff) {


### PR DESCRIPTION
The simulator runtime currently assumes Linux/glibc and x86 host APIs, which prevents it from being built for Darwin arm64.

Guard Linux-only headers, use architecture-specific spin-wait instructions, fall back to `dlopen()` on Darwin, and use `size_t` consistently for memory byte counts. Existing Linux behavior is unchanged.

Validated with the standalone Verilator build on Linux and native compilation with Apple Clang 17 on an Apple M4.

Closes #929.