### PR TITLE
fix(fpga): infer diff RAT state banks as BRAM

### DIFF
--- a/scripts/fpga/release.sh
+++ b/scripts/fpga/release.sh
@@ -137,6 +137,16 @@ for f in "$RELEASE_RTL"/array_*.v; do
 done
 echo "Replacing done."
 
+echo "Replacing Diff RAT state banks with BRAM ..."
+for f in "$RELEASE_RTL"/diff_rat_state_bank_*.sv; do
+    [ -f "$f" ] || continue
+    echo "$f"
+    sed -E -i \
+        's@^([[:space:]]*)reg ([[:space:]]*\[[0-9]+:[0-9]+\]) Memory(\[0:[0-9]+\]);@\1(* ram_style = "block" *) reg \2 Memory\3;@' \
+        "$f"
+done
+echo "Replacing done."
+
 if [ -f "$RELEASE_RTL/ClockGate.sv" ]; then
     echo "Replacing ClockGate.sv ..."
     cat > "$RELEASE_RTL/ClockGate.sv" <<'CLOCKGATE_EOF'


### PR DESCRIPTION
## Summary

- add a targeted `fpga-release` rewrite for `diff_rat_state_bank_*.sv`
- attach `ram_style = "block"` to the generated `Memory` array
- preserve the regular-memory path without adding an SRAM template entry

## Validation

- `bash -n scripts/fpga/release.sh`
- verified the rewrite against `diff_rat_state_bank_320x776.sv`; only the memory declaration changed
- `git diff --check`

Full FPGA synthesis and BRAM utilization validation were not rerun.