### PR TITLE
feat(fpga): replay post-batch trace from URAM

### DIFF
--- a/src/main/scala/Batch.scala
+++ b/src/main/scala/Batch.scala
@@ -67,6 +67,10 @@ class BatchStats(param: BatchParam) extends Bundle {
 class BatchIO(val param: BatchParam, config: GatewayConfig) extends Bundle {
   val payload = UInt(param.BeatBitLen.W)
   val step = UInt(config.stepWidth.W)
+  // The trace descriptor is meaningful only on the final beat of one input step.
+  val traceHead = UInt(16.W)
+  val traceSize = UInt(16.W)
+  val traceValid = Bool()
 }
 
 class BatchInfo extends Bundle {
@@ -78,7 +82,8 @@ object Batch {
   private val template = ListBuffer.empty[DifftestBundle]
 
   def apply(bundles: DecoupledIO[MixedVec[Valid[DifftestBundle]]], config: GatewayConfig): DecoupledIO[BatchIO] = {
-    template ++= chiselTypeOf(bundles.bits).map(_.bits).distinctBy(_.desiredCppName)
+    val newBundles = chiselTypeOf(bundles.bits).map(_.bits).distinctBy(_.desiredCppName)
+    template ++= newBundles.filterNot(bundle => template.exists(_.desiredCppName == bundle.desiredCppName))
     val module = Module(new BatchEndpoint(chiselTypeOf(bundles.bits).toSeq, config))
     module.in <> bundles
     module.out
@@ -266,6 +271,7 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, con
   val pending_valid_mask = RegInit(0.U(param.BeatChunkSize.W))
   val pending_last = RegInit(false.B)
   val pending_valid = RegInit(false.B)
+  val activeTraceInfo = Option.when(config.hasReplay)(RegInit(0.U.asTypeOf(new DiffTraceInfo(config))))
 
   // Stage 3: scan the payload beat bitmap and register one selected beat as pending.
   // Stage 4: independently merge pending into state and refill pending with the next beat.
@@ -288,9 +294,10 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, con
   val merge_full = merged_count >= param.BeatChunkSize.U
   val payload_beat_mask = VecInit(payload_beat_valid.map(_.orR)).asUInt
   val input_step_valid = delay_grouped.valid && info_num =/= 0.U && payload_beat_mask =/= 0.U
+  val start_input_step = !pending_valid && remain_beat_mask === 0.U && state_count === 0.U && input_step_valid
   val select_beat_mask = Mux(
     remain_beat_mask === 0.U,
-    Mux(!pending_valid && state_count === 0.U && input_step_valid, payload_beat_mask, 0.U),
+    Mux(start_input_step, payload_beat_mask, 0.U),
     remain_beat_mask,
   )
   val select_beat_idx = PriorityEncoder(select_beat_mask).pad(beatIdxWidth)
@@ -325,6 +332,14 @@ class BatchCollector(bundles: Seq[Valid[DifftestBundle]], param: BatchParam, con
   out.valid := should_tick
   out.bits.payload := Mux(state_tick, state_chunks.asUInt, merged_head_chunks.asUInt)
   out.bits.step := Mux(out.valid && is_last_step_beat, 1.U(config.stepWidth.W), 0.U)
+  val traceInfo = activeTraceInfo
+  out.bits.traceHead := traceInfo.map(_.trace_head).getOrElse(0.U)
+  out.bits.traceSize := traceInfo.map(_.trace_size).getOrElse(0.U)
+  out.bits.traceValid := out.valid && is_last_step_beat && traceInfo.map(_.valid).getOrElse(false.B)
+
+  when(start_input_step) {
+    activeTraceInfo.foreach(_ := delay_grouped.bits.trace_info.get)
+  }
 
   when(state_update) {
     when(pending_valid) {

--- a/src/main/scala/DPIC.scala
+++ b/src/main/scala/DPIC.scala
@@ -411,7 +411,7 @@ object DPIC {
       val interface = (dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc)
       interfaces += interface
     }
-    if (io.bits.supportsDelta && !deltaInstances.contains(io.bits)) {
+    if (io.bits.supportsDelta && !deltaInstances.exists(_.desiredCppName == io.bits.desiredCppName)) {
       deltaInstances += io.bits
     }
   }
@@ -426,7 +426,11 @@ object DPIC {
     interfaces += ((dpic.dpicFuncName, dpic.dpicFuncProto, dpic.dpicFunc))
     perfs += dpic.dpicFuncName
     perfs ++= template.map("Batch_" + _.desiredModuleName.replace("Difftest", ""))
-    deltaInstances ++= template.filter(_.supportsDelta)
+    template.filter(_.supportsDelta).foreach { bundle =>
+      if (!deltaInstances.exists(_.desiredCppName == bundle.desiredCppName)) {
+        deltaInstances += bundle
+      }
+    }
   }
 
   def collect(config: GatewayConfig, instances: Seq[DifftestBundle]): GatewayResult = {
@@ -450,6 +454,8 @@ object DPIC {
     if (config.isDelta) {
       Delta.collect()
       interfaceCpp += "#include \"difftest-delta.h\""
+      interfaceCpp += "extern \"C\" void difftest_delta_commit();"
+      interfaceCpp += "extern \"C\" void difftest_delta_restore();"
     }
     val phyRegs = instances.distinctBy(_.desiredCppName).collect { case p: DiffPhyRegState => p }
     if (phyRegs.nonEmpty) {
@@ -547,6 +553,8 @@ object DPIC {
            |#include \"difftest-delta.h\"
            |DeltaStats* dStats = nullptr;
            |#define DELTA_BUF(core_id) (dStats->get(core_id))
+           |extern "C" void difftest_delta_commit() { if (dStats) dStats->commit(); }
+           |extern "C" void difftest_delta_restore() { if (dStats) dStats->restore(); }
            |""".stripMargin
     }
     interfaceCpp +=

--- a/src/main/scala/Delta.scala
+++ b/src/main/scala/Delta.scala
@@ -38,7 +38,7 @@ object Delta {
   }
   def collect(): Unit = {
     val deltaCpp = ListBuffer.empty[String]
-    val deltaInsts = instances.filter(_.supportsDelta).distinct
+    val deltaInsts = instances.filter(_.supportsDelta).distinctBy(_.desiredCppName)
     val deltaDecl = deltaInsts.map { inst =>
       val len = inst.dataElements.flatMap(_._3).length
       val elemType = s"uint${inst.deltaElemWidth}_t"
@@ -69,11 +69,13 @@ object Delta {
          |class DeltaStats {
          |private:
          |  DeltaState buffer[NUM_CORES];
+         |  DeltaState checkpoint[NUM_CORES];
          |public:
          |  bool hasProgress = false;
          |
          |  DeltaStats() {
          |    memset(buffer, 0, sizeof(buffer));
+         |    memset(checkpoint, 0, sizeof(checkpoint));
          |  }
          |  DeltaState* get(int coreid){
          |    return buffer + coreid;
@@ -87,6 +89,14 @@ object Delta {
          |      DeltaState* delta = get(i);
          |      ${deltaSync("dut", "delta").mkString("\n      ")}
          |    }
+         |    hasProgress = false;
+         |    get(0)->delta_info.valid = false;
+         |  }
+         |  void commit() {
+         |    memcpy(checkpoint, buffer, sizeof(buffer));
+         |  }
+         |  void restore() {
+         |    memcpy(buffer, checkpoint, sizeof(buffer));
          |    hasProgress = false;
          |    get(0)->delta_info.valid = false;
          |  }

--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -25,7 +25,8 @@ import difftest.preprocess.Preprocess
 import difftest.squash.Squash
 import difftest.batch.{Batch, BatchIO}
 import difftest.delta.Delta
-import difftest.replay.Replay
+import difftest.fpga.ReplayTraceBuffer
+import difftest.replay.{Replay, ReplayInfo}
 import difftest.trace.Trace
 import difftest.validate.Validate
 
@@ -53,6 +54,7 @@ case class GatewayConfig(
   softArchUpdate: Boolean = false,
   isFPGA: Boolean = false,
   isGSIM: Boolean = false,
+  replayTraceDepth: Int = 16384,
 ) {
   def dutZoneSize: Int = if (hasDutZone) 2 else 1
   def dutZoneWidth: Int = log2Ceil(dutZoneSize)
@@ -67,6 +69,7 @@ case class GatewayConfig(
   def hasClockGate = isFPGA || isDelta || isBatch
   def hasDeferredResult: Boolean = isNonBlock || hasInternalStep
   def needTraceInfo: Boolean = hasReplay
+  def hasReplayTrace: Boolean = hasReplay && isFPGA
   def needEndpoint: Boolean =
     hasGlobalEnable || hasDutZone || isBatch || isSquash || hierarchicalWiring || traceDump || traceLoad || needPreprocess
   def needPreprocess: Boolean = hasDutZone || isBatch || isSquash || needTraceInfo || !softArchUpdate
@@ -85,7 +88,10 @@ case class GatewayConfig(
       )
     if (isSquash) macros ++= Seq("CONFIG_DIFFTEST_SQUASH", s"CONFIG_DIFFTEST_SQUASH_STAMPSIZE 4096") // Stamp Width 12
     if (isDelta) macros += "CONFIG_DIFFTEST_DELTA"
-    if (hasReplay) macros ++= Seq("CONFIG_DIFFTEST_REPLAY", s"CONFIG_DIFFTEST_REPLAY_SIZE ${replaySize}")
+    if (hasReplay)
+      macros ++= Seq("CONFIG_DIFFTEST_REPLAY", s"CONFIG_DIFFTEST_REPLAY_SIZE ${replaySize}")
+    if (hasReplayTrace)
+      macros ++= Seq("CONFIG_DIFFTEST_REPLAY_TRACE", s"CONFIG_DIFFTEST_REPLAY_TRACE_DEPTH $replayTraceDepth")
     if (hasDeferredResult) macros += "CONFIG_DIFFTEST_DEFERRED_RESULT"
     if (hasInternalStep) macros += "CONFIG_DIFFTEST_INTERNAL_STEP"
     if (traceDump || traceLoad) macros += "CONFIG_DIFFTEST_IOTRACE"
@@ -106,11 +112,17 @@ case class GatewayConfig(
         s"CONFIG_DIFFTEST_HOST_AXIS_BYTES ${hostAxisBytes}",
         s"CONFIG_DIFFTEST_HOST_AXIS_WIDTH ${hostAxisBytes * 8}",
       )
+    if (hasReplayTrace)
+      macros ++= Seq("CONFIG_DIFFTEST_REPLAY_TRACE", s"CONFIG_DIFFTEST_REPLAY_TRACE_DEPTH $replayTraceDepth")
     if (hasClockGate) macros += "CONFIG_DIFFTEST_CLOCKGATE"
     macros.toSeq
   }
   def check(): Unit = {
     if (hasReplay) require(isSquash)
+    if (hasReplayTrace) {
+      require(isPow2(replayTraceDepth), s"Replay trace depth must be a power of two, got $replayTraceDepth")
+      require(isPow2(replaySize), s"Replay size must be a power of two, got $replaySize")
+    }
     if (hasInternalStep) require(isBatch)
     if (isBatch) require(!hasDutZone)
     if (isBatch) require(isPow2(batchChunkBytes))
@@ -126,6 +138,37 @@ case class GatewayConfig(
 
 class FpgaDiffIO(dataWidth: Int) extends DecoupledIO(UInt(dataWidth.W))
 
+class ReplayTraceRequest extends Bundle {
+  val freeze = Bool()
+  val dump = Bool()
+  val rearm = Bool()
+  val traceHead = UInt(16.W)
+  val traceSize = UInt(16.W)
+}
+
+class ReplayTraceStatus extends Bundle {
+  val frozen = Bool()
+  val dumpActive = Bool()
+  val dumpDone = Bool()
+  val rangeLost = Bool()
+  val writePtr = UInt(32.W)
+  val writeSeq = UInt(32.W)
+  val dumpStart = UInt(32.W)
+  val dumpBeats = UInt(32.W)
+}
+
+private class DecoupledBroadcast[T <: Data](gen: T) extends Module {
+  val in = IO(Flipped(Decoupled(gen)))
+  val out0 = IO(Decoupled(gen))
+  val out1 = IO(Decoupled(gen))
+
+  out0.valid := in.valid
+  out0.bits := in.bits
+  out1.valid := in.valid
+  out1.bits := in.bits
+  in.ready := out0.ready && out1.ready
+}
+
 case class GatewayResult(
   cppMacros: Seq[String] = Seq(),
   vMacros: Seq[String] = Seq(),
@@ -137,6 +180,9 @@ case class GatewayResult(
   exit: Option[UInt] = None,
   step: Option[UInt] = None,
   fpgaIO: Option[FpgaDiffIO] = None,
+  replayTraceRequest: Option[ReplayTraceRequest] = None,
+  replayTraceStatus: Option[ReplayTraceStatus] = None,
+  replayTraceDump: Option[FpgaDiffIO] = None,
   fpgaSquashEnable: Option[Bool] = None,
   fpgaSquashMaxFused: Option[UInt] = None,
   clockEnable: Option[Bool] = None,
@@ -153,6 +199,9 @@ case class GatewayResult(
       exit = if (exit.isDefined) exit else that.exit,
       step = if (step.isDefined) step else that.step,
       fpgaIO = if (fpgaIO.isDefined) fpgaIO else that.fpgaIO,
+      replayTraceRequest = if (replayTraceRequest.isDefined) replayTraceRequest else that.replayTraceRequest,
+      replayTraceStatus = if (replayTraceStatus.isDefined) replayTraceStatus else that.replayTraceStatus,
+      replayTraceDump = if (replayTraceDump.isDefined) replayTraceDump else that.replayTraceDump,
       fpgaSquashEnable = if (fpgaSquashEnable.isDefined) fpgaSquashEnable else that.fpgaSquashEnable,
       fpgaSquashMaxFused = if (fpgaSquashMaxFused.isDefined) fpgaSquashMaxFused else that.fpgaSquashMaxFused,
       clockEnable = if (clockEnable.isDefined) clockEnable else that.clockEnable,
@@ -252,6 +301,9 @@ object Gateway {
         refClock = Option.when(config.hasClockGate)(endpoint.clock),
         step = Some(endpoint.step),
         fpgaIO = endpoint.fpgaIO,
+        replayTraceRequest = endpoint.replayTraceRequest,
+        replayTraceStatus = endpoint.replayTraceStatus,
+        replayTraceDump = endpoint.replayTraceDump,
         fpgaSquashEnable = endpoint.fpgaSquashEnable,
         fpgaSquashMaxFused = endpoint.fpgaSquashMaxFused,
         clockEnable = endpoint.clockEnable,
@@ -275,6 +327,9 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
   val clockEnable = Option.when(config.hasClockGate)(IO(Output(Bool())))
   val fpgaSquashEnable = Option.when(config.isSquash && config.isFPGA)(IO(Input(Bool())))
   val fpgaSquashMaxFused = Option.when(config.isSquash && config.isFPGA)(IO(Input(UInt(8.W))))
+  val replayTraceRequest = Option.when(config.hasReplayTrace)(IO(Input(new ReplayTraceRequest)))
+  val replayTraceStatus = Option.when(config.hasReplayTrace)(IO(Output(new ReplayTraceStatus)))
+  val replayTraceDump = Option.when(config.hasReplayTrace)(IO(new FpgaDiffIO(config.batchBitWidth)))
   // clockEnable should hold with one cycle fire to sample signals
   decoupledIn.valid := !reset.asBool
   clockEnable.foreach { ce =>
@@ -306,15 +361,53 @@ class GatewayEndpoint(instanceWithDelay: Seq[(DifftestBundle, Int)], config: Gat
     decoupledIn
   }
 
-  val replayed = if (config.hasReplay) {
-    Replay(preprocessed, config)
+  val tracePrepared = if (config.hasReplayTrace) {
+    ReplayInfo(preprocessed, config)
   } else {
     preprocessed
   }
 
+  val replayed = if (config.hasReplay && !config.isFPGA) {
+    Replay(tracePrepared, config)
+  } else {
+    tracePrepared
+  }
+
   val validated = Validate(replayed, config)
 
-  val squashed = if (config.isSquash) {
+  val squashed = if (config.hasReplayTrace) {
+    val fork = Module(new DecoupledBroadcast(chiselTypeOf(validated.bits)))
+    fork.in <> validated
+
+    val traceInput = Wire(Decoupled(chiselTypeOf(fork.out1.bits)))
+    traceInput.valid := fork.out1.valid
+    traceInput.bits := fork.out1.bits
+    fork.out1.ready := traceInput.ready
+    traceInput.bits.map(_.bits).filter(_.desiredCppName == "trace_info").foreach { gen =>
+      gen.asInstanceOf[DiffTraceInfo].in_replay := true.B
+    }
+
+    val traceDeltas = if (config.isDelta) {
+      Delta(traceInput, config)
+    } else {
+      traceInput
+    }
+    val traceBatch = Batch(traceDeltas, config)
+    val traceBuffer = Module(new ReplayTraceBuffer(config.batchBitWidth, config.replayTraceDepth, config.replaySize))
+    traceBuffer.io.in.valid := traceBatch.valid
+    traceBuffer.io.in.bits.payload := traceBatch.bits.payload
+    traceBuffer.io.in.bits.traceHead := traceBatch.bits.traceHead
+    traceBuffer.io.in.bits.traceSize := traceBatch.bits.traceSize
+    traceBuffer.io.in.bits.traceValid := traceBatch.bits.traceValid
+    traceBatch.ready := traceBuffer.io.in.ready
+    traceBuffer.io.request := replayTraceRequest.get
+    replayTraceStatus.get := traceBuffer.io.status
+    replayTraceDump.get.bits := traceBuffer.io.dump.bits
+    replayTraceDump.get.valid := traceBuffer.io.dump.valid
+    traceBuffer.io.dump.ready := replayTraceDump.get.ready
+
+    Squash(fork.out0, config, fpgaSquashEnable, fpgaSquashMaxFused)
+  } else if (config.isSquash) {
     Squash(validated, config, fpgaSquashEnable, fpgaSquashMaxFused)
   } else {
     validated

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -22,6 +22,47 @@ import difftest._
 import difftest.gateway.GatewayConfig
 import difftest.util.PipelineConnect
 
+object ReplayInfo {
+  def apply(
+    bundles: DecoupledIO[MixedVec[DifftestBundle]],
+    config: GatewayConfig,
+  ): DecoupledIO[MixedVec[DifftestBundle]] = {
+    val module = Module(new ReplayInfoEndpoint(chiselTypeOf(bundles.bits).toSeq, config))
+    PipelineConnect(bundles, module.in, module.in.fire)
+    module.out
+  }
+}
+
+/** Add replay range metadata without retaining the wide pre-Batch bundle. */
+class ReplayInfoEndpoint(bundles: Seq[DifftestBundle], config: GatewayConfig) extends Module {
+  val in = IO(Flipped(Decoupled(MixedVec(bundles))))
+  val info = WireInit(0.U.asTypeOf(new DiffTraceInfo(config)))
+  val appendIn = WireInit(0.U.asTypeOf(MixedVec(bundles ++ Seq(chiselTypeOf(info)))))
+  in.bits.zipWithIndex.foreach { case (gen, idx) => appendIn(idx) := gen }
+  appendIn.last := info
+  val out = IO(Decoupled(chiselTypeOf(appendIn)))
+
+  val ptr = RegInit(0.U(config.replayWidth.W))
+  val needStore = if (config.hasGlobalEnable) {
+    VecInit(in.bits.flatMap(_.bits.needUpdate).toSeq).asUInt.orR
+  } else {
+    true.B
+  }
+
+  info.valid := needStore
+  info.in_replay := false.B
+  info.trace_head := ptr
+  info.trace_size := 1.U
+
+  in.ready := out.ready
+  out.valid := in.valid
+  out.bits := appendIn
+
+  when(in.fire && needStore) {
+    ptr := Mux(ptr === (config.replaySize - 1).U, 0.U, ptr + 1.U)
+  }
+}
+
 object Replay {
   def apply(
     bundles: DecoupledIO[MixedVec[DifftestBundle]],

--- a/src/main/scala/SimTop.scala
+++ b/src/main/scala/SimTop.scala
@@ -164,6 +164,14 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
         host.io.difftest.valid := fpgaIO.valid && ctrl.diffEnable
         host.io.difftest.bits := fpgaIO.bits
         fpgaIO.ready := Mux(ctrl.diffEnable, host.io.difftest.ready, true.B)
+        host.io.enable := ctrl.diffEnable
+        host.io.replayTrace.valid := false.B
+        host.io.replayTrace.bits := 0.U
+        gateway.replayTraceDump.foreach { replayTraceDump =>
+          host.io.replayTrace.valid := replayTraceDump.valid
+          host.io.replayTrace.bits := replayTraceDump.bits
+          replayTraceDump.ready := host.io.replayTrace.ready
+        }
         val pcie_clock = IO(Input(Clock()))
         host.io.pcie_clock := pcie_clock
 
@@ -175,6 +183,11 @@ class SimTop[T <: RawModule with HasDiffTestInterfaces](cpuGen: => T, modPrefix:
 
         val cfg_axilite = IO(Flipped(new VerilogAXI4LiteRecord(32, 32)))
         cfg.io.axilite <> cfg_axilite.viewAs[AXI4LiteBundle]
+        cfg.io.replayTraceStatus := 0.U.asTypeOf(chiselTypeOf(cfg.io.replayTraceStatus))
+        gateway.replayTraceRequest.foreach(_ := cfg.io.replayTraceRequest)
+        gateway.replayTraceStatus.foreach { replayTraceStatus =>
+          cfg.io.replayTraceStatus := replayTraceStatus
+        }
 
         val hostCtrl = IO(Output(new XDMAHostCtrlIO))
         hostCtrl := ctrl

--- a/src/main/scala/fpga/Host.scala
+++ b/src/main/scala/fpga/Host.scala
@@ -20,12 +20,12 @@ import chisel3._
 import chisel3.util._
 import difftest.common.AXI4Stream
 import difftest.gateway.FpgaDiffIO
-import difftest.util.PipelineConnect
 
 class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module {
   val io = IO(new Bundle {
     val pcie_clock = Input(Clock()) // Read clock
     val reset = Input(Bool())
+    val enable = Input(Bool())
     val difftest = Flipped(new FpgaDiffIO(difftest_width))
     val axis = new AXI4Stream(axis_width)
   })
@@ -52,8 +52,8 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
     val currentPktID = RegInit(0.U(pkt_id_w.W))
     val sendPacketEnd = counter === (numPacketPerRange - 1).U
 
-    val startTransfer = !rangeActive && fifo.io.deq.valid
-    val loadPacket = fifo.io.deq.valid && (!rangeActive || !packetValid)
+    val startTransfer = io.enable && !rangeActive && fifo.io.deq.valid
+    val loadPacket = fifo.io.deq.valid && !packetValid && (rangeActive || io.enable)
 
     val packetPayload =
       if (payload_pad_width > 0) {
@@ -65,16 +65,20 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
 
     fifo.io.deq.ready := loadPacket
 
-    when(startTransfer) {
+    when(!io.enable) {
+      rangeActive := false.B
+      packetValid := false.B
+      sendCnt := 0.U
+    }.elsewhen(startTransfer) {
       rangeActive := true.B
       counter := 0.U
     }
 
-    when(loadPacket) {
+    when(io.enable && loadPacket) {
       packetBeats := packetPayloadBeats
       packetValid := true.B
       sendCnt := 0.U
-    }.elsewhen(packetValid && io.axis.fire) {
+    }.elsewhen(io.enable && packetValid && io.axis.fire) {
       when(sendLast) {
         packetValid := false.B
         sendCnt := 0.U
@@ -92,7 +96,7 @@ class Difftest2AXIs(val difftest_width: Int, val axis_width: Int) extends Module
     }
 
     // AXI output
-    io.axis.valid := packetValid
+    io.axis.valid := packetValid && io.enable
     io.axis.bits.data := packetBeats(sendCnt)
     io.axis.bits.keep := Fill(axis_width / 8, 1.U(1.W))
     io.axis.bits.last := packetValid && sendLast && sendPacketEnd
@@ -105,8 +109,10 @@ class HostEndpoint(
 ) extends Module {
   val io = IO(new Bundle {
     val difftest = Flipped(new FpgaDiffIO(diffWidth))
+    val replayTrace = Flipped(new FpgaDiffIO(diffWidth))
     val to_host_axis = new AXI4Stream(axisWidth)
     val pcie_clock = Input(Clock())
+    val enable = Input(Bool())
   })
 
   // Instantiate the converter module
@@ -115,7 +121,15 @@ class HostEndpoint(
   // Connect clock and reset signals
   diff2axis.io.pcie_clock := io.pcie_clock
   diff2axis.io.reset := reset
-  PipelineConnect(io.difftest, diff2axis.io.difftest, diff2axis.io.difftest.fire)
+  // Keep the packetizer alive for a Replay dump after Path A is disabled.
+  diff2axis.io.enable := io.enable || io.replayTrace.valid
+  // Replay dumps have priority once requested. Normal output is disabled by the
+  // host before requesting a dump, so this mux only drains already queued data.
+  val selectReplayTrace = io.replayTrace.valid
+  diff2axis.io.difftest.valid := Mux(selectReplayTrace, io.replayTrace.valid, io.difftest.valid)
+  diff2axis.io.difftest.bits := Mux(selectReplayTrace, io.replayTrace.bits, io.difftest.bits)
+  io.replayTrace.ready := diff2axis.io.difftest.ready && selectReplayTrace
+  io.difftest.ready := diff2axis.io.difftest.ready && !selectReplayTrace
 
   // AXI-Stream output domain (PCIe clock)
   io.to_host_axis <> diff2axis.io.axis

--- a/src/main/scala/fpga/ReplayTrace.scala
+++ b/src/main/scala/fpga/ReplayTrace.scala
@@ -1,0 +1,299 @@
+/***************************************************************************************
+ * Copyright (c) 2026 Institute of Computing Technology, Chinese Academy of Sciences
+ *
+ * DiffTest is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ *
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the Mulan PSL v2 for more details.
+ ***************************************************************************************/
+
+package difftest.fpga
+
+import chisel3._
+import chisel3.util._
+import difftest.gateway.{ReplayTraceRequest, ReplayTraceStatus}
+
+object ReplayTraceProtocol {
+  val Magic: BigInt = BigInt("5254524143453031", 16) // "RTRACE01"
+  val Version = 1
+}
+
+class ReplayTraceWrite(dataWidth: Int) extends Bundle {
+  val payload = UInt(dataWidth.W)
+  val traceHead = UInt(16.W)
+  val traceSize = UInt(16.W)
+  val traceValid = Bool()
+}
+
+class ReplayTraceUram(dataWidth: Int, depth: Int) extends BlackBox with HasBlackBoxInline {
+  private val addrWidth = log2Ceil(depth)
+
+  override def desiredName: String = s"ReplayTraceUram_${dataWidth}x$depth"
+
+  val io = IO(new Bundle {
+    val clock = Input(Clock())
+    val wr_en = Input(Bool())
+    val wr_addr = Input(UInt(addrWidth.W))
+    val wr_data = Input(UInt(dataWidth.W))
+    val rd_en = Input(Bool())
+    val rd_addr = Input(UInt(addrWidth.W))
+    val rd_data = Output(UInt(dataWidth.W))
+  })
+
+  setInline(
+    s"$desiredName.sv",
+    s"""module $desiredName (
+       |  input  wire                  clock,
+       |  input  wire                  wr_en,
+       |  input  wire [${addrWidth - 1}:0] wr_addr,
+       |  input  wire [${dataWidth - 1}:0] wr_data,
+       |  input  wire                  rd_en,
+       |  input  wire [${addrWidth - 1}:0] rd_addr,
+       |  output reg  [${dataWidth - 1}:0] rd_data
+       |);
+       |  (* ram_style = "ultra" *) reg [${dataWidth - 1}:0] mem [0:${depth - 1}];
+       |
+       |  always @(posedge clock) begin
+       |    if (wr_en) begin
+       |      mem[wr_addr] <= wr_data;
+       |    end
+       |    if (rd_en) begin
+       |      rd_data <= mem[rd_addr];
+       |    end
+       |  end
+       |endmodule
+       |""".stripMargin,
+  )
+}
+
+class ReplayTraceBuffer(dataWidth: Int, depth: Int, replaySize: Int) extends Module {
+  require(isPow2(depth), s"Replay trace depth must be a power of two, got $depth")
+  require(isPow2(replaySize), s"Replay size must be a power of two, got $replaySize")
+  require(dataWidth >= 320, s"Replay trace header needs at least 320 bits, got $dataWidth")
+
+  private val ptrWidth = log2Ceil(depth)
+  private val traceIndexWidth = log2Ceil(replaySize)
+  private val sequenceWidth = 32
+  private val descriptorWidth = sequenceWidth + 1
+
+  val io = IO(new Bundle {
+    val in = Flipped(Decoupled(new ReplayTraceWrite(dataWidth)))
+    val request = Input(new ReplayTraceRequest)
+    val status = Output(new ReplayTraceStatus)
+    val dump = Decoupled(UInt(dataWidth.W))
+  })
+
+  private val states = Enum(11)
+  val capture = states(0)
+  val frozen = states(1)
+  val lookupPrev = states(2)
+  val lookupPrevWait = states(3)
+  val lookupEnd = states(4)
+  val lookupEndWait = states(5)
+  val dumpHeader = states(6)
+  val dumpRead = states(7)
+  val dumpEmit = states(8)
+  val dumpPad = states(9)
+  val dumpDone = states(10)
+  val state = RegInit(capture)
+
+  val dataMem = Module(new ReplayTraceUram(dataWidth, depth))
+  dataMem.io.clock := clock
+  dataMem.io.wr_en := false.B
+  dataMem.io.wr_addr := 0.U
+  dataMem.io.wr_data := 0.U
+  dataMem.io.rd_en := false.B
+  dataMem.io.rd_addr := 0.U
+
+  val descriptors = SyncReadMem(replaySize, UInt(descriptorWidth.W))
+  // SyncReadMem contents are intentionally not reset; keep validity in resettable
+  // flops so an unwritten descriptor can never authorize a dump.
+  val descriptorValid = RegInit(VecInit(Seq.fill(replaySize)(false.B)))
+  val descReadEnable = WireDefault(false.B)
+  val descReadAddr = WireDefault(0.U(traceIndexWidth.W))
+  val descReadData = descriptors.read(descReadAddr, descReadEnable)
+
+  val writePtr = RegInit(0.U(ptrWidth.W))
+  val writeSeq = RegInit(0.U(sequenceWidth.W))
+  val snapshotPtr = RegInit(0.U(ptrWidth.W))
+  val snapshotSeq = RegInit(0.U(sequenceWidth.W))
+  val oldestSeq = RegInit(0.U(sequenceWidth.W))
+
+  val requestHead = RegInit(0.U(16.W))
+  val requestSize = RegInit(0.U(16.W))
+  val previousDescriptor = RegInit(0.U(descriptorWidth.W))
+  val dumpStartPtr = RegInit(0.U(ptrWidth.W))
+  val dumpWords = RegInit(0.U(sequenceWidth.W))
+  val dumpRemaining = RegInit(0.U(sequenceWidth.W))
+  val dumpReadPtr = RegInit(0.U(ptrWidth.W))
+  val padRemaining = RegInit(0.U(3.W))
+  val rangeLost = RegInit(false.B)
+  val dumpHandled = RegInit(false.B)
+
+  def traceIndex(value: UInt): UInt = value(traceIndexWidth - 1, 0)
+
+  io.in.ready := true.B
+  val captureFire = io.in.fire && state === capture && !io.request.freeze
+  val traceTail = traceIndex(io.in.bits.traceHead + io.in.bits.traceSize - 1.U)
+  dataMem.io.wr_en := captureFire
+  dataMem.io.wr_addr := writePtr
+  dataMem.io.wr_data := io.in.bits.payload
+
+  when(captureFire) {
+    writePtr := writePtr + 1.U
+    writeSeq := writeSeq + 1.U
+    when(io.in.bits.traceValid && io.in.bits.traceSize =/= 0.U) {
+      descriptors.write(traceTail, Cat(true.B, writeSeq))
+      descriptorValid(traceTail) := true.B
+    }
+  }
+
+  when(state === capture && io.request.freeze) {
+    snapshotPtr := writePtr
+    snapshotSeq := writeSeq
+    oldestSeq := Mux(writeSeq > depth.U, writeSeq - depth.U, 0.U)
+    state := frozen
+  }
+
+  val previousHead = traceIndex(requestHead - 1.U)
+  val requestTail = traceIndex(requestHead + requestSize - 1.U)
+
+  when(state === frozen) {
+    when(io.request.rearm && !io.request.freeze) {
+      rangeLost := false.B
+      dumpHandled := false.B
+      state := capture
+    }.elsewhen(!io.request.dump) {
+      dumpHandled := false.B
+    }.elsewhen(!dumpHandled) {
+      requestHead := io.request.traceHead
+      requestSize := io.request.traceSize
+      rangeLost := false.B
+      dumpHandled := true.B
+      state := lookupPrev
+    }
+  }
+
+  when(state === lookupPrev) {
+    descReadEnable := true.B
+    descReadAddr := previousHead
+    state := lookupPrevWait
+  }
+
+  when(state === lookupPrevWait) {
+    previousDescriptor := Cat(descriptorValid(previousHead), descReadData(sequenceWidth - 1, 0))
+    state := lookupEnd
+  }
+
+  when(state === lookupEnd) {
+    descReadEnable := true.B
+    descReadAddr := requestTail
+    state := lookupEndWait
+  }
+
+  val previousValid = previousDescriptor(descriptorWidth - 1)
+  val previousSeq = previousDescriptor(sequenceWidth - 1, 0)
+  val endValid = descriptorValid(requestTail)
+  val endSeq = descReadData(sequenceWidth - 1, 0)
+  val firstAvailableSeq = Mux(previousValid && previousSeq >= oldestSeq, previousSeq + 1.U, oldestSeq)
+  val rangeAvailable =
+    requestSize =/= 0.U && endValid && endSeq >= firstAvailableSeq && endSeq < snapshotSeq && firstAvailableSeq >= oldestSeq
+  val selectedStartSeq = Mux(rangeAvailable, firstAvailableSeq, 0.U(sequenceWidth.W))
+  val selectedWords = Mux(rangeAvailable, endSeq - firstAvailableSeq + 1.U, 0.U(sequenceWidth.W))
+  val packetRemainder = (selectedWords + 1.U)(2, 0)
+  val selectedPadding = Mux(packetRemainder === 0.U, 0.U(3.W), (8.U(4.W) - packetRemainder)(2, 0))
+
+  when(state === lookupEndWait) {
+    rangeLost := !rangeAvailable
+    dumpStartPtr := selectedStartSeq(ptrWidth - 1, 0)
+    dumpReadPtr := selectedStartSeq(ptrWidth - 1, 0)
+    dumpWords := selectedWords
+    dumpRemaining := selectedWords
+    padRemaining := selectedPadding
+    state := dumpHeader
+  }
+
+  // The serialized header keeps rangeLost in flags bit 0; the AXI status word
+  // has its own bit layout.
+  // The serialized header keeps rangeLost in flags bit 0; the AXI status word
+  // has its own bit layout.
+  val dumpFlags = Cat(0.U(31.W), rangeLost)
+  val dumpHeaderBits = Cat(
+    0.U((dataWidth - 320).W),
+    snapshotSeq,
+    snapshotPtr.pad(32),
+    dumpWords,
+    dumpStartPtr.pad(32),
+    requestSize,
+    requestHead,
+    dumpFlags,
+    ReplayTraceProtocol.Version.U(32.W),
+    ReplayTraceProtocol.Magic.U(64.W),
+  )
+
+  io.dump.valid := false.B
+  io.dump.bits := 0.U
+  when(state === dumpHeader) {
+    io.dump.valid := true.B
+    io.dump.bits := dumpHeaderBits
+    when(io.dump.fire) {
+      when(dumpRemaining =/= 0.U) {
+        state := dumpRead
+      }.elsewhen(padRemaining =/= 0.U) {
+        state := dumpPad
+      }.otherwise {
+        state := dumpDone
+      }
+    }
+  }
+
+  when(state === dumpRead) {
+    dataMem.io.rd_en := true.B
+    dataMem.io.rd_addr := dumpReadPtr
+    state := dumpEmit
+  }
+
+  when(state === dumpEmit) {
+    io.dump.valid := true.B
+    io.dump.bits := dataMem.io.rd_data
+    when(io.dump.fire) {
+      dumpRemaining := dumpRemaining - 1.U
+      dumpReadPtr := dumpReadPtr + 1.U
+      when(dumpRemaining === 1.U) {
+        when(padRemaining =/= 0.U) {
+          state := dumpPad
+        }.otherwise {
+          state := dumpDone
+        }
+      }.otherwise {
+        state := dumpRead
+      }
+    }
+  }
+
+  when(state === dumpPad) {
+    io.dump.valid := true.B
+    io.dump.bits := 0.U
+    when(io.dump.fire) {
+      padRemaining := padRemaining - 1.U
+      when(padRemaining === 1.U) {
+        state := dumpDone
+      }
+    }
+  }
+
+  io.status.frozen := state =/= capture
+  io.status.dumpActive := state === dumpHeader || state === dumpRead || state === dumpEmit || state === dumpPad
+  io.status.dumpDone := state === dumpDone
+  io.status.rangeLost := rangeLost
+  io.status.writePtr := writePtr.pad(32)
+  io.status.writeSeq := writeSeq
+  io.status.dumpStart := dumpStartPtr.pad(32)
+  io.status.dumpBeats := dumpWords
+}

--- a/src/main/scala/fpga/XDMAConfigBar.scala
+++ b/src/main/scala/fpga/XDMAConfigBar.scala
@@ -19,6 +19,7 @@ package difftest.fpga
 import chisel3._
 import chisel3.util._
 import difftest.common.AXI4LiteBundle
+import difftest.gateway.{ReplayTraceRequest, ReplayTraceStatus}
 
 /** XDMA Config BAR for both FPGA/FPGA_SIM
   *
@@ -35,6 +36,16 @@ import difftest.common.AXI4LiteBundle
   *   - 0x24: HOST_IO_MEM_CPU
   *   - 0x28: HOST_IO_MEM_H2C
   *   - 0x2c: HOST_IO_H2C_SIZE_MB
+  *   - 0x30: HOST_IO_REPLAY_TRACE_FREEZE
+  *   - 0x34: HOST_IO_REPLAY_TRACE_HEAD
+  *   - 0x38: HOST_IO_REPLAY_TRACE_SIZE
+  *   - 0x3c: HOST_IO_REPLAY_TRACE_DUMP
+  *   - 0x40: HOST_IO_REPLAY_TRACE_REARM
+  *   - 0x44: HOST_IO_REPLAY_TRACE_STATUS (read-only)
+  *   - 0x48: HOST_IO_REPLAY_TRACE_WRITE_PTR (read-only)
+  *   - 0x4c: HOST_IO_REPLAY_TRACE_WRITE_SEQ (read-only)
+  *   - 0x50: HOST_IO_REPLAY_TRACE_DUMP_START (read-only)
+  *   - 0x54: HOST_IO_REPLAY_TRACE_DUMP_BEATS (read-only)
   */
 class XDMAHostCtrlIO extends Bundle {
   val reset = Bool()
@@ -55,8 +66,9 @@ class XDMAMemCtrlIO extends Bundle {
 }
 
 private object XDMAConfigReg extends Enumeration {
-  val CfgReset, HostReset, DiffEnable, IlaTrigger, EnableSquash, SquashMaxFused, Seed, RamSizeMB, MemInit, MemCPU,
-    MemH2C, H2CSizeMB = Value
+  val CfgReset, HostReset, DiffEnable, IlaTrigger, EnableSquash, SquashMaxFused, Seed, RamSizeMB, MemInit, MemCPU, MemH2C, H2CSizeMB,
+    ReplayTraceFreeze, ReplayTraceHead, ReplayTraceSize, ReplayTraceDump, ReplayTraceRearm, ReplayTraceStatus,
+    ReplayTraceWritePtr, ReplayTraceWriteSeq, ReplayTraceDumpStart, ReplayTraceDumpBeats = Value
 }
 
 class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Module {
@@ -67,6 +79,8 @@ class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Mo
     val cfgReset = Output(Bool())
     val hostCtrl = Output(new XDMAHostCtrlIO)
     val memCtrl = new XDMAMemCtrlIO
+    val replayTraceRequest = Output(new ReplayTraceRequest)
+    val replayTraceStatus = Input(new ReplayTraceStatus)
   })
 
   private val numRegs = XDMAConfigReg.maxId
@@ -88,6 +102,11 @@ class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Mo
   io.memCtrl.ramSizeMB := regfile(XDMAConfigReg.RamSizeMB.id)
   io.memCtrl.h2cSizeMB := regfile(XDMAConfigReg.H2CSizeMB.id)
   io.cfgReset := regfile(XDMAConfigReg.CfgReset.id)(0)
+  io.replayTraceRequest.freeze := regfile(XDMAConfigReg.ReplayTraceFreeze.id)(0)
+  io.replayTraceRequest.traceHead := regfile(XDMAConfigReg.ReplayTraceHead.id)(15, 0)
+  io.replayTraceRequest.traceSize := regfile(XDMAConfigReg.ReplayTraceSize.id)(15, 0)
+  io.replayTraceRequest.dump := regfile(XDMAConfigReg.ReplayTraceDump.id)(0)
+  io.replayTraceRequest.rearm := regfile(XDMAConfigReg.ReplayTraceRearm.id)(0)
 
   private def mergeByByte(oldData: UInt, newData: UInt, strb: UInt): UInt = {
     VecInit((0 until dataWidth / 8).map { i =>
@@ -126,7 +145,10 @@ class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Mo
     wValid := true.B
   }
   when(doWrite) {
-    when(writeWord < numRegs.U) {
+    when(
+      writeWord < XDMAConfigReg.ReplayTraceStatus.id.U ||
+        writeWord === XDMAConfigReg.ReplayTraceRearm.id.U
+    ) {
       regfile(writeIdx) := mergeByByte(regfile(writeIdx), nextWData, nextWStrb)
     }
     awValid := false.B
@@ -145,10 +167,25 @@ class XDMAConfigBar(val addrWidth: Int = 32, val dataWidth: Int = 32) extends Mo
   io.axilite.r.bits.data := rData
   io.axilite.r.bits.resp := 0.U
 
+  val replayTraceStatus = Cat(
+    0.U(28.W),
+    io.replayTraceStatus.rangeLost,
+    io.replayTraceStatus.dumpDone,
+    io.replayTraceStatus.dumpActive,
+    io.replayTraceStatus.frozen,
+  )
   when(io.axilite.ar.valid && arReady) {
     val readWord = io.axilite.ar.bits.addr(addrWidth - 1, 2)
     val readIdx = readWord(idxBits - 1, 0)
-    rData := Mux(readWord < numRegs.U, regfile(readIdx), 0.U)
+    rData := MuxLookup(readWord, Mux(readWord < numRegs.U, regfile(readIdx), 0.U))(
+      Seq(
+        XDMAConfigReg.ReplayTraceStatus.id.U -> replayTraceStatus,
+        XDMAConfigReg.ReplayTraceWritePtr.id.U -> io.replayTraceStatus.writePtr,
+        XDMAConfigReg.ReplayTraceWriteSeq.id.U -> io.replayTraceStatus.writeSeq,
+        XDMAConfigReg.ReplayTraceDumpStart.id.U -> io.replayTraceStatus.dumpStart,
+        XDMAConfigReg.ReplayTraceDumpBeats.id.U -> io.replayTraceStatus.dumpBeats,
+      )
+    )
     arReady := false.B
     rValid := true.B
   }.elsewhen(rValid && io.axilite.r.ready) {

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -28,6 +28,9 @@
 #if defined(CONFIG_DIFFTEST_SQUASH) && !defined(CONFIG_DIFFTEST_FPGA)
 #include "svdpi.h"
 #endif // CONFIG_DIFFTEST_SQUASH && !CONFIG_DIFFTEST_FPGA
+#if defined(CONFIG_DIFFTEST_REPLAY) && defined(FPGA_SIM) && !defined(FPGA_HOST)
+#include "verilated_dpi.h"
+#endif // CONFIG_DIFFTEST_REPLAY && FPGA_SIM && !FPGA_HOST
 #ifdef CONFIG_DIFFTEST_PERFCNT
 #include "perf.h"
 #endif // CONFIG_DIFFTEST_PERFCNT
@@ -255,7 +258,7 @@ void difftest_squash_max_fused(int squash_max_fused) {
 }
 #endif // CONFIG_DIFFTEST_SQUASH && !CONFIG_DIFFTEST_FPGA
 
-#ifdef CONFIG_DIFFTEST_REPLAY
+#if defined(CONFIG_DIFFTEST_REPLAY) && !defined(CONFIG_DIFFTEST_FPGA)
 svScope replayScope;
 void set_replay_scope() {
   replayScope = svGetScope();
@@ -270,7 +273,7 @@ void difftest_replay_head(int head) {
   svSetScope(replayScope);
   set_replay_head(head);
 }
-#endif // CONFIG_DIFFTEST_REPLAY
+#endif // CONFIG_DIFFTEST_REPLAY && !CONFIG_DIFFTEST_FPGA
 
 Difftest::Difftest(int coreid) {
   state = new DiffState(coreid);
@@ -554,7 +557,9 @@ void Difftest::do_replay() {
     matrix_store_checker->replay_restore();
   }
 #endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
+#ifndef CONFIG_DIFFTEST_FPGA
   difftest_replay_head(info.trace_head);
+#endif // CONFIG_DIFFTEST_FPGA
   // clear buffered queue
 #ifdef CONFIG_DIFFTEST_STOREEVENT
   while (!state->store_event_queue.empty())

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -178,6 +178,19 @@ public:
     state->has_commit = true;
   }
 
+#if defined(CONFIG_DIFFTEST_REPLAY_TRACE) && defined(CONFIG_DIFFTEST_REPLAY)
+  bool get_replay_range(uint16_t *trace_head, uint16_t *trace_size) const {
+    if (!trace_head || !trace_size || !replay_status.in_replay || replay_status.trace_size <= 0 ||
+        replay_status.trace_head < 0 || replay_status.trace_head >= CONFIG_DIFFTEST_REPLAY_SIZE ||
+        replay_status.trace_size > CONFIG_DIFFTEST_REPLAY_SIZE) {
+      return false;
+    }
+    *trace_head = static_cast<uint16_t>(replay_status.trace_head);
+    *trace_size = static_cast<uint16_t>(replay_status.trace_size);
+    return true;
+  }
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE && CONFIG_DIFFTEST_REPLAY
+
 protected:
   DiffState *state = NULL;
   DiffTrace<DiffTestState> *difftrace = nullptr;

--- a/src/test/csrc/fpga/fpga_main.cpp
+++ b/src/test/csrc/fpga/fpga_main.cpp
@@ -18,6 +18,7 @@
 #include "common.h"
 #include "device.h"
 #include "diffstate.h"
+#include "difftest-dpic.h"
 #include "difftest.h"
 #include "flash.h"
 #include "goldenmem.h"
@@ -339,6 +340,29 @@ extern "C" void fpga_nstep(uint8_t step) {
   if (fpga_result != FPGA_RUN)
     return;
   int ret = fpga_get_result(step);
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+  if (ret == FPGA_RUN) {
+    for (int i = 0; i < NUM_CORES; i++) {
+      uint16_t trace_head = 0;
+      uint16_t trace_size = 0;
+      if (difftest[i]->get_replay_range(&trace_head, &trace_size)) {
+        if (!xdma_device->replay_trace_in_progress()) {
+#ifdef CONFIG_DIFFTEST_DELTA
+          difftest_delta_restore();
+#endif // CONFIG_DIFFTEST_DELTA
+        }
+        if (!xdma_device->queue_replay_trace(trace_head, trace_size)) {
+          fpga_result = FPGA_FAIL;
+          xdma_device->stop();
+        }
+        return;
+      }
+    }
+#ifdef CONFIG_DIFFTEST_DELTA
+    difftest_delta_commit();
+#endif // CONFIG_DIFFTEST_DELTA
+  }
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
   if (ret != FPGA_RUN) {
     fpga_display_result(ret);
     fpga_result = ret;

--- a/src/test/csrc/fpga/xdma.cpp
+++ b/src/test/csrc/fpga/xdma.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <inttypes.h>
 #include <iostream>
+#include <poll.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -117,6 +118,139 @@ void FpgaXdma::wait_fpga_io_done(uint64_t address, const char *tag) {
   exit(1);
 }
 
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+bool FpgaXdma::queue_replay_trace(uint16_t trace_head, uint16_t trace_size) {
+  if (replay_trace_pending || replay_trace_requested) {
+    return true;
+  }
+
+  replay_trace_pending_head = trace_head;
+  replay_trace_pending_size = trace_size;
+  replay_trace_pending = true;
+  return true;
+}
+
+bool FpgaXdma::service_replay_trace_request() {
+  if (!replay_trace_pending || replay_trace_requested) {
+    return true;
+  }
+
+  fpga_io(HOST_IO_DIFFTEST_ENABLE, false);
+#ifdef FPGA_SIM
+  // Let already queued Path-A C2H ranges drain/discard before switching the
+  // shared channel to the replay dump stream.
+  xdma_sim_drain(0, 100);
+#endif
+  fpga_io(HOST_IO_REPLAY_TRACE_HEAD, static_cast<uint32_t>(replay_trace_pending_head));
+  fpga_io(HOST_IO_REPLAY_TRACE_SIZE, static_cast<uint32_t>(replay_trace_pending_size));
+  fpga_io(HOST_IO_REPLAY_TRACE_FREEZE, true);
+
+  const int max_retry = 1000;
+  for (int retry = 0; retry < max_retry; retry++) {
+    if (fpga_io_read(HOST_IO_REPLAY_TRACE_STATUS) & REPLAY_TRACE_STATUS_FROZEN) {
+      break;
+    }
+    usleep(1000);
+    if (retry == max_retry - 1) {
+      fprintf(stderr, "[fpga-host] timeout freezing replay trace buffer\n");
+      return false;
+    }
+  }
+
+  replay_trace_requested = true;
+  replay_trace_header_seen = false;
+  replay_trace_discarded = 0;
+  replay_trace_remaining = 0;
+  replay_trace_packets = 0;
+  const char *path = std::getenv("FPGA_REPLAY_TRACE_DUMP");
+  if (path && path[0]) {
+    replay_trace_file.open(path, std::ios::binary | std::ios::trunc);
+    if (!replay_trace_file.is_open()) {
+      fprintf(stderr, "[fpga-host] failed to open replay trace file %s\n", path);
+      replay_trace_requested = false;
+      return false;
+    }
+  }
+  fpga_io(HOST_IO_REPLAY_TRACE_DUMP, true);
+  printf("[fpga-host] replay trace requested: head=%u size=%u\n", replay_trace_pending_head,
+         replay_trace_pending_size);
+  replay_trace_pending = false;
+  return true;
+}
+
+bool FpgaXdma::consume_replay_trace_packet(const uint8_t *payload) {
+  if ((!replay_trace_pending && !replay_trace_requested) || !payload) {
+    return false;
+  }
+  if (replay_trace_pending) {
+    return true;
+  }
+
+  if (!replay_trace_header_seen) {
+    ReplayTraceDumpHeader header;
+    memcpy(&header, payload, sizeof(header));
+    static bool replay_trace_debug_dumped = false;
+    if (!replay_trace_debug_dumped) {
+      replay_trace_debug_dumped = true;
+      fprintf(stderr, "[fpga-host] replay trace first beat:");
+      for (size_t i = 0; i < sizeof(header); i++) fprintf(stderr, " %02x", payload[i]);
+      fprintf(stderr, "\n");
+    }
+    if (header.magic != UINT64_C(0x5254524143453031)) {
+      replay_trace_discarded++;
+      return true;
+    }
+    if (header.version != 1 || header.trace_head >= CONFIG_DIFFTEST_REPLAY_TRACE_DEPTH ||
+        header.trace_size > CONFIG_DIFFTEST_REPLAY_TRACE_DEPTH ||
+        header.dump_words > CONFIG_DIFFTEST_REPLAY_TRACE_DEPTH ||
+        (header.dump_words != 0 && header.dump_start >= CONFIG_DIFFTEST_REPLAY_TRACE_DEPTH)) {
+      fprintf(stderr, "[fpga-host] invalid replay trace header\n");
+      replay_trace_requested = false;
+      running = false;
+      return true;
+    }
+    replay_trace_header_seen = true;
+    if (replay_trace_discarded != 0) {
+      printf("[fpga-host] discarded %u queued Batch beats before replay trace\n", replay_trace_discarded);
+    }
+    replay_trace_remaining = header.dump_words;
+    replay_trace_packets = 1 + header.dump_words;
+    replay_trace_packets += (8 - (replay_trace_packets & 7)) & 7;
+    if (replay_trace_file.is_open()) {
+      replay_trace_file.write(reinterpret_cast<const char *>(&header), sizeof(header));
+    }
+    if (header.flags & REPLAY_TRACE_HEADER_RANGE_LOST) {
+      fprintf(stderr, "[fpga-host] replay trace range was overwritten before freeze\n");
+      replay_trace_requested = false;
+      running = false;
+      return true;
+    }
+  } else if (replay_trace_remaining != 0) {
+    if (replay_trace_file.is_open()) {
+      replay_trace_file.write(reinterpret_cast<const char *>(payload), CONFIG_DIFFTEST_BATCH_BYTELEN);
+    }
+    replay_trace_remaining--;
+    v_difftest_Batch(const_cast<uint8_t *>(payload));
+  }
+
+  if (replay_trace_packets != 0) {
+    replay_trace_packets--;
+  }
+  if (replay_trace_packets == 0) {
+    if (replay_trace_file.is_open()) {
+      replay_trace_file.flush();
+      replay_trace_file.close();
+    }
+    replay_trace_requested = false;
+    if (running) {
+      fprintf(stderr, "[fpga-host] replay range ended without reproducing the error\n");
+      running = false;
+    }
+  }
+  return true;
+}
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
+
 #ifdef CONFIG_USE_XDMA_H2C
 void FpgaXdma::h2c_load_workload(const void *payload, uint64_t size) {
   if (payload == nullptr) {
@@ -171,6 +305,11 @@ void FpgaXdma::h2c_load_workload(const void *payload, uint64_t size) {
 void FpgaXdma::device_write(bool is_bypass, const char *workload, uint64_t addr, uint64_t value) {
   (void)workload;
 #ifdef FPGA_SIM
+  static const bool debug_axilite = std::getenv("FPGA_DEBUG_AXILITE") != nullptr;
+  if (debug_axilite) {
+    fprintf(stderr, "[fpga-host] AXIL write begin addr=0x%lx value=0x%lx\n", addr, value);
+    fflush(stderr);
+  }
   if (is_bypass) {
     fprintf(stderr, "[fpga-host] FPGA_SIM XDMA bypass write is unsupported\n");
     exit(-1);
@@ -178,6 +317,10 @@ void FpgaXdma::device_write(bool is_bypass, const char *workload, uint64_t addr,
   if (xdma_sim_axilite_write(static_cast<uint32_t>(addr), static_cast<uint32_t>(value), 0xf) != 0) {
     fprintf(stderr, "[fpga-host] FPGA_SIM AXI-Lite command queue is full, addr=0x%lx value=0x%lx\n", addr, value);
     exit(-1);
+  }
+  if (debug_axilite) {
+    fprintf(stderr, "[fpga-host] AXIL write done addr=0x%lx\n", addr);
+    fflush(stderr);
   }
   return;
 #endif // FPGA_SIM
@@ -227,6 +370,11 @@ void FpgaXdma::device_write(bool is_bypass, const char *workload, uint64_t addr,
 
 uint32_t FpgaXdma::device_read(bool is_bypass, uint64_t addr) {
 #ifdef FPGA_SIM
+  static const bool debug_axilite = std::getenv("FPGA_DEBUG_AXILITE") != nullptr;
+  if (debug_axilite) {
+    fprintf(stderr, "[fpga-host] AXIL read begin addr=0x%lx\n", addr);
+    fflush(stderr);
+  }
   if (is_bypass) {
     fprintf(stderr, "[fpga-host] FPGA_SIM XDMA bypass read is unsupported\n");
     exit(-1);
@@ -235,6 +383,10 @@ uint32_t FpgaXdma::device_read(bool is_bypass, uint64_t addr) {
   if (xdma_sim_axilite_read(static_cast<uint32_t>(addr), &data) != 0) {
     fprintf(stderr, "[fpga-host] FPGA_SIM AXI-Lite read failed, addr=0x%lx\n", addr);
     exit(-1);
+  }
+  if (debug_axilite) {
+    fprintf(stderr, "[fpga-host] AXIL read done addr=0x%lx data=0x%x\n", addr, data);
+    fflush(stderr);
   }
   return data;
 #endif // FPGA_SIM
@@ -281,6 +433,11 @@ void FpgaXdma::start_transmit_thread() {
 }
 
 void FpgaXdma::stop_thansmit_thread() {
+#ifdef FPGA_SIM
+  for (int i = 0; i < CONFIG_DMA_CHANNELS; i++) {
+    xdma_sim_cancel(i);
+  }
+#endif // FPGA_SIM
   for (int i = 0; i < CONFIG_DMA_CHANNELS; i++) {
     if (receive_thread[i].joinable())
       receive_thread[i].join();
@@ -305,6 +462,20 @@ void FpgaXdma::read_xdma_thread(int channel) {
 #ifdef FPGA_SIM
     ssize_t size = static_cast<ssize_t>(xdma_sim_read(channel, mem, sizeof(FpgaPackgeHead)));
 #else
+    struct pollfd poll_fd = {xdma_c2h_fd[channel], POLLIN, 0};
+    int poll_result;
+    do {
+      poll_result = poll(&poll_fd, 1, 100);
+    } while (poll_result < 0 && errno == EINTR);
+    if (poll_result == 0) {
+      continue;
+    }
+    if (poll_result < 0 || (poll_fd.revents & (POLLERR | POLLHUP | POLLNVAL))) {
+      break;
+    }
+    if (!running || signal_num != 0) {
+      break;
+    }
     ssize_t size = read(xdma_c2h_fd[channel], mem, sizeof(FpgaPackgeHead));
 #endif // FPGA_SIM
     if (size <= 0) {
@@ -337,9 +508,20 @@ void FpgaXdma::write_difftest_thread() {
     recv_count++;
     // packge unpack
     for (size_t i = 0; i < DMA_PACKGE_NUM; i++) {
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+      if (!consume_replay_trace_packet(packge->diff_packge[i].diff_packge)) {
+        v_difftest_Batch(packge->diff_packge[i].diff_packge);
+      }
+#else
       v_difftest_Batch(packge->diff_packge[i].diff_packge);
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
     }
     xdma_mempool.set_free_chunk();
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+    if (!service_replay_trace_request()) {
+      running = false;
+    }
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
   }
 }
 
@@ -371,8 +553,19 @@ void FpgaXdma::read_and_process() {
       continue;
     }
     for (size_t i = 0; i < DMA_PACKGE_NUM; i++) {
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+      if (!consume_replay_trace_packet(packge->diff_packge[i].diff_packge)) {
+        v_difftest_Batch(packge->diff_packge[i].diff_packge);
+      }
+#else
       v_difftest_Batch(packge->diff_packge[i].diff_packge);
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
     }
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+    if (!service_replay_trace_request()) {
+      running = false;
+    }
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
   }
   free(packge);
 }

--- a/src/test/csrc/fpga/xdma.h
+++ b/src/test/csrc/fpga/xdma.h
@@ -20,6 +20,8 @@
 #include "diffstate.h"
 #include "mpool.h"
 #include <atomic>
+#include <cstdint>
+#include <fstream>
 #include <queue>
 #include <signal.h>
 #include <stdbool.h>
@@ -45,6 +47,41 @@
 #define HOST_IO_MEM_CPU          0x24
 #define HOST_IO_MEM_H2C          0x28
 #define HOST_IO_H2C_SIZE_MB      0x2c
+
+#define HOST_IO_REPLAY_TRACE_FREEZE     0x30
+#define HOST_IO_REPLAY_TRACE_HEAD       0x34
+#define HOST_IO_REPLAY_TRACE_SIZE       0x38
+#define HOST_IO_REPLAY_TRACE_DUMP       0x3c
+#define HOST_IO_REPLAY_TRACE_REARM      0x40
+#define HOST_IO_REPLAY_TRACE_STATUS     0x44
+#define HOST_IO_REPLAY_TRACE_WRITE_PTR  0x48
+#define HOST_IO_REPLAY_TRACE_WRITE_SEQ  0x4c
+#define HOST_IO_REPLAY_TRACE_DUMP_START 0x50
+#define HOST_IO_REPLAY_TRACE_DUMP_BEATS 0x54
+
+#define REPLAY_TRACE_STATUS_FROZEN       (1u << 0)
+#define REPLAY_TRACE_STATUS_DUMP_ACTIVE (1u << 1)
+#define REPLAY_TRACE_STATUS_DUMP_DONE   (1u << 2)
+#define REPLAY_TRACE_STATUS_RANGE_LOST  (1u << 3)
+#define REPLAY_TRACE_HEADER_RANGE_LOST  (1u << 0)
+
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+typedef struct __attribute__((packed)) {
+  uint64_t magic;
+  uint32_t version;
+  uint32_t flags;
+  uint16_t trace_head;
+  uint16_t trace_size;
+  uint32_t dump_start;
+  uint32_t dump_words;
+  uint32_t snapshot_ptr;
+  uint32_t snapshot_seq;
+  uint8_t reserved[28];
+} ReplayTraceDumpHeader;
+
+static_assert(sizeof(ReplayTraceDumpHeader) == CONFIG_DIFFTEST_BATCH_BYTELEN,
+              "Replay trace header must occupy one batch beat");
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
 
 #define DMA_PACKGE_NUM 8
 // DMA_PADDING (packge_idx(1) + difftest_data) send width to be calculated by mod up
@@ -94,6 +131,11 @@ public:
 
   void stop() {
     running = false;
+#ifdef FPGA_SIM
+    for (int i = 0; i < CONFIG_DMA_CHANNELS; i++) {
+      xdma_sim_cancel(i);
+    }
+#endif // FPGA_SIM
 #ifdef USE_THREAD_MEMPOOL
     thread_cv.notify_one();
 #endif // USE_THREAD_MEMPOOL
@@ -111,13 +153,21 @@ public:
     return device_read(false, address);
   }
 
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+  bool queue_replay_trace(uint16_t trace_head, uint16_t trace_size);
+  bool replay_trace_in_progress() const {
+    return replay_trace_pending || replay_trace_requested;
+  }
+  bool consume_replay_trace_packet(const uint8_t *payload);
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
+
   void wait_fpga_io_done(uint64_t address, const char *tag);
 #ifdef CONFIG_USE_XDMA_H2C
   void h2c_load_workload(const void *payload, uint64_t size);
 #endif
 
 private:
-  bool running = false;
+  std::atomic<bool> running{false};
   int xdma_c2h_fd[CONFIG_DMA_CHANNELS];
 #ifdef CONFIG_USE_XDMA_H2C
   int xdma_h2c_fd;
@@ -125,6 +175,20 @@ private:
 
   void device_write(bool is_bypass, const char *workload, uint64_t addr, uint64_t value);
   uint32_t device_read(bool is_bypass, uint64_t addr);
+
+#ifdef CONFIG_DIFFTEST_REPLAY_TRACE
+  bool replay_trace_pending = false;
+  bool replay_trace_requested = false;
+  bool replay_trace_header_seen = false;
+  uint16_t replay_trace_pending_head = 0;
+  uint16_t replay_trace_pending_size = 0;
+  uint32_t replay_trace_discarded = 0;
+  uint32_t replay_trace_remaining = 0;
+  uint32_t replay_trace_packets = 0;
+  std::ofstream replay_trace_file;
+
+  bool service_replay_trace_request();
+#endif // CONFIG_DIFFTEST_REPLAY_TRACE
 
 #ifdef USE_THREAD_MEMPOOL
   std::mutex thread_mtx;

--- a/src/test/csrc/fpga_sim/xdma_sim.cpp
+++ b/src/test/csrc/fpga_sim/xdma_sim.cpp
@@ -33,6 +33,11 @@
 #define BUFFER_SIZE        65536
 #define WORKLOAD_PATH_SIZE 4096
 
+static bool xdma_sim_debug_c2h() {
+  static const bool enabled = std::getenv("FPGA_DEBUG_C2H") != nullptr;
+  return enabled;
+}
+
 template <typename T> class xdma_shm_device {
 private:
   int shm_fd = -1;
@@ -81,6 +86,8 @@ typedef struct {
   pthread_cond_t write_cond;
   bool read_waiting;
   bool data_valid;
+  bool closed;
+  bool discard;
   uint64_t tkeep;
   uint8_t tlast;
   int read_size;
@@ -130,6 +137,12 @@ public:
       pthread_condattr_setpshared(&cattr, PTHREAD_PROCESS_SHARED);
       pthread_cond_init(&shm_ptr->read_cond, &cattr);
       pthread_cond_init(&shm_ptr->write_cond, &cattr);
+      shm_ptr->read_waiting = false;
+      shm_ptr->data_valid = false;
+      shm_ptr->closed = false;
+      shm_ptr->discard = false;
+      shm_ptr->read_size = 0;
+      shm_ptr->write_size = 0;
     }
   }
 
@@ -137,11 +150,21 @@ public:
     assert(size <= BUFFER_SIZE);
     pthread_mutex_lock(&shm_ptr->lock);
 
+    if (shm_ptr->closed) {
+      pthread_mutex_unlock(&shm_ptr->lock);
+      return -1;
+    }
     shm_ptr->read_waiting = true;
     shm_ptr->write_size = 0;
     shm_ptr->read_size = size;
-    while (shm_ptr->write_size < size) {
+    while (shm_ptr->write_size < size && !shm_ptr->closed) {
       pthread_cond_wait(&shm_ptr->read_cond, &shm_ptr->lock);
+    }
+    if (shm_ptr->closed) {
+      shm_ptr->read_waiting = false;
+      pthread_cond_broadcast(&shm_ptr->write_cond);
+      pthread_mutex_unlock(&shm_ptr->lock);
+      return -1;
     }
     size_t to_copy = size < shm_ptr->write_size ? size : shm_ptr->write_size;
     memcpy(buf, shm_ptr->buffer, to_copy);
@@ -151,11 +174,32 @@ public:
     return to_copy;
   }
 
+  int drain(int timeout_ms) {
+    pthread_mutex_lock(&shm_ptr->lock);
+    shm_ptr->discard = true;
+    pthread_mutex_unlock(&shm_ptr->lock);
+    if (timeout_ms > 0) {
+      usleep(static_cast<useconds_t>(timeout_ms) * 1000);
+    }
+    pthread_mutex_lock(&shm_ptr->lock);
+    shm_ptr->discard = false;
+    pthread_mutex_unlock(&shm_ptr->lock);
+    return 0;
+  }
+
   int write(const char *buf, unsigned char tlast, size_t size) {
     pthread_mutex_lock(&shm_ptr->lock);
-    while (!shm_ptr->read_waiting) {
+    while (!shm_ptr->read_waiting && !shm_ptr->discard && !shm_ptr->closed) {
       pthread_mutex_unlock(&shm_ptr->lock);
       pthread_mutex_lock(&shm_ptr->lock);
+    }
+    if (shm_ptr->closed) {
+      pthread_mutex_unlock(&shm_ptr->lock);
+      return -1;
+    }
+    if (shm_ptr->discard && !shm_ptr->read_waiting) {
+      pthread_mutex_unlock(&shm_ptr->lock);
+      return static_cast<int>(size);
     }
     size_t space = shm_ptr->read_size - shm_ptr->write_size;
     size_t to_write = size < space ? size : space;
@@ -172,6 +216,15 @@ public:
     pthread_mutex_unlock(&shm_ptr->lock);
 
     return to_write;
+  }
+
+  void cancel() {
+    pthread_mutex_lock(&shm_ptr->lock);
+    shm_ptr->closed = true;
+    shm_ptr->read_waiting = false;
+    pthread_cond_broadcast(&shm_ptr->read_cond);
+    pthread_cond_broadcast(&shm_ptr->write_cond);
+    pthread_mutex_unlock(&shm_ptr->lock);
   }
 };
 
@@ -441,7 +494,33 @@ void xdma_sim_close(int channel) {
 }
 
 int xdma_sim_read(int channel, char *buf, size_t size) {
-  return xsim[channel]->read(buf, size);
+  static uint64_t read_count = 0;
+  uint64_t seq = ++read_count;
+  if (xdma_sim_debug_c2h() && (seq <= 4 || (seq % 64) == 0)) {
+    fprintf(stderr, "[xdma-sim] C2H read begin seq=%lu size=%zu\n", seq, size);
+    fflush(stderr);
+  }
+  int ret = xsim[channel]->read(buf, size);
+  if (xdma_sim_debug_c2h() && (seq <= 4 || (seq % 64) == 0)) {
+    fprintf(stderr, "[xdma-sim] C2H read done seq=%lu ret=%d\n", seq, ret);
+    fflush(stderr);
+  }
+  return ret;
+}
+
+int xdma_sim_drain(int channel, int timeout_ms) {
+  if (xsim[channel] == nullptr) {
+    return -1;
+  }
+  return xsim[channel]->drain(timeout_ms);
+}
+
+void xdma_sim_cancel(int channel) {
+  pthread_mutex_lock(&xsim_lock);
+  if (xsim[channel] != nullptr) {
+    xsim[channel]->cancel();
+  }
+  pthread_mutex_unlock(&xsim_lock);
 }
 
 int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size) {
@@ -535,6 +614,12 @@ extern "C" void v_xdma_write(uint8_t channel, const char *axi_tdata, uint8_t axi
 }
 
 extern "C" void v_xdma_c2h_write(uint8_t channel, const char *axi_tdata, uint8_t axi_tlast) {
+  static uint64_t beat_count = 0;
+  uint64_t seq = ++beat_count;
+  if (xdma_sim_debug_c2h() && (axi_tlast || seq <= 4)) {
+    fprintf(stderr, "[xdma-sim] C2H beat seq=%lu last=%u\n", seq, axi_tlast);
+    fflush(stderr);
+  }
   xdma_sim_write(channel, axi_tdata, axi_tlast, CONFIG_DIFFTEST_HOST_AXIS_BYTES);
 }
 

--- a/src/test/csrc/fpga_sim/xdma_sim.h
+++ b/src/test/csrc/fpga_sim/xdma_sim.h
@@ -20,11 +20,13 @@
 
 void xdma_sim_open(int channel, bool is_host);
 void xdma_sim_close(int channel);
+void xdma_sim_cancel(int channel);
 void xdma_sim_axilite_open(bool is_host);
 void xdma_sim_axilite_close(bool is_host);
 void xdma_sim_workload_open(bool is_host);
 void xdma_sim_workload_close(bool is_host);
 int xdma_sim_read(int channel, char *buf, size_t size);
+int xdma_sim_drain(int channel, int timeout_ms);
 int xdma_sim_write(int channel, const char *buf, uint8_t tlast, size_t size);
 void xdma_sim_h2c_open(int channel, bool is_host);
 void xdma_sim_h2c_close(int channel);


### PR DESCRIPTION
Keep software Replay before Squash for non-FPGA builds and capture the FPGA post-Delta Batch stream in URAM. Queue replay requests outside the DMA callback, restore Delta state, and feed the returned trace back through the host Batch path.