### PR TITLE
fix(squash): synchronize input handshakes

### DIFF
--- a/src/main/scala/Squash.scala
+++ b/src/main/scala/Squash.scala
@@ -163,7 +163,6 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
   val squashers = uniqBundles.zip(want_tick_vec).map { case (u, wt) =>
     val s_in = pipelined.bits.filter(_.bits.desiredCppName == u.desiredCppName)
     val squasher = Module(new Squasher(chiselTypeOf(s_in.head), s_in.length, numCores, config))
-    squasher.in.valid := pipelined.valid
     squasher.in.bits.zip(s_in).foreach { case (dst, src) => dst := src }
     squasher.maxFused := maxFused
     wt := squasher.want_tick
@@ -189,6 +188,8 @@ class SquashEndpoint(bundles: Seq[Valid[DifftestBundle]], config: GatewayConfig)
   }
   squashers.foreach(_.out.ready := out.ready)
   pipelined.ready := VecInit(squashers.map(_.in.ready)).asUInt.andR
+  // All squashers must fire synchronously so a held input is consumed only once.
+  squashers.foreach(_.in.valid := pipelined.fire)
   out.valid := VecInit(squashers.map(_.out.valid)).asUInt.orR
 }
 


### PR DESCRIPTION
## Summary

- synchronize all Squasher input handshakes with the shared pipeline fire
- prevent a ready Squasher from consuming a held transaction repeatedly while another Squasher is stalled

## Root cause

`SquashEndpoint` only advances the upstream pipeline when every Squasher is ready, but each Squasher previously received `pipelined.valid` directly. Under output backpressure, a non-ticking Squasher could remain ready and fire on the same held input every cycle while a ticking Squasher blocked the global handshake.

## Fix

Drive every Squasher input valid from `pipelined.fire`. Since `pipelined.ready` remains the AND of all Squasher ready signals, every input transaction is now accepted by all Squashers atomically. This follows the existing `DeltaEndpoint` handshake pattern and adds no state or interface width.

## Verification

- `mill -i difftest.compile`
- `make difftest_verilog CONFIG=S` (37 Squashers elaborated)
- `mill -i difftest.test` (the repository currently contains no ScalaTest cases)