### PR TITLE
feat(fpga): allow configurable UART device

### DIFF
--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -174,7 +174,11 @@ void fpga_init() {
 #endif // FPGA_SIM
 
 #ifdef USE_SERIAL_PORT
-  serial_port = new SerialPort("/dev/ttyUSB0");
+  const char *serial_port_device = std::getenv("FPGA_UART_PORT");
+  if (!serial_port_device || !serial_port_device[0]) {
+    serial_port_device = "/dev/ttyUSB0";
+  }
+  serial_port = new SerialPort(serial_port_device);
   serial_port->start();
 #endif // USE_SERIAL_PORT
 


### PR DESCRIPTION
## Summary
- read `FPGA_UART_PORT` when fpga-host starts UART forwarding
- retain `/dev/ttyUSB0` when the variable is unset or empty

## Validation
- `g++ -std=c++20 -fsyntax-only -DUSE_SERIAL_PORT -DCONFIG_DMA_CHANNELS=1 -DCONFIG_DIFFTEST_HOST_AXIS_BYTES=64 ... src/test/csrc/fpga/fpga_main.cpp`
- `git diff --check`

The full fpga-host build was not run because this clean worktree has no generated `build/chisel_db.cpp` input.