### PR TITLE
fix(topdown): generate topdown DPI shims during elaboration

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -577,6 +577,8 @@ object DifftestModule {
   private val interfaces = ListBuffer.empty[(DifftestBundle, Int)]
   private val cppExtModules = ListBuffer.empty[(String, String)]
   private val cppExtHeaders = ListBuffer.empty[String]
+  private val cppDPICModules = ListBuffer.empty[(String, String)]
+  private val cppDPICHeaders = ListBuffer.empty[String]
   private val nameExcludes = ListBuffer.empty[String]
   private val cmdConfigs = ListBuffer.empty[String]
   private val extraCppMacros = scala.collection.mutable.LinkedHashSet.empty[String]
@@ -648,6 +650,9 @@ object DifftestModule {
       gateway.structPacked.getOrElse(false),
       gateway.structAligned.getOrElse(false),
     )
+    if (cppDPICModules.nonEmpty) {
+      generateCppDPICModules()
+    }
     if (gateway.cppExtModule.getOrElse(false)) {
       generateCppExtModules()
     }
@@ -845,6 +850,24 @@ object DifftestModule {
     }
   }
   def createCppExtModule(name: String, func: String): Unit = createCppExtModule(name, func, None)
+
+  def createCppDPICModule(name: String, func: String, header: Option[String]): Unit = {
+    if (!cppDPICModules.exists(_._1 == name)) {
+      cppDPICModules += ((name, func))
+      if (header.isDefined && !cppDPICHeaders.contains(header.get)) {
+        cppDPICHeaders += header.get
+      }
+    }
+  }
+  def createCppDPICModule(name: String, func: String): Unit = createCppDPICModule(name, func, None)
+
+  def generateCppDPICModules(): Unit = {
+    val difftestCppDPICs = ListBuffer.empty[String]
+    difftestCppDPICs += "#include <cstdint>"
+    cppDPICHeaders.foreach(h => difftestCppDPICs += s"#include $h")
+    cppDPICModules.foreach(m => difftestCppDPICs += m._2)
+    FileControl.write(difftestCppDPICs, "difftest-dpic-ext.cpp")
+  }
 
   def generateCppExtModules(): Unit = {
     val difftestCppExts = ListBuffer.empty[String]

--- a/src/main/scala/plugin/topdown/TopdownDPI.scala
+++ b/src/main/scala/plugin/topdown/TopdownDPI.scala
@@ -102,6 +102,42 @@ private[topdown] object TopdownDPI {
     }
   }
 
