### PR TITLE
fix(gsim): record GSIM build durations in time.log

### DIFF
--- a/gsim.mk
+++ b/gsim.mk
@@ -29,7 +29,9 @@ GSIM_FLAGS = --supernode-max-size=15 --cpp-max-size-KB=8192 --sep-mod=__DOT__ --
 
 $(GSIM_GEN_CSRC_DIR)/$(SIM_TOP)0.cpp: $(RTL_DIR)/$(SIM_TOP).fir
 	@mkdir -p $(@D)
-	$(GSIM_BIN) $(GSIM_FLAGS) --dir $(@D) $< | tee $(GSIM_EMU_BUILD_DIR)/gsim-gen-cpp.log
+	@printf '\n[gsim] Generating C++ files...\n' >> $(TIMELOG)
+	@date -R | tee -a $(TIMELOG)
+	$(TIME_CMD) $(GSIM_BIN) $(GSIM_FLAGS) --dir $(@D) $< | tee $(GSIM_EMU_BUILD_DIR)/gsim-gen-cpp.log
 
 gsim-gen-cpp: $(GSIM_GEN_CSRC_DIR)/$(SIM_TOP)0.cpp
 
@@ -82,14 +84,18 @@ gsim-clean-obj:
 # Profile Guided Optimization
 gsim-gen-emu:
 ifdef PGO_WORKLOAD
-	$(MAKE) pgo-build \
+	@printf '\n[c++] Building emu with PGO...\n' >> $(TIMELOG)
+	@date -R | tee -a $(TIMELOG)
+	$(TIME_CMD) $(MAKE) pgo-build \
 		PGO_CLEAN_OBJ=gsim-clean-obj \
 		PGO_BUILD_TARGET=gsim-build-emu \
 		PGO_TARGET=$(GSIM_EMU_TARGET) \
 		PGO_EMU_DIR=$(GSIM_EMU_BUILD_DIR)
 else
+	@printf '\n[c++] Compiling C++ files...\n' >> $(TIMELOG)
+	@date -R | tee -a $(TIMELOG)
 	@echo "Building emu..."
-	@$(MAKE) gsim-build-emu
+	$(TIME_CMD) $(MAKE) gsim-build-emu
 endif # ifdef PGO_WORKLOAD
 
 gsim-emu:


### PR DESCRIPTION
The verilator flow reports each build phase into build/time.log, but the GSIM flow never did: only the Chisel elaboration driven by the caller shows up, and both GSIM phases are silent. That leaves the two longest steps of a GSIM build unaccounted for.

Report the FIR-to-C++ translation and the emu compilation the same way verilator.mk already does, so both flows produce comparable entries. The PGO branch gets its own header because the timed span there also covers the training run, not just compilation.