### PR TITLE
feat(difftest): add uArchProbe for uarch trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,27 @@ coherence via RefillTest.
 | `DiffAmuCtrlEvent` | AMU control events for Matrix instructions | No |
 | `DiffAmuFinishEvent` | AMU execution completion and matrix register-bank updates | No |
 | `DiffMsyncEvent` | Synchronization events for msyncregreset, macquire, and mfence instructions | No |
+| `DiffUArchProbe` | Generic microarchitecture state snapshots | No |
+
+### Microarchitecture Probes
+
+`DiffUArchProbe` accepts any Chisel `Bundle` made of bits, nested Bundles, and Vecs. Its
+field paths and widths are preserved in the generated C++ struct and Query table. Fields
+wider than 64 bits are emitted as arrays of 64-bit words. Each instance gets an
+independent `uarchId`, while `cycleCnt` is copied from the `DiffTrapEvent` with the same
+`coreid` during preprocessing.
+
+```scala
+val probe = DifftestModule(new DiffUArchProbe(chiselTypeOf(io.backendState)))
+probe.coreid := coreId
+probe.valid := io.backendStateValid
+probe.setPayload(io.backendState)
+```
+
+The probe handles squash independently from architectural DiffTest interfaces. Its
+`uarchId`, `cycleCnt`, and `index` fields are managed internally and must not be assigned
+by the caller. Probe types are identified by the Bundle name and a stable layout hash, so
+different Bundle layouts with the same total width remain separate software types.
 
 The DiffTest framework comes with a simulation framework with some top-level IOs.
 They will be automatically created when calling `DifftestModule.finish(cpu: String)`.

--- a/src/main/scala/Bundles.scala
+++ b/src/main/scala/Bundles.scala
@@ -17,6 +17,7 @@ package difftest
 
 import chisel3._
 import chisel3.util._