+  def iqDPICWrapper(dpiFuncName: String): String =
+    s"""
+       |extern "C" void topdown_iq_info_dpic(
+       |  unsigned int entries_num,
+       |  const uint32_t *in_bits,
+       |  uint32_t *out_bits
+       |);
+       |
+       |extern "C" void $dpiFuncName(
+       |  unsigned int entries_num,
+       |  const uint32_t *in_bits,
+       |  uint32_t *out_bits
+       |) {
+       |  topdown_iq_info_dpic(entries_num, in_bits, out_bits);
+       |}
+       |""".stripMargin
+
+  def robDPICWrapper(dpiFuncName: String): String =
+    s"""
+       |extern "C" void topdown_rob_info_dpic(
+       |  unsigned int iq_entries_num,
+       |  unsigned int rob_entries_num,
+       |  const uint32_t *in_bits,
+       |  uint32_t *out_bits
+       |);
+       |
+       |extern "C" void $dpiFuncName(
+       |  unsigned int iq_entries_num,
+       |  unsigned int rob_entries_num,
+       |  const uint32_t *in_bits,
+       |  uint32_t *out_bits
+       |) {
+       |  topdown_rob_info_dpic(iq_entries_num, rob_entries_num, in_bits, out_bits);
+       |}
+       |""".stripMargin
+
   def iqHelperVerilog(
     moduleName: String,
     dpiFuncName: String,
@@ -124,6 +160,7 @@ private[topdown] object TopdownDPI {
        |
        |`ifndef SYNTHESIS
        |  import "DPI-C" function void $dpiFuncName(
+       |    input  int unsigned entries_num,
        |    input  bit [ENTRY_NUM*INFO_WIDTH-1:0] in,
        |    output bit [ENTRY_NUM*OUT_WIDTH-1:0] out
        |  );
@@ -136,6 +173,7 @@ private[topdown] object TopdownDPI {
        |    /* verilator lint_on WIDTHCONCAT */
        |`ifndef SYNTHESIS
        |    $dpiFuncName(
+       |      ENTRY_NUM,
        |      in[ENTRY_NUM*INFO_WIDTH-1:0],
        |      dpi_out
        |    );
@@ -166,6 +204,8 @@ private[topdown] object TopdownDPI {
        |
        |`ifndef SYNTHESIS
        |  import "DPI-C" function void $dpiFuncName(
+       |    input  int unsigned iq_entries_num,
+       |    input  int unsigned rob_entries_num,
        |    input  bit [IQ_ENTRY_NUM*INFO_WIDTH-1:0] in,
        |    output bit [ROB_ENTRY_NUM*INFO_WIDTH-1:0] out
        |  );
@@ -178,6 +218,8 @@ private[topdown] object TopdownDPI {
        |    /* verilator lint_on WIDTHCONCAT */
        |`ifndef SYNTHESIS
        |    $dpiFuncName(
+       |      IQ_ENTRY_NUM,
+       |      ROB_ENTRY_NUM,
        |      in[IQ_ENTRY_NUM*INFO_WIDTH-1:0],
        |      dpi_out
        |    );

--- a/src/main/scala/plugin/topdown/TopdownIQInfo.scala
+++ b/src/main/scala/plugin/topdown/TopdownIQInfo.scala
@@ -67,6 +67,7 @@ class TopdownIQInfoHelper(val entriesNum: Int)
     s"$desiredName.v",
     TopdownDPI.iqHelperVerilog(desiredName, dpiFuncName, inPaddedWidth, outPaddedWidth),
   )
+  difftest.DifftestModule.createCppDPICModule(dpiFuncName, TopdownDPI.iqDPICWrapper(dpiFuncName))
 
   private val cppExtModule =
     s"""

--- a/src/main/scala/plugin/topdown/TopdownRobInfo.scala
+++ b/src/main/scala/plugin/topdown/TopdownRobInfo.scala
@@ -56,6 +56,7 @@ class TopdownRobInfoHelper(val IQEntriesNum: Int, val RobEntriesNum: Int)
     s"$desiredName.v",
     TopdownDPI.robHelperVerilog(desiredName, dpiFuncName, inPaddedWidth, outPaddedWidth),
   )
+  difftest.DifftestModule.createCppDPICModule(dpiFuncName, TopdownDPI.robDPICWrapper(dpiFuncName))
 
   private val cppExtModule =
     s"""

--- a/src/test/csrc/plugin/topdown/topdown_iq_info.cpp
+++ b/src/test/csrc/plugin/topdown/topdown_iq_info.cpp
@@ -64,12 +64,3 @@ extern "C" void topdown_iq_info_dpic(unsigned int entries_num, const svBitVecVal
     out[i].idealIssueTime = get_ideal_issue_time(i, entries_num, in);
   }
 }
-
-#define DEFINE_TOPDOWN_IQ_INFO_DPIC(ENTRIES_NUM)                                                          \
-  extern "C" void topdown_iq_info_dpic_##ENTRIES_NUM(const svBitVecVal *in_bits, svBitVecVal *out_bits) { \
-    topdown_iq_info_dpic(ENTRIES_NUM, in_bits, out_bits);                                                 \
-  }
-
-DEFINE_TOPDOWN_IQ_INFO_DPIC(64)
-DEFINE_TOPDOWN_IQ_INFO_DPIC(80)
-DEFINE_TOPDOWN_IQ_INFO_DPIC(238)

--- a/src/test/csrc/plugin/topdown/topdown_rob_info.cpp
+++ b/src/test/csrc/plugin/topdown/topdown_rob_info.cpp
@@ -39,7 +39,7 @@ static void topdown_rob_info_apply(int iq_entries_num, int rob_entries_num, cons
   }
 
   for (int i = 0; i < iq_entries_num; i++) {
-    if (in[i].valid == 0) {
+    if (in[i].valid == 0 || in[i].robIdx >= rob_entries_num) {
       continue;
     }
 
@@ -63,11 +63,3 @@ extern "C" void topdown_rob_info_dpic(unsigned int iq_entries_num, unsigned int 
   topdown_zero_bytes(out_bits, rob_entries_num * sizeof(TopdownRobInfoFrame));
   topdown_rob_info_apply(iq_entries_num, rob_entries_num, in, out);
 }
-
-#define DEFINE_TOPDOWN_ROB_INFO_DPIC(IQ_ENTRIES_NUM, ROB_ENTRIES_NUM)                                    \
-  extern "C" void topdown_rob_info_dpic_##IQ_ENTRIES_NUM##_##ROB_ENTRIES_NUM(const svBitVecVal *in_bits, \
-                                                                             svBitVecVal *out_bits) {    \
-    topdown_rob_info_dpic(IQ_ENTRIES_NUM, ROB_ENTRIES_NUM, in_bits, out_bits);                           \
-  }
-
-DEFINE_TOPDOWN_ROB_INFO_DPIC(382, 352)


### PR DESCRIPTION
- Generate configuration-specific IQ and ROB topdown DPI wrappers from Scala instead of maintaining fixed entry-count wrappers in C++.
- skip out-of-range ROB indices