### PR TITLE
feat(fpga): filter costly difftest debug fields

### DIFF
--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -81,6 +81,8 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
   protected val needFlatten: Boolean = false
   def isFlatten: Boolean = hasAddress && this.needFlatten
 
+  def fpgaFilterElems: Seq[String] = Seq.empty
+
   // Convert elements into flatten UInt/Vec[UInt]
   private def seqUIntHelper(in: Seq[(String, Data)]): Seq[(String, Seq[UInt])] = {
     in.flatMap { case (s, data) =>
@@ -241,6 +243,8 @@ class DiffArchEvent extends ArchEvent with DifftestBundle {
 
 class DiffInstrCommit(nPhyRegs: Int = 32) extends InstrCommit(nPhyRegs) with DifftestBundle with DifftestWithIndex {
   override val desiredCppName: String = "commit"
+  override def fpgaFilterElems: Seq[String] =
+    Seq("robIdx", "lqIdx", "sqIdx", "isLoad", "isStore")
 
   override def supportsSquash(base: DifftestBundle, maxFused: UInt): Bool = {
     val that = base.asInstanceOf[DiffInstrCommit]
@@ -275,6 +279,7 @@ private[difftest] class DiffVecCommitData extends VecCommitData with DifftestBun
 
 class DiffTrapEvent extends TrapEvent with DifftestBundle {
   override val desiredCppName: String = "trap"
+  override def fpgaFilterElems: Seq[String] = Seq("code")
   override def supportsSquashBase: Bool = !hasTrap && !hasWFI
 }
 

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -191,7 +191,20 @@ object Gateway {
   }
 
   def apply[T <: DifftestBundle](gen: T, delay: Int): T = {
-    val bundle = WireInit(0.U.asTypeOf(gen)).suggestName(gen.desiredCppName)
+    val ret = WireInit(0.U.asTypeOf(gen)).suggestName(gen.desiredCppName)
+    val bundle = if (config.isFPGA && gen.fpgaFilterElems.nonEmpty) {
+      val filtered = WireInit(ret)
+      gen.fpgaFilterElems.foreach { name =>
+        require(
+          filtered.elements.contains(name),
+          s"${gen.desiredModuleName} does not contain FPGA DontCare field $name",
+        )
+        filtered.elements(name) := DontCare
+      }
+      filtered
+    } else {
+      ret
+    }
     dontTouch(bundle)
     if (!config.traceLoad) {
       if (config.needEndpoint) {
@@ -204,7 +217,7 @@ object Gateway {
       }
     }
     instanceWithDelay += ((gen, delay))
-    bundle
+    ret
   }
 
   def getInstance(bundles: Seq[DifftestBundle]): Seq[DifftestBundle] = {


### PR DESCRIPTION
Some debug signals is area-costly but low-debug-value, or can be inferred
from others. This change add fpgaFilterElems so FPGA builds can drive
selected fields to DontCare.