+import difftest.util.UArchProbeSchema
 
 sealed trait HasValid {
   val valid = Bool()
@@ -50,6 +51,15 @@ sealed trait DifftestBaseBundle extends Bundle {
 
 private[difftest] class DeltaElem(elemWidth: Int) extends DifftestBaseBundle {
   val data = UInt(elemWidth.W)
+}
+
+private[difftest] class UArchProbe(val schema: String) extends DifftestBaseBundle with HasValid {
+  private[difftest] val probeSchema = UArchProbeSchema.fromJson(schema)
+  val payloadBits: Int = probeSchema.payloadBits
+
+  val uarchId = UInt(16.W)
+  val cycleCnt = UInt(64.W)
+  val data = MixedVec(probeSchema.storageWidths.map(width => UInt(width.W)))
 }
 
 class ArchEvent extends DifftestBaseBundle with HasValid {

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -79,6 +79,7 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
   def dpicFuncName: String = s"v_difftest_${desiredName.replace("DiffExt", "")}"
   def dpicFuncArgs: Seq[Seq[(String, Data)]] =
     modPorts.filterNot(p => p.length == 1 && commonPorts.exists(_._1 == p.head._1))
+  def dpicFuncCallArgs: Seq[String] = dpicFuncArgs.flatten.map(_._1)
   def dpicFuncProto: String =
     s"""
        |extern "C" void $dpicFuncName (
@@ -160,7 +161,7 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
          |$gfifoInitial
          |  always @(posedge clock) begin
          |    if (enable)
-         |      $dpicFuncName (${dpicFuncArgs.flatten.map(_._1).mkString(", ")});
+         |      $dpicFuncName (${dpicFuncCallArgs.mkString(", ")});
          |  end
          |`endif // CONFIG_DIFFTEST_FPGA
          |`endif // DIFFTEST
@@ -177,7 +178,7 @@ abstract class DPICBase(config: GatewayConfig) extends ExtModule with HasExtModu
        |  ${extArgs.mkString(",\n  ")}
        |) {
        |  if (enable) {
-       |    $dpicFuncName (${dpicFuncArgs.flatten.map(_._1).mkString(", ")});
+       |    $dpicFuncName (${dpicFuncCallArgs.mkString(", ")});
        |  }
        |}
        |""".stripMargin
@@ -188,18 +189,37 @@ class DPIC[T <: DifftestBundle](gen: T, config: GatewayConfig) extends DPICBase(
   val io = IO(Input(gen))
 
   override def desiredName: String = gen.desiredModuleName.replace("Difftest", "DiffExt")
-  override def modPorts: Seq[Seq[(String, Data)]] = {
-    super.modPorts ++ io.elementsInSeqUInt.map { case (name, dataSeq) =>
+  private def namedIOPorts(elements: Seq[(String, Seq[UInt])]): Seq[Seq[(String, Data)]] = {
+    elements.map { case (name, dataSeq) =>
       val prefixName = s"io_$name"
       val finalName = (i: Int) => if (dataSeq.length == 1) prefixName else s"${prefixName}_$i"
       dataSeq.zipWithIndex.map { case (d, i) => (finalName(i), d) }
     }
   }
-  override def dpicFuncArgs: Seq[Seq[(String, Data)]] = if (gen.bits.hasValid) {
-    super.dpicFuncArgs.filterNot(p => p.length == 1 && p.head._1 == "io_valid")
-  } else {
-    super.dpicFuncArgs
+
+  private val physicalIOPorts = namedIOPorts(io.physicalElementsInSeqUInt)
+  private val logicalIOPorts = namedIOPorts(io.elementsInSeqUInt)
+  require(
+    physicalIOPorts.flatten.length == logicalIOPorts.flatten.length,
+    s"Physical and logical DPIC layouts differ for ${gen.desiredModuleName}",
+  )
+  require(
+    physicalIOPorts.flatten.map(_._2.getWidth) == logicalIOPorts.flatten.map(_._2.getWidth),
+    s"Physical and logical DPIC widths differ for ${gen.desiredModuleName}",
+  )
+
+  private def withoutCommonPorts(ports: Seq[Seq[(String, Data)]]): Seq[Seq[(String, Data)]] =
+    ports.filterNot(p => p.length == 1 && commonPorts.exists(_._1 == p.head._1))
+
+  private def withoutValid(ports: Seq[Seq[(String, Data)]]): Seq[Seq[(String, Data)]] = {
+    if (gen.bits.hasValid) ports.filterNot(p => p.length == 1 && p.head._1 == "io_valid") else ports
   }
+
+  override def modPorts: Seq[Seq[(String, Data)]] = super.modPorts ++ physicalIOPorts
+  override def dpicFuncArgs: Seq[Seq[(String, Data)]] =
+    withoutValid(withoutCommonPorts(super.modPorts) ++ logicalIOPorts)
+  override def dpicFuncCallArgs: Seq[String] =
+    withoutValid(withoutCommonPorts(super.modPorts) ++ physicalIOPorts).flatten.map(_._1)
 
   override def dpicFuncAssigns: Seq[String] = {
     val filters: Seq[(DifftestBundle => Boolean, Seq[String])] = Seq(

--- a/src/main/scala/Difftest.scala
+++ b/src/main/scala/Difftest.scala
@@ -22,7 +22,7 @@ import circt.stage.FirtoolOption
 import chisel3.util._
 import difftest.common.FileControl
 import difftest.gateway.{Gateway, GatewayConfig, GatewayResult}
-import difftest.util.Profile
+import difftest.util.{Profile, UArchProbeSchema}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
@@ -97,7 +97,10 @@ sealed trait DifftestBundle extends Bundle with DifftestWithCoreid { this: Difft
     }
   }
 
-  def elementsInSeqUInt: Seq[(String, Seq[UInt])] = seqUIntHelper(elements.toSeq.reverse)
+  private[difftest] def physicalElementsInSeqUInt: Seq[(String, Seq[UInt])] =
+    seqUIntHelper(elements.toSeq.reverse)
+
+  def elementsInSeqUInt: Seq[(String, Seq[UInt])] = physicalElementsInSeqUInt
 
   // return (name, data_width_aligned, data_seq) for all elements, where width can be 8,16,32,64
   def totalElements: Seq[(String, Int, Seq[UInt])] = {
@@ -239,6 +242,69 @@ class DiffArchEvent extends ArchEvent with DifftestBundle {
   // DiffArchEvent must be instantiated once for each core.
   override def isUniqueIdentifier: Boolean = true
   override val desiredCppName: String = "event"
+}
+
+class DiffUArchProbe[T <: Bundle](override val schema: String)
+  extends UArchProbe(schema)
+  with DifftestBundle
+  with DifftestWithIndex {
+  def this(payload: T) = this(UArchProbeSchema.fromBundle(payload).json)
+
+  override val desiredCppName: String = s"uarch_probe_${probeSchema.instanceSuffix}"
+  override def desiredModuleName: String = s"DifftestUArchProbe${probeSchema.typeSuffix}"
+  override def classArgs: Map[String, Any] = Map("schema" -> schema)
+  override val squashGroup: Seq[String] = Seq("UARCH")
+  override def supportsSquash(base: DifftestBundle, maxFused: UInt): Bool = !valid
+
+  override private[difftest] def physicalElementsInSeqUInt: Seq[(String, Seq[UInt])] = Seq(
+    "valid" -> Seq(valid),
+    "uarchId" -> Seq(uarchId),
+    "cycleCnt" -> Seq(cycleCnt),
+    "data" -> data.toSeq,
+    "coreid" -> Seq(coreid),
+    "index" -> Seq(index),
+  )
+
+  override def elementsInSeqUInt: Seq[(String, Seq[UInt])] = {
+    var offset = 0
+    val payloadElements = probeSchema.fields.map { field =>
+      val elements = data.slice(offset, offset + field.storageCount).toSeq
+      offset += field.storageCount
+      (field.name, elements)
+    }
+    Seq(
+      "valid" -> Seq(valid),
+      "uarchId" -> Seq(uarchId),
+      "cycleCnt" -> Seq(cycleCnt),
+    ) ++ payloadElements ++ Seq(
+      "coreid" -> Seq(coreid),
+      "index" -> Seq(index),
+    )
+  }
+
+  def setPayload(payload: T): Unit = {
+    val (payloadSchema, payloadFields) = UArchProbeSchema.payloadData(payload)
+    require(
+      payloadSchema == probeSchema,
+      s"DiffUArchProbe payload schema changed from ${probeSchema.json} to ${payloadSchema.json}",
+    )
+    val encoded = payloadSchema.fields.zip(payloadFields).flatMap { case (field, elements) =>
+      elements.flatMap { element =>
+        if (field.width > 64) {
+          val packed = element.pad(field.wordsPerElement * 64)
+          Seq.tabulate(field.wordsPerElement) { index =>
+            packed((index + 1) * 64 - 1, index * 64)
+          }
+        } else {
+          Seq(element)
+        }
+      }
+    }
+    require(encoded.length == data.length, "DiffUArchProbe encoded payload size does not match its schema")
+    data.zip(encoded).foreach { case (sink, source) =>
+      sink := source
+    }
+  }
 }
 
 class DiffInstrCommit(nPhyRegs: Int = 32) extends InstrCommit(nPhyRegs) with DifftestBundle with DifftestWithIndex {
@@ -622,6 +688,13 @@ object DifftestModule {
     delay: Int = 0,
   ): T = {
     val difftest: T = Wire(gen)
+    difftest match {
+      case probe: DiffUArchProbe[_] =>
+        probe.uarchId := 0.U
+        probe.cycleCnt := 0.U
+        probe.index := 0.U
+      case _ =>
+    }
     val isExcluded = nameExcludes.exists(ex => gen.desiredModuleName.contains(ex))
     if (enabled && !isExcluded) {
       Gateway(gen, delay) := difftest

--- a/src/main/scala/Preprocess.scala
+++ b/src/main/scala/Preprocess.scala
@@ -102,6 +102,48 @@ object Preprocess {
 
     bundles.filterNot(b => Seq("pregs_", "rat_").exists(s => b.desiredCppName.contains(s))) ++ archRegs ++ commitDatas
   }
+
+  def addUArchInfo(bundles: Seq[DifftestBundle], valid: Bool): Seq[DifftestBundle] = {
+    val probes = bundles.collect { case probe: DiffUArchProbe[_] => probe }
+    if (probes.isEmpty) {
+      bundles
+    } else {
+      val numCores = bundles.count(_.isUniqueIdentifier)
+      val traps = bundles.collect { case trap: DiffTrapEvent => trap }
+      require(numCores > 0, "DiffUArchProbe requires DiffArchEvent to identify cores")
+      require(traps.length == numCores, "DiffUArchProbe requires one DiffTrapEvent per core")
+      require(probes.length % numCores == 0, "DiffUArchProbe instances must be symmetric across cores")
+
+      val probesPerCore = probes.length / numCores
+      require(probesPerCore <= (1 << 16), "DiffUArchProbe uarchId exceeds 16 bits")
+      val layouts = probes.grouped(probesPerCore).map(_.map(_.desiredCppName)).toSeq
+      require(layouts.tail.forall(_ == layouts.head), "DiffUArchProbe layout must be symmetric across cores")
+      layouts.head.groupBy(identity).foreach { case (name, instances) =>
+        require(instances.length <= (1 << 8), s"$name index exceeds 8 bits")
+      }
+
+      val processed = probes.zipWithIndex.map { case (probe, globalId) =>
+        val localId = globalId % probesPerCore
+        val coreBase = globalId - localId
+        val typeIndex = probes.slice(coreBase, globalId).count(_.desiredCppName == probe.desiredCppName)
+        val coreMatches = traps.map(_.coreid === probe.coreid)
+        val result = WireInit(probe)
+        result.uarchId := localId.U
+        result.index := typeIndex.U
+        result.cycleCnt := Mux1H(coreMatches, traps.map(_.cycleCnt))
+        when(valid && probe.valid) {
+          assert(PopCount(coreMatches) === 1.U, "DiffUArchProbe coreid must match exactly one DiffTrapEvent")
+        }
+        result
+      }
+
+      val processedIterator = processed.iterator
+      bundles.map {
+        case _: DiffUArchProbe[_] => processedIterator.next()
+        case bundle               => bundle
+      }
+    }
+  }
 }
 
 class PreprocessEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
@@ -123,7 +165,7 @@ class PreprocessEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) ex
     replaceReg
   }
 
-  val preprocessed = MixedVecInit(skipLoad.toSeq)
+  val preprocessed = MixedVecInit(Preprocess.addUArchInfo(skipLoad, pipelined.valid).toSeq)
   val out = IO(Decoupled(chiselTypeOf(preprocessed)))
   pipelined.ready := out.ready
   out.valid := pipelined.valid

--- a/src/main/scala/util/Profile.scala
+++ b/src/main/scala/util/Profile.scala
@@ -30,7 +30,14 @@ case class BundleProfile(
   delay: Int,
 ) {
   def toBundle: DifftestBundle = {
-    val constructor = Class.forName(className).getConstructors()(0)
+    val constructors = Class.forName(className).getConstructors
+    val constructor = constructors
+      .filter(_.getParameters.forall(param => classArgs.contains(param.getName)))
+      .sortBy(constructor => (constructor.getParameterCount != classArgs.size, -constructor.getParameterCount))
+      .headOption
+      .getOrElse(
+        throw new IllegalArgumentException(s"No constructor for $className matches ${classArgs.keys.mkString(", ")}")
+      )
     val args = constructor.getParameters.map { param =>
       (classArgs(param.getName), param.getType.getName) match {
         case (arg: BigInt, "int") => arg.toInt

--- a/src/main/scala/util/Query.scala
+++ b/src/main/scala/util/Query.scala
@@ -73,9 +73,13 @@ object Query {
          |public:
          |  ${tables.map { t => s"Query* ${t.instName};" }.mkString("\n  ")}
          |  ${batchTable.map(_.members).getOrElse("")}
-         |  QueryStats(char *path): QueryStatsBase(path) {
+         |  QueryStats(const char *path): QueryStatsBase(path) {
          |    ${tables.map(_.initInvoke).mkString("\n    ")}
          |    ${batchTable.map(_.initInvoke).getOrElse("")}
+         |  }
+         |  ~QueryStats() {
+         |    ${tables.map(t => s"delete ${t.instName};").mkString("\n    ")}
+         |    ${batchTable.map(_.deleteInvoke).getOrElse("")}
          |  }
          |  ${tables.map(_.initDecl).mkString("")}
          |  ${tables.map(_.writeDecl).mkString("")}
@@ -169,6 +173,7 @@ class BatchQueryTable(template: Seq[DifftestBundle]) {
        |  Query* query_BatchStep;""".stripMargin
 
   val initInvoke: String = "BatchTable_init();"
+  val deleteInvoke: String = "delete query_BatchInfo;\n    delete query_BatchStep;"
 
   val initDecl: String = {
     val bundleNameInserts = bundleNames.zipWithIndex.map { case (name, id) =>

--- a/src/main/scala/util/UArchProbe.scala
+++ b/src/main/scala/util/UArchProbe.scala
@@ -1,0 +1,102 @@
+/***************************************************************************************
+ * Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.util
+
+import chisel3._
+import org.json4s.DefaultFormats
+import org.json4s.native.{JsonMethods, Serialization}
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+case class UArchProbeField(name: String, width: Int, count: Int) {
+  require(name.matches("[A-Za-z_][A-Za-z0-9_]*"), s"Invalid DiffUArchProbe field name: $name")
+  require(width > 0, s"DiffUArchProbe field $name must not be empty")
+  require(count > 0, s"DiffUArchProbe field $name must contain data")
+
+  val storageWidth: Int = if (width > 64) 64 else width
+  val wordsPerElement: Int = (width + 63) / 64
+  val storageCount: Int = count * wordsPerElement
+}
+
+case class UArchProbeSchema(bundleName: String, fields: Seq[UArchProbeField]) {
+  require(bundleName.matches("[A-Za-z_][A-Za-z0-9_]*"), s"Invalid DiffUArchProbe bundle name: $bundleName")
+  require(fields.nonEmpty, "DiffUArchProbe payload must not be empty")
+  require(fields.map(_.name).distinct.length == fields.length, "DiffUArchProbe payload contains duplicate field paths")
+
+  val payloadBits: Int = fields.map(field => field.width * field.count).sum
+  val storageWidths: Seq[Int] = fields.flatMap(field => Seq.fill(field.storageCount)(field.storageWidth))
+  lazy val json: String = Serialization.write(this)(DefaultFormats)
+  lazy val layoutHash: String = {
+    val digest = MessageDigest.getInstance("SHA-256").digest(json.getBytes(StandardCharsets.UTF_8))
+    digest.take(6).map("%02x".format(_)).mkString
+  }
+  lazy val typeSuffix: String = s"$bundleName${layoutHash.toUpperCase}"
+  lazy val instanceSuffix: String = {
+    val snakeName = bundleName
+      .replaceAll("([a-z0-9])([A-Z])", "$1_$2")
+      .toLowerCase
+    s"${snakeName}_$layoutHash"
+  }
+}
+
+object UArchProbeSchema {
+  private case class PayloadField(field: UArchProbeField, data: Seq[UInt])
+
+  def fromJson(json: String): UArchProbeSchema =
+    JsonMethods.parse(json).extract[UArchProbeSchema](DefaultFormats, manifest[UArchProbeSchema])
+
+  def fromBundle(payload: Bundle): UArchProbeSchema = inspect(payload)._1
+
+  def payloadData(payload: Bundle): (UArchProbeSchema, Seq[Seq[UInt]]) = {
+    val (schema, fields) = inspect(payload)
+    (schema, fields.map(_.data))
+  }
+
+  private def inspect(payload: Bundle): (UArchProbeSchema, Seq[PayloadField]) = {
+    val bundleName = sanitizeBundleName(payload.getClass.getSimpleName)
+    val fields = flatten(payload, "payload")
+    val schema = UArchProbeSchema(bundleName, fields.map(_.field))
+    (schema, fields)
+  }
+
+  private def flatten(data: Data, name: String): Seq[PayloadField] = data match {
+    case vec: Vec[_] if vec.nonEmpty && vec.forall(_.isInstanceOf[Bits]) =>
+      val values = vec.map(_.asInstanceOf[Bits].asUInt).toSeq
+      val widths = values.map(_.getWidth).distinct
+      require(widths.length == 1, s"DiffUArchProbe Vec field $name has inconsistent element widths")
+      Seq(PayloadField(UArchProbeField(name, widths.head, values.length), values))
+    case vec: Vec[_] =>
+      vec.zipWithIndex.flatMap { case (element, index) => flatten(element, s"${name}_$index") }.toSeq
+    case bits: Bits =>
+      Seq(PayloadField(UArchProbeField(name, bits.getWidth, 1), Seq(bits.asUInt)))
+    case record: Record =>
+      record.elements.toSeq.reverse.flatMap { case (fieldName, fieldData) =>
+        flatten(fieldData, s"${name}_$fieldName")
+      }
+    case _ =>
+      throw new IllegalArgumentException(
+        s"DiffUArchProbe does not support field $name of type ${data.getClass.getName}"
+      )
+  }
+
+  private def sanitizeBundleName(name: String): String = {
+    val simpleName = name.split("\\$").filter(_.nonEmpty).lastOption.getOrElse("Bundle")
+    val sanitized = simpleName.replaceAll("[^A-Za-z0-9_]", "_")
+    if (sanitized.headOption.exists(_.isDigit)) s"Bundle$sanitized" else sanitized
+  }
+}

--- a/src/test/csrc/common/query.cpp
+++ b/src/test/csrc/common/query.cpp
@@ -21,8 +21,11 @@
 QueryStats *qStats;
 
 void difftest_query_init() {
-  char query_path[128];
-  snprintf(query_path, 128, "%s/build/%s", getenv("NOOP_HOME"), "difftest_query.db");
+  char query_path[PATH_MAX];
+  const char *noop_home = getenv("NOOP_HOME");
+  assert(noop_home != nullptr);
+  int path_length = snprintf(query_path, PATH_MAX, "%s/build/%s", noop_home, "difftest_query.db");
+  assert(path_length >= 0 && path_length < PATH_MAX);
   // remove exist file
   FILE *fp = fopen(query_path, "r");
   if (fp) {

--- a/src/test/csrc/common/query.h
+++ b/src/test/csrc/common/query.h
@@ -20,6 +20,7 @@
 #include "common.h"
 
 #ifdef CONFIG_DIFFTEST_QUERY
+#include <limits.h>
 #include <sqlite3.h>
 #include <type_traits>
 
@@ -82,12 +83,13 @@ public:
 
 class QueryStatsBase {
 public:
-  char path[128];
+  char path[PATH_MAX];
   int query_zone = 0;
   long long query_step = 0;
   sqlite3 *mem_db = nullptr;
-  QueryStatsBase(char *_path) {
-    strncpy(path, _path, 128);
+  QueryStatsBase(const char *_path) {
+    strncpy(path, _path, PATH_MAX);
+    path[PATH_MAX - 1] = '\0';
     sqlite3_open(":memory:", &mem_db);
     sqlite3_exec(mem_db, "PRAGMA synchronous = OFF", 0, 0, 0);
     sqlite3_exec(mem_db, "BEGIN;", 0, 0, 0);

--- a/src/test/scala/DiffUArchProbeSpec.scala
+++ b/src/test/scala/DiffUArchProbeSpec.scala
@@ -1,0 +1,90 @@
+/***************************************************************************************
+ * Copyright (c) 2026 Beijing Institute of Open Source Chip (BOSC)
+ * Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest
+
+import chisel3._
+import difftest.util.BundleProfile
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DiffUArchProbeSpec extends AnyFlatSpec with Matchers {
+  private class TestPayload extends Bundle {
+    val flag = Bool()
+    val wide = UInt(65.W)
+    val lanes = Vec(2, UInt(5.W))
+    val nested = new Bundle {
+      val count = UInt(12.W)
+      val ready = Bool()
+    }
+  }
+
+  private class SplitBytePayload extends Bundle {
+    val low = UInt(4.W)
+    val high = UInt(4.W)
+  }
+
+  private class WholeBytePayload extends Bundle {
+    val value = UInt(8.W)
+  }
+
+  "DiffUArchProbe" should "preserve Bundle fields and survive profile reconstruction" in {
+    val probe = new DiffUArchProbe(new TestPayload)
+    probe.payloadBits shouldBe 89
+    probe.data.length shouldBe 7
+    (probe.probeSchema.layoutHash should fullyMatch).regex("[0-9a-f]{12}")
+    probe.dataElements.map(_._1) shouldBe Seq(
+      "valid", "uarchId", "cycleCnt", "payload_flag", "payload_wide", "payload_lanes", "payload_nested_count",
+      "payload_nested_ready",
+    )
+    probe.dataElements.find(_._1 == "payload_wide").get._3.length shouldBe 2
+    probe.dataElements.find(_._1 == "payload_lanes").get._3.length shouldBe 2
+    probe.physicalElementsInSeqUInt.map(_._1) should contain("data")
+    probe.physicalElementsInSeqUInt.map(_._1) should not contain "payload_flag"
+
+    val cpp = probe.toCppDeclaration(packed = true, aligned = false)
+    cpp should include("uint8_t  payload_flag;")
+    cpp should include("uint64_t payload_wide[2];")
+    cpp should include("uint8_t  payload_lanes[2];")
+    cpp should include("uint16_t payload_nested_count;")
+    cpp should include("uint8_t  payload_nested_ready;")
+
+    val restored = BundleProfile.fromBundle(probe, delay = 0).toBundle
+    restored shouldBe a[DiffUArchProbe[_]]
+    val restoredProbe = restored.asInstanceOf[DiffUArchProbe[_]]
+    restoredProbe.schema shouldBe probe.schema
+    restoredProbe.desiredModuleName shouldBe probe.desiredModuleName
+    restoredProbe.dataElements.map(_._1) shouldBe probe.dataElements.map(_._1)
+  }
+
+  it should "distinguish Bundle layouts with the same total width" in {
+    val split = new DiffUArchProbe(new SplitBytePayload)
+    val whole = new DiffUArchProbe(new WholeBytePayload)
+
+    split.payloadBits shouldBe whole.payloadBits
+    split.desiredModuleName should not be whole.desiredModuleName
+    split.desiredCppName should not be whole.desiredCppName
+  }
+
+  "BundleProfile" should "continue to reconstruct existing interfaces" in {
+    BundleProfile.fromBundle(new DiffArchEvent, delay = 0).toBundle shouldBe a[DiffArchEvent]
+    BundleProfile.fromBundle(new DiffArchIntDelayedUpdate, delay = 0).toBundle shouldBe a[DiffArchIntDelayedUpdate]
+
+    val commit = BundleProfile.fromBundle(new DiffInstrCommit(48), delay = 1).toBundle
+    commit shouldBe a[DiffInstrCommit]
+    commit.asInstanceOf[DiffInstrCommit].numPhyRegs shouldBe 48
+  }
+}


### PR DESCRIPTION
Allow Chisel designs to wrap arbitrary Bundles in DiffUArchProbe. Preprocess assigns per-core IDs and TrapEvent cycle counters, while a dedicated squash group keeps probe events independent from architectural interfaces.

Make profile constructor selection deterministic so probes can be reconstructed from their packed payload width.