### PR TITLE
fix(build): honor BUILD_DIR for generated difftest artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ export NOOP_HOME
 SIM_TOP    ?= SimTop
 DESIGN_DIR ?= $(NOOP_HOME)
 
-BUILD_DIR  = $(DESIGN_DIR)/build
+BUILD_DIR  ?= $(DESIGN_DIR)/build
+GENERATED_DIR ?= $(abspath $(BUILD_DIR))
 
 RTL_DIR = $(BUILD_DIR)/rtl
 RTL_SUFFIX ?= sv
@@ -42,7 +43,7 @@ ifneq ($(CONFIG), )
 MILL_ARGS += --difftest-config $(CONFIG)
 endif
 difftest_verilog:
-	mill -i difftest.test.runMain difftest.DifftestMain --target-dir $(RTL_DIR) $(MILL_ARGS)
+	GENERATED_DIR="$(GENERATED_DIR)" mill -i difftest.test.runMain difftest.DifftestMain --target-dir $(RTL_DIR) $(MILL_ARGS)
 
 TIMELOG = $(BUILD_DIR)/time.log
 TIME_CMD = time -avp -o $(TIMELOG)

--- a/src/main/scala/common/FileControl.scala
+++ b/src/main/scala/common/FileControl.scala
@@ -19,10 +19,13 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths, StandardOpenOption}
 
 object FileControl {
+  private def generatedDir: String =
+    sys.env.getOrElse("GENERATED_DIR", Paths.get(sys.env("NOOP_HOME"), "build").toString)
+
   def write(fileStream: Iterable[String], fileName: String): Unit = write(fileStream, fileName, append = false)
 
   def write(fileStream: Iterable[String], fileName: String, append: Boolean): Unit = {
-    val outputDir = Paths.get(sys.env("NOOP_HOME"), "build", "generated-src")
+    val outputDir = Paths.get(generatedDir, "generated-src")
     write(fileStream, fileName, outputDir.toString, append)
   }
 


### PR DESCRIPTION
## Summary

- derive `GENERATED_DIR` from `BUILD_DIR`
- write generated DiffTest artifacts below `GENERATED_DIR/generated-src`
- preserve the existing `<NOOP_HOME>/build` fallback

## Problem

The Verilator flow supports custom `BUILD_DIR` values for RTL and emulator outputs, but some Chisel and DiffTest artifacts are still written to `<NOOP_HOME>/build` and `<NOOP_HOME>/build/generated-src`.

This prevents parallel builds of different XiangShan configurations from the same `NOOP_HOME`. For example, `DefaultConfig` and `MinimalConfig`, or `DefaultMatrixConfig` with `ZhuJiang` and `OpenLLC`, can use different `BUILD_DIR` values while still overwriting shared generated files such as `DifftestMacros.svh`, `chisel_db.cpp`, `constantin.cpp`, and `perfCCT.cpp` under `<NOOP_HOME>/build`.

## Scope

This change only affects generated artifact placement. DiffTest runtime behavior is unchanged.
