### PR TITLE
feat(ame): add mcfg state comparison to DiffTest

### DIFF
--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -248,6 +248,10 @@ class MatrixCSRState extends DifftestBaseBundle {
   val msync = UInt(64.W)
 }
 
+class McfgState extends DifftestBaseBundle {
+  val value = Vec(8, UInt(64.W))
+}
+
 class SbufferEvent extends DifftestBaseBundle with HasValid {
   val addr = UInt(64.W)
   val data = Vec(64, UInt(8.W))

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -410,6 +410,12 @@ class DiffMatrixCSRState extends MatrixCSRState with DifftestBundle {
   override val updateDependency: Seq[String] = Seq("commit", "event")
 }
 
+class DiffMcfgState extends McfgState with DifftestBundle {
+  override val desiredCppName: String = "mcfg"
+  override val desiredRegOffset: Option[Int] = Some(9)
+  override val updateDependency: Seq[String] = Seq("commit", "event")
+}
+
 class DiffSbufferEvent extends SbufferEvent with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "sbuffer"
   override val squashGroup: Seq[String] = Seq("GOLDENMEM")

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -173,6 +173,9 @@ void RefProxy::regcpy(const DiffTestRegState *regs, uint64_t pc) {
 #ifdef CONFIG_DIFFTEST_MATRIXCSRSTATE
   memcpy(&state.mcsr, &regs->mcsr, sizeof(state.mcsr));
 #endif // CONFIG_DIFFTEST_MATRIXCSRSTATE
+#ifdef CONFIG_DIFFTEST_MCFGSTATE
+  memcpy(&state.mcfg, &regs->mcfg, sizeof(state.mcfg));
+#endif // CONFIG_DIFFTEST_MCFGSTATE
 #ifdef CONFIG_DIFFTEST_TRIGGERCSRSTATE
   memcpy(&state.triggercsr, &regs->triggercsr, sizeof(state.triggercsr));
 #endif //CONFIG_DIFFTEST_TRIGGERCSRSTATE
@@ -201,6 +204,9 @@ int RefProxy::compare(DiffTestState *dut) {
 #ifdef CONFIG_DIFFTEST_MATRIXCSRSTATE
                          PROXY_COMPARE(mcsr),
 #endif // CONFIG_DIFFTEST_MATRIXCSRSTATE
+#ifdef CONFIG_DIFFTEST_MCFGSTATE
+                         PROXY_COMPARE(mcfg),
+#endif // CONFIG_DIFFTEST_MCFGSTATE
 #ifdef CONFIG_DIFFTEST_TRIGGERCSRSTATE
                          PROXY_COMPARE(triggercsr),
 #endif // CONFIG_DIFFTEST_TRIGGERCSRSTATE
@@ -258,6 +264,9 @@ void RefProxy::display(DiffTestState *dut) {
 #ifdef CONFIG_DIFFTEST_MATRIXCSRSTATE
     PROXY_COMPARE_AND_DISPLAY(mcsr, regs_name_matrix_csr)
 #endif // CONFIG_DIFFTEST_MATRIXCSRSTATE
+#ifdef CONFIG_DIFFTEST_MCFGSTATE
+    PROXY_COMPARE_AND_DISPLAY(mcfg, regs_name_mcfg)
+#endif // CONFIG_DIFFTEST_MCFGSTATE
 #ifdef CONFIG_DIFFTEST_TRIGGERCSRSTATE
     PROXY_COMPARE_AND_DISPLAY(triggercsr, regs_name_triggercsr)
 #endif // CONFIG_DIFFTEST_TRIGGERCSRSTATE

--- a/src/test/csrc/difftest/refproxy.h
+++ b/src/test/csrc/difftest/refproxy.h
@@ -81,6 +81,11 @@ static const char *regs_name_matrix_csr[] = {
   "mtilem", "mtilen", "mtilek", "msync"
 };
 
+static const char *regs_name_mcfg[] = {
+  "mcfg0", "mcfg1", "mcfg2", "mcfg3",
+  "mcfg4", "mcfg5", "mcfg6", "mcfg7"
+};
+
 static const char *regs_name_triggercsr[] = {
   "tselect", "tdata1", "tinfo"
 };
@@ -214,6 +219,9 @@ typedef struct __attribute__((packed)) {
 #ifdef CONFIG_DIFFTEST_MATRIXCSRSTATE
   DifftestMatrixCSRState mcsr;
 #endif
+#ifdef CONFIG_DIFFTEST_MCFGSTATE
+  DifftestMcfgState mcfg;
+#endif // CONFIG_DIFFTEST_MCFGSTATE
 #ifdef CONFIG_DIFFTEST_TRIGGERCSRSTATE
   DifftestTriggerCSRState triggercsr;
 #endif // CONFIG_DIFFTEST_TRIGGERCSRSTATE

--- a/src/test/scala/DifftestTop.scala
+++ b/src/test/scala/DifftestTop.scala
@@ -30,6 +30,7 @@ class DifftestInterfaces extends Module {
   val csr_state = DifftestModule(new DiffCSRState, dontCare = true)
   val hcsr_state = DifftestModule(new DiffHCSRState, dontCare = true)
   val matrix_csr_state = DifftestModule(new DiffMatrixCSRState, dontCare = true)
+  val mcfg_state = DifftestModule(new DiffMcfgState, dontCare = true)
   val debug_mode = DifftestModule(new DiffDebugMode, dontCare = true)
   val trigger_csr_state = DifftestModule(new DiffTriggerCSRState, dontCare = true)
   val arch_int_delayed_update = DifftestModule(new DiffArchIntDelayedUpdate, dontCare = true)


### PR DESCRIPTION
Define the eight 64-bit mcfg entries as an architectural-state bundle at register-copy offset 9, with commit and event update dependencies.

Extend the reference-state ABI and RefProxy paths to synchronize, compare, and report each mcfg entry through the existing regcpy interface.