### PR TITLE
fix(fpga): correct fpga-release scripts syntax

### DIFF
--- a/scripts/fpga/release.sh
+++ b/scripts/fpga/release.sh
@@ -8,7 +8,7 @@ set -e
 CPU_DIR="$1"
 RELEASE_DIR="$2"
 RELEASE_SUFFIX="${3:-}"
-if [ $# -ne 2 ] && [ $# -ne 3]; then
+if [ $# -ne 2 ] && [ $# -ne 3 ]; then
     echo "Usage: $0 <CPU_PATH> <RELEASE_FOLDER> [RELEASE_SUFFIX]"
     exit 1
 fi


### PR DESCRIPTION
## Summary

Restore the missing whitespace before the closing test bracket in fpga-release argument validation.

## Why

The malformed test reports a shell syntax diagnostic for invalid argument counts and can skip the intended usage exit, allowing release.sh to continue with missing or extra inputs.

## Verification

- bash -n scripts/fpga/release.sh
- Checked argument counts 0 through 4: only 2 and 3 are accepted.