### PR TITLE
fix(build): probe for a usable `time` before recording build durations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,17 @@ difftest_verilog:
 	mill -i difftest.test.runMain difftest.DifftestMain --target-dir $(RTL_DIR) $(MILL_ARGS)
 
 TIMELOG = $(BUILD_DIR)/time.log
-TIME_CMD = time -avp -o $(TIMELOG)
+# Resolve `time` to a real binary: shells such as bash provide `time` only as a
+# reserved word, which accepts neither -o nor the GNU report flags. `env` looks
+# the binary up on PATH without going through the shell, so it stays usable when
+# no well-known path exists. Then pick the richest report format the available
+# implementation actually supports, and leave TIME_CMD empty if none does, so an
+# unusual host loses the timings instead of failing the build.
+TIME_BIN ?= $(or $(firstword $(wildcard /usr/bin/time /bin/time)),env time)
+TIME_FLAGS := $(shell for f in -av -ap -a; do \
+                        $(TIME_BIN) $$f -o /dev/null true >/dev/null 2>&1 && { echo $$f; break; }; \
+                      done)
+TIME_CMD = $(if $(TIME_FLAGS),$(TIME_BIN) $(TIME_FLAGS) -o $(TIMELOG))
 
 # remote machine with more cores to speedup c++ build
 REMOTE ?= localhost


### PR DESCRIPTION
TIME_CMD hardcoded `time -avp -o`, which assumes both that the shell resolves `time` to GNU time and that the implementation accepts -v and -p. Neither holds everywhere: bash provides `time` only as a reserved word that accepts no -o, and non-GNU implementations reject -v or -p. On such hosts every recipe using TIME_CMD fails instead of merely losing its timings.

Resolve the binary explicitly, preferring a well-known path and falling back to `env` so the lookup skips the shell keyword. Then select the richest report format that actually runs, and leave TIME_CMD empty when none does so the build proceeds untimed. -p is dropped from the preferred form because -v already takes precedence over it, leaving the log format unchanged.