### PR TITLE
fix(difftest): fix DiffState memcpy for Replay

### DIFF
--- a/src/test/csrc/difftest/checkers/matrix.cpp
+++ b/src/test/csrc/difftest/checkers/matrix.cpp
@@ -171,7 +171,6 @@ int AmuCtrlRecorder::check(const DifftestAmuCtrlEvent &probe) {
   DiffState::AmeInstRobEntry entry;
   entry.amu_event = probe;
   entry.state = DiffState::WAIT_REF_COMMIT;
-  entry.res = NULL;
   state->matrix_sw_rob.push_back(entry);
   return STATE_OK;
 }
@@ -236,10 +235,6 @@ int AmuExecRecorder::check(const DifftestAmuFinishEvent &probe) {
           printf("Failed to execute REF mrelease: core %d, pc 0x%016lx\n", state->coreid, amu_event.pc);
           return STATE_ERROR;
         }
-        if (iter->res != nullptr) {
-          delete[] iter->res;
-          iter->res = nullptr;
-        }
         state->matrix_sw_rob.erase(iter);
         return STATE_OK;
       } else { // mload/mstore/mma/marith
@@ -249,10 +244,9 @@ int AmuExecRecorder::check(const DifftestAmuFinishEvent &probe) {
         if (matrix_u64_size == 0) {
           matrix_u64_size = 1;
         }
-        if (entry.res == NULL) {
+        if (entry.res.empty()) {
           // first `valid` for this inst: alloc space for matrix inst
-          entry.res = new uint64_t[matrix_u64_size];
-          memset(entry.res, 0, matrix_u64_size * sizeof(uint64_t));
+          entry.res.resize(matrix_u64_size, 0);
         }
         uint8_t md = entry.amu_event.md;
         size_t stride = 0;
@@ -313,54 +307,35 @@ int AmuExecChecker::do_step() {
           // Allocate buffer for MMA verification
           buffer = mma_verifier->allocate_buffer(&amu_event);
           // Store DUT result in the buffer
-          memcpy(buffer->dut_result, iter->res,
+          memcpy(buffer->dut_result, iter->res.data(),
                  amu_event.mtilem * amu_event.mtilen * get_element_size(amu_event.typed));
           // Call get_amu_lazy with buffer pointers
           // Store REF's src1/2/3 in the buffer, and copy DUT's result to REF
           // REF will directly take DUT's result instead of executing the MMA instruction
-          if (proxy->get_amu_lazy(&amu_event, iter->res, buffer->src1, buffer->src2, buffer->src3) != 0) {
+          if (proxy->get_amu_lazy(&amu_event, iter->res.data(), buffer->src1, buffer->src2, buffer->src3) != 0) {
             printf("Failed to get REF operands for MMA verification: core %d, pc 0x%016lx\n", state->coreid,
                    amu_event.pc);
             mma_verifier->free_buffer(buffer);
-            delete[] iter->res;
-            iter->res = nullptr;
             set_error_pc(state->coreid, amu_event.pc);
             return STATE_ERROR;
           }
           // Pass buffer to verification thread
           mma_verifier->add_to_verification_queue(buffer);
-          delete[] iter->res;
           break;
         case 1: // MLS
         case 3: // Arith
-          if (proxy->get_amu_exec(&amu_event, iter->res) == 1) {
+          if (proxy->get_amu_exec(&amu_event, iter->res.data()) == 1) {
             printf("Mismatch for amu exec event: pc 0x%016lx, op %s\n", amu_event.pc, amu_ctrl_op_name(amu_event.op));
-            if (iter->res != nullptr) {
-              delete[] iter->res;
-              iter->res = nullptr;
-            }
             set_error_pc(state->coreid, amu_event.pc);
             return STATE_ERROR;
-          }
-          if (iter->res != nullptr) {
-            delete[] iter->res;
-            iter->res = nullptr;
           }
           break;
         case 2: // MRelease
           printf("Mrelease reached ordered software ROB commit unexpectedly: core %d, pc 0x%016lx\n", state->coreid,
                  amu_event.pc);
-          if (iter->res != nullptr) {
-            delete[] iter->res;
-            iter->res = nullptr;
-          }
           return STATE_ERROR;
         default:
           printf("Unknown amu event op: %d\n", op);
-          if (iter->res != nullptr) {
-            delete[] iter->res;
-            iter->res = nullptr;
-          }
           set_error_pc(state->coreid, amu_event.pc);
           return STATE_ERROR;
       }

--- a/src/test/csrc/difftest/checkers/matrix.cpp
+++ b/src/test/csrc/difftest/checkers/matrix.cpp
@@ -171,6 +171,7 @@ int AmuCtrlRecorder::check(const DifftestAmuCtrlEvent &probe) {
   DiffState::AmeInstRobEntry entry;
   entry.amu_event = probe;
   entry.state = DiffState::WAIT_REF_COMMIT;
+  entry.res = NULL;
   state->matrix_sw_rob.push_back(entry);
   return STATE_OK;
 }
@@ -235,6 +236,10 @@ int AmuExecRecorder::check(const DifftestAmuFinishEvent &probe) {
           printf("Failed to execute REF mrelease: core %d, pc 0x%016lx\n", state->coreid, amu_event.pc);
           return STATE_ERROR;
         }
+        if (iter->res != nullptr) {
+          delete[] iter->res;
+          iter->res = nullptr;
+        }
         state->matrix_sw_rob.erase(iter);
         return STATE_OK;
       } else { // mload/mstore/mma/marith
@@ -244,9 +249,10 @@ int AmuExecRecorder::check(const DifftestAmuFinishEvent &probe) {
         if (matrix_u64_size == 0) {
           matrix_u64_size = 1;
         }
-        if (entry.res.empty()) {
+        if (entry.res == NULL) {
           // first `valid` for this inst: alloc space for matrix inst
-          entry.res.resize(matrix_u64_size, 0);
+          entry.res = new uint64_t[matrix_u64_size];
+          memset(entry.res, 0, matrix_u64_size * sizeof(uint64_t));
         }
         uint8_t md = entry.amu_event.md;
         size_t stride = 0;
@@ -307,35 +313,54 @@ int AmuExecChecker::do_step() {
           // Allocate buffer for MMA verification
           buffer = mma_verifier->allocate_buffer(&amu_event);
           // Store DUT result in the buffer
-          memcpy(buffer->dut_result, iter->res.data(),
+          memcpy(buffer->dut_result, iter->res,
                  amu_event.mtilem * amu_event.mtilen * get_element_size(amu_event.typed));
           // Call get_amu_lazy with buffer pointers
           // Store REF's src1/2/3 in the buffer, and copy DUT's result to REF
           // REF will directly take DUT's result instead of executing the MMA instruction
-          if (proxy->get_amu_lazy(&amu_event, iter->res.data(), buffer->src1, buffer->src2, buffer->src3) != 0) {
+          if (proxy->get_amu_lazy(&amu_event, iter->res, buffer->src1, buffer->src2, buffer->src3) != 0) {
             printf("Failed to get REF operands for MMA verification: core %d, pc 0x%016lx\n", state->coreid,
                    amu_event.pc);
             mma_verifier->free_buffer(buffer);
+            delete[] iter->res;
+            iter->res = nullptr;
             set_error_pc(state->coreid, amu_event.pc);
             return STATE_ERROR;
           }
           // Pass buffer to verification thread
           mma_verifier->add_to_verification_queue(buffer);
+          delete[] iter->res;
           break;
         case 1: // MLS
         case 3: // Arith
-          if (proxy->get_amu_exec(&amu_event, iter->res.data()) == 1) {
+          if (proxy->get_amu_exec(&amu_event, iter->res) == 1) {
             printf("Mismatch for amu exec event: pc 0x%016lx, op %s\n", amu_event.pc, amu_ctrl_op_name(amu_event.op));
+            if (iter->res != nullptr) {
+              delete[] iter->res;
+              iter->res = nullptr;
+            }
             set_error_pc(state->coreid, amu_event.pc);
             return STATE_ERROR;
+          }
+          if (iter->res != nullptr) {
+            delete[] iter->res;
+            iter->res = nullptr;
           }
           break;
         case 2: // MRelease
           printf("Mrelease reached ordered software ROB commit unexpectedly: core %d, pc 0x%016lx\n", state->coreid,
                  amu_event.pc);
+          if (iter->res != nullptr) {
+            delete[] iter->res;
+            iter->res = nullptr;
+          }
           return STATE_ERROR;
         default:
           printf("Unknown amu event op: %d\n", op);
+          if (iter->res != nullptr) {
+            delete[] iter->res;
+            iter->res = nullptr;
+          }
           set_error_pc(state->coreid, amu_event.pc);
           return STATE_ERROR;
       }

--- a/src/test/csrc/difftest/diffstate.cpp
+++ b/src/test/csrc/difftest/diffstate.cpp
@@ -16,8 +16,10 @@
 
 #include "diffstate.h"
 #include "spikedasm.h"
+#include <algorithm>
+#include <cassert>
 
-void CommitTrace::display(bool use_spike) {
+void CommitTrace::display(bool use_spike) const {
   Info("%s pc %016lx inst %08x", get_type(), pc, inst);
   display_custom();
   if (use_spike) {
@@ -25,7 +27,7 @@ void CommitTrace::display(bool use_spike) {
   }
 }
 
-void CommitTrace::display_line(int index, bool use_spike, bool is_retire) {
+void CommitTrace::display_line(int index, bool use_spike, bool is_retire) const {
   Info("[%02d] ", index);
   display(use_spike);
   Info("%s\n", is_retire ? " <--" : "");
@@ -47,7 +49,7 @@ void DiffState::display() {
   Info("\n============== Commit Instr Trace ==============\n");
   int commit_index = 0;
   while (!commit_trace.empty()) {
-    CommitTrace *trace = commit_trace.front();
+    auto trace = commit_trace.front();
     commit_trace.pop();
     trace->display_line(commit_index, use_spike, commit_trace.empty());
     commit_index++;
@@ -57,6 +59,79 @@ void DiffState::display() {
 }
 
 DiffState::DiffState(int coreid) : use_spike(spike_valid()), coreid(coreid) {}
+
+#ifdef CONFIG_DIFFTEST_REPLAY
+void DiffState::replay_snapshot() {
+  replay_state.valid = false;
+  replay_state.has_commit = has_commit;
+  replay_state.last_commit_cycle = last_commit_cycle;
+  replay_state.has_trap = has_trap;
+  replay_state.trap_code = trap_code;
+#ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
+  std::copy(delayed_int, delayed_int + 32, replay_state.delayed_int.begin());
+#endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
+#ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
+  std::copy(delayed_fp, delayed_fp + 32, replay_state.delayed_fp.begin());
+#endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
+#ifdef CONFIG_DIFFTEST_STOREEVENT
+  replay_state.store_event_queue = store_event_queue;
+#endif // CONFIG_DIFFTEST_STOREEVENT
+#ifdef CONFIG_DIFFTEST_CMOINVALEVENT
+  replay_state.cmo_inval_event_set = cmo_inval_event_set;
+#endif // CONFIG_DIFFTEST_CMOINVALEVENT
+#ifdef CONFIG_DIFFTEST_SQUASH
+  replay_state.commit_stamp = commit_stamp;
+#ifdef CONFIG_DIFFTEST_LOADEVENT
+  replay_state.load_event_queue = load_event_queue;
+#endif // CONFIG_DIFFTEST_LOADEVENT
+#endif // CONFIG_DIFFTEST_SQUASH
+#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
+  replay_state.matrix_sw_rob = matrix_sw_rob;
+#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
+#ifdef CONFIG_DIFFTEST_MSYNCEVENT
+  replay_state.msync_event_queue = msync_event_queue;
+#endif // CONFIG_DIFFTEST_MSYNCEVENT
+  replay_state.retire_group_queue = retire_group_queue;
+  replay_state.commit_trace = commit_trace;
+  replay_state.commit_counter = commit_counter;
+  replay_state.valid = true;
+}
+
+void DiffState::replay_restore() {
+  assert(replay_state.valid);
+  has_commit = replay_state.has_commit;
+  last_commit_cycle = replay_state.last_commit_cycle;
+  has_trap = replay_state.has_trap;
+  trap_code = replay_state.trap_code;
+#ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
+  std::copy(replay_state.delayed_int.begin(), replay_state.delayed_int.end(), delayed_int);
+#endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
+#ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
+  std::copy(replay_state.delayed_fp.begin(), replay_state.delayed_fp.end(), delayed_fp);
+#endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
+#ifdef CONFIG_DIFFTEST_STOREEVENT
+  store_event_queue = replay_state.store_event_queue;
+#endif // CONFIG_DIFFTEST_STOREEVENT
+#ifdef CONFIG_DIFFTEST_CMOINVALEVENT
+  cmo_inval_event_set = replay_state.cmo_inval_event_set;
+#endif // CONFIG_DIFFTEST_CMOINVALEVENT
+#ifdef CONFIG_DIFFTEST_SQUASH
+  commit_stamp = replay_state.commit_stamp;
+#ifdef CONFIG_DIFFTEST_LOADEVENT
+  load_event_queue = replay_state.load_event_queue;
+#endif // CONFIG_DIFFTEST_LOADEVENT
+#endif // CONFIG_DIFFTEST_SQUASH
+#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
+  matrix_sw_rob = replay_state.matrix_sw_rob;
+#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
+#ifdef CONFIG_DIFFTEST_MSYNCEVENT
+  msync_event_queue = replay_state.msync_event_queue;
+#endif // CONFIG_DIFFTEST_MSYNCEVENT
+  retire_group_queue = replay_state.retire_group_queue;
+  commit_trace = replay_state.commit_trace;
+  commit_counter = replay_state.commit_counter;
+}
+#endif // CONFIG_DIFFTEST_REPLAY
 
 static uint64_t get_int_data(const DiffTestState *state, int index) {
 #ifdef CONFIG_DIFFTEST_PHYINTREGSTATE

--- a/src/test/csrc/difftest/diffstate.cpp
+++ b/src/test/csrc/difftest/diffstate.cpp
@@ -17,7 +17,6 @@
 #include "diffstate.h"
 #include "spikedasm.h"
 #include <cassert>
-#include <cstring>
 
 void CommitTrace::display(bool use_spike) {
   Info("%s pc %016lx inst %08x", get_type(), pc, inst);
@@ -58,58 +57,18 @@ void DiffState::display() {
   fflush(stdout);
 }
 
-DiffState::DiffState(int coreid) : use_spike(spike_valid()), coreid(coreid) {}
+DiffState::DiffState(int coreid) : DiffStateValues(coreid), use_spike(spike_valid()) {}
 
 #ifdef CONFIG_DIFFTEST_REPLAY
 void DiffState::replay_snapshot() {
-  replay_state.valid = false;
-  replay_state.coreid = coreid;
-  replay_state.cycle_count = cycle_count;
-  replay_state.has_progress = has_progress;
-  replay_state.has_commit = has_commit;
-  replay_state.last_commit_cycle = last_commit_cycle;
-  replay_state.has_trap = has_trap;
-  replay_state.trap_code = trap_code;
-#ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-  memcpy(replay_state.delayed_int, delayed_int, sizeof(delayed_int));
-#endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-  memcpy(replay_state.delayed_fp, delayed_fp, sizeof(delayed_fp));
-#endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_SQUASH
-  replay_state.commit_stamp = commit_stamp;
-#endif // CONFIG_DIFFTEST_SQUASH
-#ifdef DEBUG_REFILL
-  replay_state.track_instr = track_instr;
-#endif // DEBUG_REFILL
-  replay_state.dump_commit_trace = dump_commit_trace;
-  replay_state.commit_counter = commit_counter;
-  replay_state.valid = true;
+  replay_state_valid = false;
+  replay_state = static_cast<const DiffStateValues &>(*this);
+  replay_state_valid = true;
 }
 
 void DiffState::replay_restore() {
-  assert(replay_state.valid);
-  coreid = replay_state.coreid;
-  cycle_count = replay_state.cycle_count;
-  has_progress = replay_state.has_progress;
-  has_commit = replay_state.has_commit;
-  last_commit_cycle = replay_state.last_commit_cycle;
-  has_trap = replay_state.has_trap;
-  trap_code = replay_state.trap_code;
-#ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-  memcpy(delayed_int, replay_state.delayed_int, sizeof(delayed_int));
-#endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-  memcpy(delayed_fp, replay_state.delayed_fp, sizeof(delayed_fp));
-#endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_SQUASH
-  commit_stamp = replay_state.commit_stamp;
-#endif // CONFIG_DIFFTEST_SQUASH
-#ifdef DEBUG_REFILL
-  track_instr = replay_state.track_instr;
-#endif // DEBUG_REFILL
-  dump_commit_trace = replay_state.dump_commit_trace;
-  commit_counter = replay_state.commit_counter;
+  assert(replay_state_valid);
+  static_cast<DiffStateValues &>(*this) = replay_state;
 
 #ifdef CONFIG_DIFFTEST_STOREEVENT
   while (!store_event_queue.empty()) {

--- a/src/test/csrc/difftest/diffstate.cpp
+++ b/src/test/csrc/difftest/diffstate.cpp
@@ -16,7 +16,6 @@
 
 #include "diffstate.h"
 #include "spikedasm.h"
-#include <cassert>
 
 void CommitTrace::display(bool use_spike) {
   Info("%s pc %016lx inst %08x", get_type(), pc, inst);
@@ -61,36 +60,25 @@ DiffState::DiffState(int coreid) : DiffStateValues(coreid), use_spike(spike_vali
 
 #ifdef CONFIG_DIFFTEST_REPLAY
 void DiffState::replay_snapshot() {
-  replay_state_valid = false;
   replay_state = static_cast<const DiffStateValues &>(*this);
-  replay_state_valid = true;
 }
 
 void DiffState::replay_restore() {
-  assert(replay_state_valid);
   static_cast<DiffStateValues &>(*this) = replay_state;
 
 #ifdef CONFIG_DIFFTEST_STOREEVENT
-  while (!store_event_queue.empty()) {
-    store_event_queue.pop();
-  }
+  store_event_queue = {};
 #endif // CONFIG_DIFFTEST_STOREEVENT
 #ifdef CONFIG_DIFFTEST_CMOINVALEVENT
   cmo_inval_event_set.clear();
 #endif // CONFIG_DIFFTEST_CMOINVALEVENT
 #if defined(CONFIG_DIFFTEST_LOADEVENT) && defined(CONFIG_DIFFTEST_SQUASH)
-  while (!load_event_queue.empty()) {
-    load_event_queue.pop();
-  }
+  load_event_queue = {};
 #endif // CONFIG_DIFFTEST_LOADEVENT && CONFIG_DIFFTEST_SQUASH
 #ifdef CONFIG_DIFFTEST_MSYNCEVENT
-  while (!msync_event_queue.empty()) {
-    msync_event_queue.pop();
-  }
+  msync_event_queue = {};
 #endif // CONFIG_DIFFTEST_MSYNCEVENT
-  while (!retire_group_queue.empty()) {
-    retire_group_queue.pop();
-  }
+  retire_group_queue = {};
   while (!commit_trace.empty()) {
     delete commit_trace.front();
     commit_trace.pop();

--- a/src/test/csrc/difftest/diffstate.cpp
+++ b/src/test/csrc/difftest/diffstate.cpp
@@ -16,10 +16,10 @@
 
 #include "diffstate.h"
 #include "spikedasm.h"
-#include <algorithm>
 #include <cassert>
+#include <cstring>
 
-void CommitTrace::display(bool use_spike) const {
+void CommitTrace::display(bool use_spike) {
   Info("%s pc %016lx inst %08x", get_type(), pc, inst);
   display_custom();
   if (use_spike) {
@@ -27,7 +27,7 @@ void CommitTrace::display(bool use_spike) const {
   }
 }
 
-void CommitTrace::display_line(int index, bool use_spike, bool is_retire) const {
+void CommitTrace::display_line(int index, bool use_spike, bool is_retire) {
   Info("[%02d] ", index);
   display(use_spike);
   Info("%s\n", is_retire ? " <--" : "");
@@ -49,7 +49,7 @@ void DiffState::display() {
   Info("\n============== Commit Instr Trace ==============\n");
   int commit_index = 0;
   while (!commit_trace.empty()) {
-    auto trace = commit_trace.front();
+    CommitTrace *trace = commit_trace.front();
     commit_trace.pop();
     trace->display_line(commit_index, use_spike, commit_trace.empty());
     commit_index++;
@@ -63,73 +63,79 @@ DiffState::DiffState(int coreid) : use_spike(spike_valid()), coreid(coreid) {}
 #ifdef CONFIG_DIFFTEST_REPLAY
 void DiffState::replay_snapshot() {
   replay_state.valid = false;
+  replay_state.coreid = coreid;
+  replay_state.cycle_count = cycle_count;
+  replay_state.has_progress = has_progress;
   replay_state.has_commit = has_commit;
   replay_state.last_commit_cycle = last_commit_cycle;
   replay_state.has_trap = has_trap;
   replay_state.trap_code = trap_code;
 #ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-  std::copy(delayed_int, delayed_int + 32, replay_state.delayed_int.begin());
+  memcpy(replay_state.delayed_int, delayed_int, sizeof(delayed_int));
 #endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
 #ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-  std::copy(delayed_fp, delayed_fp + 32, replay_state.delayed_fp.begin());
+  memcpy(replay_state.delayed_fp, delayed_fp, sizeof(delayed_fp));
 #endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_STOREEVENT
-  replay_state.store_event_queue = store_event_queue;
-#endif // CONFIG_DIFFTEST_STOREEVENT
-#ifdef CONFIG_DIFFTEST_CMOINVALEVENT
-  replay_state.cmo_inval_event_set = cmo_inval_event_set;
-#endif // CONFIG_DIFFTEST_CMOINVALEVENT
 #ifdef CONFIG_DIFFTEST_SQUASH
   replay_state.commit_stamp = commit_stamp;
-#ifdef CONFIG_DIFFTEST_LOADEVENT
-  replay_state.load_event_queue = load_event_queue;
-#endif // CONFIG_DIFFTEST_LOADEVENT
 #endif // CONFIG_DIFFTEST_SQUASH
-#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
-  replay_state.matrix_sw_rob = matrix_sw_rob;
-#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
-#ifdef CONFIG_DIFFTEST_MSYNCEVENT
-  replay_state.msync_event_queue = msync_event_queue;
-#endif // CONFIG_DIFFTEST_MSYNCEVENT
-  replay_state.retire_group_queue = retire_group_queue;
-  replay_state.commit_trace = commit_trace;
+#ifdef DEBUG_REFILL
+  replay_state.track_instr = track_instr;
+#endif // DEBUG_REFILL
+  replay_state.dump_commit_trace = dump_commit_trace;
   replay_state.commit_counter = commit_counter;
   replay_state.valid = true;
 }
 
 void DiffState::replay_restore() {
   assert(replay_state.valid);
+  coreid = replay_state.coreid;
+  cycle_count = replay_state.cycle_count;
+  has_progress = replay_state.has_progress;
   has_commit = replay_state.has_commit;
   last_commit_cycle = replay_state.last_commit_cycle;
   has_trap = replay_state.has_trap;
   trap_code = replay_state.trap_code;
 #ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-  std::copy(replay_state.delayed_int.begin(), replay_state.delayed_int.end(), delayed_int);
+  memcpy(delayed_int, replay_state.delayed_int, sizeof(delayed_int));
 #endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
 #ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-  std::copy(replay_state.delayed_fp.begin(), replay_state.delayed_fp.end(), delayed_fp);
+  memcpy(delayed_fp, replay_state.delayed_fp, sizeof(delayed_fp));
 #endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_STOREEVENT
-  store_event_queue = replay_state.store_event_queue;
-#endif // CONFIG_DIFFTEST_STOREEVENT
-#ifdef CONFIG_DIFFTEST_CMOINVALEVENT
-  cmo_inval_event_set = replay_state.cmo_inval_event_set;
-#endif // CONFIG_DIFFTEST_CMOINVALEVENT
 #ifdef CONFIG_DIFFTEST_SQUASH
   commit_stamp = replay_state.commit_stamp;
-#ifdef CONFIG_DIFFTEST_LOADEVENT
-  load_event_queue = replay_state.load_event_queue;
-#endif // CONFIG_DIFFTEST_LOADEVENT
 #endif // CONFIG_DIFFTEST_SQUASH
-#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
-  matrix_sw_rob = replay_state.matrix_sw_rob;
-#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
-#ifdef CONFIG_DIFFTEST_MSYNCEVENT
-  msync_event_queue = replay_state.msync_event_queue;
-#endif // CONFIG_DIFFTEST_MSYNCEVENT
-  retire_group_queue = replay_state.retire_group_queue;
-  commit_trace = replay_state.commit_trace;
+#ifdef DEBUG_REFILL
+  track_instr = replay_state.track_instr;
+#endif // DEBUG_REFILL
+  dump_commit_trace = replay_state.dump_commit_trace;
   commit_counter = replay_state.commit_counter;
+
+#ifdef CONFIG_DIFFTEST_STOREEVENT
+  while (!store_event_queue.empty()) {
+    store_event_queue.pop();
+  }
+#endif // CONFIG_DIFFTEST_STOREEVENT
+#ifdef CONFIG_DIFFTEST_CMOINVALEVENT
+  cmo_inval_event_set.clear();
+#endif // CONFIG_DIFFTEST_CMOINVALEVENT
+#if defined(CONFIG_DIFFTEST_LOADEVENT) && defined(CONFIG_DIFFTEST_SQUASH)
+  while (!load_event_queue.empty()) {
+    load_event_queue.pop();
+  }
+#endif // CONFIG_DIFFTEST_LOADEVENT && CONFIG_DIFFTEST_SQUASH
+#ifdef CONFIG_DIFFTEST_MSYNCEVENT
+  while (!msync_event_queue.empty()) {
+    msync_event_queue.pop();
+  }
+#endif // CONFIG_DIFFTEST_MSYNCEVENT
+  while (!retire_group_queue.empty()) {
+    retire_group_queue.pop();
+  }
+  while (!commit_trace.empty()) {
+    delete commit_trace.front();
+    commit_trace.pop();
+  }
 }
 #endif // CONFIG_DIFFTEST_REPLAY
 

--- a/src/test/csrc/difftest/diffstate.h
+++ b/src/test/csrc/difftest/diffstate.h
@@ -18,10 +18,13 @@
 #define __DIFFSTATE_H__
 
 #include "common.h"
+#include <array>
 #include <cstdint>
 #include <deque>
+#include <memory>
 #include <queue>
 #include <unordered_set>
+#include <vector>
 
 class CommitTrace {
 public:
@@ -30,12 +33,12 @@ public:
 
   CommitTrace(uint64_t pc, uint32_t inst) : pc(pc), inst(inst) {}
   virtual ~CommitTrace() {}
-  virtual const char *get_type() = 0;
-  virtual void display(bool use_spike = false);
-  void display_line(int index, bool use_spike, bool is_retire);
+  virtual const char *get_type() const = 0;
+  virtual void display(bool use_spike = false) const;
+  void display_line(int index, bool use_spike, bool is_retire) const;
 
 protected:
-  virtual void display_custom() = 0;
+  virtual void display_custom() const = 0;
 };
 
 class InstrTrace : public CommitTrace {
@@ -55,12 +58,12 @@ public:
              uint16_t robidx, uint8_t isLoad, uint8_t isStore, bool skip = false, bool delayed = false)
       : CommitTrace(pc, inst), robidx(robidx), isLoad(isLoad), lqidx(lqidx), isStore(isStore), sqidx(sqidx), wen(wen),
         dest(dest), data(data), tag(get_tag(skip, delayed)) {}
-  virtual inline const char *get_type() {
+  virtual inline const char *get_type() const {
     return "commit";
   };
 
 protected:
-  void display_custom() {
+  void display_custom() const {
     Info(" wen %d dst %02d data %016lx idx %03x", wen, dest, data, robidx);
     if (isLoad) {
       Info(" (%02x)", lqidx);
@@ -88,12 +91,12 @@ class ExceptionTrace : public CommitTrace {
 public:
   uint64_t cause;
   ExceptionTrace(uint64_t pc, uint32_t inst, uint64_t cause) : CommitTrace(pc, inst), cause(cause) {}
-  virtual inline const char *get_type() {
+  virtual inline const char *get_type() const {
     return "exception";
   };
 
 protected:
-  void display_custom() {
+  void display_custom() const {
     Info(" cause %016lx", cause);
   }
 };
@@ -101,7 +104,7 @@ protected:
 class InterruptTrace : public ExceptionTrace {
 public:
   InterruptTrace(uint64_t pc, uint32_t inst, uint64_t cause) : ExceptionTrace(pc, inst, cause) {}
-  virtual inline const char *get_type() {
+  virtual inline const char *get_type() const {
     return "interrupt";
   }
 };
@@ -165,7 +168,7 @@ public:
   typedef struct {
     DifftestAmuCtrlEvent amu_event;
     AmeInstState state;
-    uint64_t *res;
+    std::vector<uint64_t> res;
   } AmeInstRobEntry;
 
   std::deque<AmeInstRobEntry> matrix_sw_rob;
@@ -182,21 +185,13 @@ public:
   bool dump_commit_trace = false;
 
   DiffState(int coreid);
-  ~DiffState() {
-#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
-    for (auto &entry: matrix_sw_rob) {
-      if (entry.res != nullptr) {
-        delete[] entry.res;
-        entry.res = nullptr;
-      }
-    }
-    matrix_sw_rob.clear();
-#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
-    while (!commit_trace.empty()) {
-      delete commit_trace.front();
-      commit_trace.pop();
-    }
-  }
+  DiffState(const DiffState &) = delete;
+  DiffState &operator=(const DiffState &) = delete;
+
+#ifdef CONFIG_DIFFTEST_REPLAY
+  void replay_snapshot();
+  void replay_restore();
+#endif // CONFIG_DIFFTEST_REPLAY
 
   void record_group(uint64_t pc, uint32_t count) {
     if (retire_group_queue.size() >= DEBUG_GROUP_TRACE_SIZE) {
@@ -206,13 +201,14 @@ public:
   }
   void record_inst(uint64_t pc, uint32_t inst, uint8_t en, uint8_t dest, uint64_t data, bool skip, bool delayed,
                    uint8_t lqidx, uint8_t sqidx, uint16_t robidx, uint8_t isLoad, uint8_t isStore) {
-    push_back_trace(new InstrTrace(pc, inst, en, dest, data, lqidx, sqidx, robidx, isLoad, isStore, skip, delayed));
+    push_back_trace(
+        std::make_shared<InstrTrace>(pc, inst, en, dest, data, lqidx, sqidx, robidx, isLoad, isStore, skip, delayed));
   };
   void record_exception(uint64_t pc, uint32_t inst, uint64_t cause) {
-    push_back_trace(new ExceptionTrace(pc, inst, cause));
+    push_back_trace(std::make_shared<ExceptionTrace>(pc, inst, cause));
   };
   void record_interrupt(uint64_t pc, uint32_t inst, uint64_t cause) {
-    push_back_trace(new InterruptTrace(pc, inst, cause));
+    push_back_trace(std::make_shared<InterruptTrace>(pc, inst, cause));
   };
   void display();
 
@@ -228,12 +224,11 @@ private:
   std::queue<std::pair<uint64_t, uint32_t>> retire_group_queue;
 
   static const int DEBUG_INST_TRACE_SIZE = 32;
-  std::queue<CommitTrace *> commit_trace;
+  std::queue<std::shared_ptr<const CommitTrace>> commit_trace;
 
   uint64_t commit_counter = 0;
-  void push_back_trace(CommitTrace *trace) {
+  void push_back_trace(std::shared_ptr<const CommitTrace> trace) {
     if (commit_trace.size() >= DEBUG_INST_TRACE_SIZE) {
-      delete commit_trace.front();
       commit_trace.pop();
     }
     commit_trace.push(trace);
@@ -247,6 +242,46 @@ private:
       fflush(stdout);
     }
   }
+
+#ifdef CONFIG_DIFFTEST_REPLAY
+  // Per-step fields and instance configuration are rebuilt or remain unchanged across replay.
+  struct ReplaySnapshot {
+    bool valid = false;
+    bool has_commit = false;
+    uint64_t last_commit_cycle = 0;
+    bool has_trap = false;
+    uint64_t trap_code = 0;
+#ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
+    std::array<int, 32> delayed_int{};
+#endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
+#ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
+    std::array<int, 32> delayed_fp{};
+#endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
+#ifdef CONFIG_DIFFTEST_STOREEVENT
+    std::queue<StoreCommit> store_event_queue;
+#endif // CONFIG_DIFFTEST_STOREEVENT
+#ifdef CONFIG_DIFFTEST_CMOINVALEVENT
+    std::unordered_set<uint64_t> cmo_inval_event_set;
+#endif // CONFIG_DIFFTEST_CMOINVALEVENT
+#ifdef CONFIG_DIFFTEST_SQUASH
+    int commit_stamp = 0;
+#ifdef CONFIG_DIFFTEST_LOADEVENT
+    std::queue<DifftestLoadEvent> load_event_queue;
+#endif // CONFIG_DIFFTEST_LOADEVENT
+#endif // CONFIG_DIFFTEST_SQUASH
+#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
+    std::deque<AmeInstRobEntry> matrix_sw_rob;
+#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
+#ifdef CONFIG_DIFFTEST_MSYNCEVENT
+    std::queue<DifftestMsyncEvent> msync_event_queue;
+#endif // CONFIG_DIFFTEST_MSYNCEVENT
+    std::queue<std::pair<uint64_t, uint32_t>> retire_group_queue;
+    std::queue<std::shared_ptr<const CommitTrace>> commit_trace;
+    uint64_t commit_counter = 0;
+  };
+
+  ReplaySnapshot replay_state;
+#endif // CONFIG_DIFFTEST_REPLAY
 };
 
 extern uint64_t get_commit_data(const DiffTestState *state, int index);

--- a/src/test/csrc/difftest/diffstate.h
+++ b/src/test/csrc/difftest/diffstate.h
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <deque>
 #include <queue>
-#include <type_traits>
 #include <unordered_set>
 
 class CommitTrace {
@@ -139,9 +138,6 @@ struct DiffStateValues {
 protected:
   uint64_t commit_counter = 0;
 };
-
-static_assert(std::is_trivially_copyable<DiffStateValues>::value,
-              "DiffStateValues must contain only trivially copyable state");
 
 class DiffState : public DiffStateValues {
 public:
@@ -269,7 +265,6 @@ private:
 
 #ifdef CONFIG_DIFFTEST_REPLAY
   DiffStateValues replay_state;
-  bool replay_state_valid = false;
 #endif // CONFIG_DIFFTEST_REPLAY
 };
 

--- a/src/test/csrc/difftest/diffstate.h
+++ b/src/test/csrc/difftest/diffstate.h
@@ -18,13 +18,10 @@
 #define __DIFFSTATE_H__
 
 #include "common.h"
-#include <array>
 #include <cstdint>
 #include <deque>
-#include <memory>
 #include <queue>
 #include <unordered_set>
-#include <vector>
 
 class CommitTrace {
 public:
@@ -33,12 +30,12 @@ public:
 
   CommitTrace(uint64_t pc, uint32_t inst) : pc(pc), inst(inst) {}
   virtual ~CommitTrace() {}
-  virtual const char *get_type() const = 0;
-  virtual void display(bool use_spike = false) const;
-  void display_line(int index, bool use_spike, bool is_retire) const;
+  virtual const char *get_type() = 0;
+  virtual void display(bool use_spike = false);
+  void display_line(int index, bool use_spike, bool is_retire);
 
 protected:
-  virtual void display_custom() const = 0;
+  virtual void display_custom() = 0;
 };
 
 class InstrTrace : public CommitTrace {
@@ -58,12 +55,12 @@ public:
              uint16_t robidx, uint8_t isLoad, uint8_t isStore, bool skip = false, bool delayed = false)
       : CommitTrace(pc, inst), robidx(robidx), isLoad(isLoad), lqidx(lqidx), isStore(isStore), sqidx(sqidx), wen(wen),
         dest(dest), data(data), tag(get_tag(skip, delayed)) {}
-  virtual inline const char *get_type() const {
+  virtual inline const char *get_type() {
     return "commit";
   };
 
 protected:
-  void display_custom() const {
+  void display_custom() {
     Info(" wen %d dst %02d data %016lx idx %03x", wen, dest, data, robidx);
     if (isLoad) {
       Info(" (%02x)", lqidx);
@@ -91,12 +88,12 @@ class ExceptionTrace : public CommitTrace {
 public:
   uint64_t cause;
   ExceptionTrace(uint64_t pc, uint32_t inst, uint64_t cause) : CommitTrace(pc, inst), cause(cause) {}
-  virtual inline const char *get_type() const {
+  virtual inline const char *get_type() {
     return "exception";
   };
 
 protected:
-  void display_custom() const {
+  void display_custom() {
     Info(" cause %016lx", cause);
   }
 };
@@ -104,7 +101,7 @@ protected:
 class InterruptTrace : public ExceptionTrace {
 public:
   InterruptTrace(uint64_t pc, uint32_t inst, uint64_t cause) : ExceptionTrace(pc, inst, cause) {}
-  virtual inline const char *get_type() const {
+  virtual inline const char *get_type() {
     return "interrupt";
   }
 };
@@ -168,7 +165,7 @@ public:
   typedef struct {
     DifftestAmuCtrlEvent amu_event;
     AmeInstState state;
-    std::vector<uint64_t> res;
+    uint64_t *res;
   } AmeInstRobEntry;
 
   std::deque<AmeInstRobEntry> matrix_sw_rob;
@@ -185,8 +182,21 @@ public:
   bool dump_commit_trace = false;
 
   DiffState(int coreid);
-  DiffState(const DiffState &) = delete;
-  DiffState &operator=(const DiffState &) = delete;
+  ~DiffState() {
+#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
+    for (auto &entry: matrix_sw_rob) {
+      if (entry.res != nullptr) {
+        delete[] entry.res;
+        entry.res = nullptr;
+      }
+    }
+    matrix_sw_rob.clear();
+#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
+    while (!commit_trace.empty()) {
+      delete commit_trace.front();
+      commit_trace.pop();
+    }
+  }
 
 #ifdef CONFIG_DIFFTEST_REPLAY
   void replay_snapshot();
@@ -201,14 +211,13 @@ public:
   }
   void record_inst(uint64_t pc, uint32_t inst, uint8_t en, uint8_t dest, uint64_t data, bool skip, bool delayed,
                    uint8_t lqidx, uint8_t sqidx, uint16_t robidx, uint8_t isLoad, uint8_t isStore) {
-    push_back_trace(
-        std::make_shared<InstrTrace>(pc, inst, en, dest, data, lqidx, sqidx, robidx, isLoad, isStore, skip, delayed));
+    push_back_trace(new InstrTrace(pc, inst, en, dest, data, lqidx, sqidx, robidx, isLoad, isStore, skip, delayed));
   };
   void record_exception(uint64_t pc, uint32_t inst, uint64_t cause) {
-    push_back_trace(std::make_shared<ExceptionTrace>(pc, inst, cause));
+    push_back_trace(new ExceptionTrace(pc, inst, cause));
   };
   void record_interrupt(uint64_t pc, uint32_t inst, uint64_t cause) {
-    push_back_trace(std::make_shared<InterruptTrace>(pc, inst, cause));
+    push_back_trace(new InterruptTrace(pc, inst, cause));
   };
   void display();
 
@@ -224,11 +233,12 @@ private:
   std::queue<std::pair<uint64_t, uint32_t>> retire_group_queue;
 
   static const int DEBUG_INST_TRACE_SIZE = 32;
-  std::queue<std::shared_ptr<const CommitTrace>> commit_trace;
+  std::queue<CommitTrace *> commit_trace;
 
   uint64_t commit_counter = 0;
-  void push_back_trace(std::shared_ptr<const CommitTrace> trace) {
+  void push_back_trace(CommitTrace *trace) {
     if (commit_trace.size() >= DEBUG_INST_TRACE_SIZE) {
+      delete commit_trace.front();
       commit_trace.pop();
     }
     commit_trace.push(trace);
@@ -244,39 +254,29 @@ private:
   }
 
 #ifdef CONFIG_DIFFTEST_REPLAY
-  // Per-step fields and instance configuration are rebuilt or remain unchanged across replay.
+  // Keep only mutable value state. Owning containers are cleared when replay starts.
   struct ReplaySnapshot {
     bool valid = false;
+    int coreid = 0;
+    uint64_t cycle_count = 0;
+    bool has_progress = false;
     bool has_commit = false;
     uint64_t last_commit_cycle = 0;
     bool has_trap = false;
     uint64_t trap_code = 0;
 #ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-    std::array<int, 32> delayed_int{};
+    int delayed_int[32] = {0};
 #endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
 #ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-    std::array<int, 32> delayed_fp{};
+    int delayed_fp[32] = {0};
 #endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_STOREEVENT
-    std::queue<StoreCommit> store_event_queue;
-#endif // CONFIG_DIFFTEST_STOREEVENT
-#ifdef CONFIG_DIFFTEST_CMOINVALEVENT
-    std::unordered_set<uint64_t> cmo_inval_event_set;
-#endif // CONFIG_DIFFTEST_CMOINVALEVENT
 #ifdef CONFIG_DIFFTEST_SQUASH
     int commit_stamp = 0;
-#ifdef CONFIG_DIFFTEST_LOADEVENT
-    std::queue<DifftestLoadEvent> load_event_queue;
-#endif // CONFIG_DIFFTEST_LOADEVENT
 #endif // CONFIG_DIFFTEST_SQUASH
-#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
-    std::deque<AmeInstRobEntry> matrix_sw_rob;
-#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
-#ifdef CONFIG_DIFFTEST_MSYNCEVENT
-    std::queue<DifftestMsyncEvent> msync_event_queue;
-#endif // CONFIG_DIFFTEST_MSYNCEVENT
-    std::queue<std::pair<uint64_t, uint32_t>> retire_group_queue;
-    std::queue<std::shared_ptr<const CommitTrace>> commit_trace;
+#ifdef DEBUG_REFILL
+    uint64_t track_instr = 0;
+#endif // DEBUG_REFILL
+    bool dump_commit_trace = false;
     uint64_t commit_counter = 0;
   };
 

--- a/src/test/csrc/difftest/diffstate.h
+++ b/src/test/csrc/difftest/diffstate.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <deque>
 #include <queue>
+#include <type_traits>
 #include <unordered_set>
 
 class CommitTrace {
@@ -106,8 +107,10 @@ public:
   }
 };
 
-class DiffState {
-public:
+// State copied when replay starts. Keep owning or self-referential types out.
+struct DiffStateValues {
+  explicit DiffStateValues(int coreid = 0) : coreid(coreid) {}
+
   int coreid;
   uint64_t cycle_count = 0;
   bool has_progress = false;
@@ -123,6 +126,25 @@ public:
   int delayed_fp[32] = {0};
 #endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
 
+#ifdef CONFIG_DIFFTEST_SQUASH
+  int commit_stamp = 0;
+#endif // CONFIG_DIFFTEST_SQUASH
+
+#ifdef DEBUG_REFILL
+  uint64_t track_instr = 0;
+#endif // DEBUG_REFILL
+
+  bool dump_commit_trace = false;
+
+protected:
+  uint64_t commit_counter = 0;
+};
+
+static_assert(std::is_trivially_copyable<DiffStateValues>::value,
+              "DiffStateValues must contain only trivially copyable state");
+
+class DiffState : public DiffStateValues {
+public:
 #ifdef CONFIG_DIFFTEST_STOREEVENT
   typedef struct {
     uint8_t valid;
@@ -148,7 +170,6 @@ public:
 #endif
 
 #ifdef CONFIG_DIFFTEST_SQUASH
-  int commit_stamp = 0;
 #ifdef CONFIG_DIFFTEST_LOADEVENT
   std::queue<DifftestLoadEvent> load_event_queue;
 #endif // CONFIG_DIFFTEST_LOADEVENT
@@ -174,12 +195,6 @@ public:
 #ifdef CONFIG_DIFFTEST_MSYNCEVENT
   std::queue<DifftestMsyncEvent> msync_event_queue;
 #endif // CONFIG_DIFFTEST_MSYNCEVENT
-
-#ifdef DEBUG_REFILL
-  uint64_t track_instr = 0;
-#endif // DEBUG_REFILL
-
-  bool dump_commit_trace = false;
 
   DiffState(int coreid);
   ~DiffState() {
@@ -235,7 +250,6 @@ private:
   static const int DEBUG_INST_TRACE_SIZE = 32;
   std::queue<CommitTrace *> commit_trace;
 
-  uint64_t commit_counter = 0;
   void push_back_trace(CommitTrace *trace) {
     if (commit_trace.size() >= DEBUG_INST_TRACE_SIZE) {
       delete commit_trace.front();
@@ -254,33 +268,8 @@ private:
   }
 
 #ifdef CONFIG_DIFFTEST_REPLAY
-  // Keep only mutable value state. Owning containers are cleared when replay starts.
-  struct ReplaySnapshot {
-    bool valid = false;
-    int coreid = 0;
-    uint64_t cycle_count = 0;
-    bool has_progress = false;
-    bool has_commit = false;
-    uint64_t last_commit_cycle = 0;
-    bool has_trap = false;
-    uint64_t trap_code = 0;
-#ifdef CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-    int delayed_int[32] = {0};
-#endif // CONFIG_DIFFTEST_ARCHINTDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-    int delayed_fp[32] = {0};
-#endif // CONFIG_DIFFTEST_ARCHFPDELAYEDUPDATE
-#ifdef CONFIG_DIFFTEST_SQUASH
-    int commit_stamp = 0;
-#endif // CONFIG_DIFFTEST_SQUASH
-#ifdef DEBUG_REFILL
-    uint64_t track_instr = 0;
-#endif // DEBUG_REFILL
-    bool dump_commit_trace = false;
-    uint64_t commit_counter = 0;
-  };
-
-  ReplaySnapshot replay_state;
+  DiffStateValues replay_state;
+  bool replay_state_valid = false;
 #endif // CONFIG_DIFFTEST_REPLAY
 };
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -274,9 +274,6 @@ void difftest_replay_head(int head) {
 
 Difftest::Difftest(int coreid) {
   state = new DiffState(coreid);
-#ifdef CONFIG_DIFFTEST_REPLAY
-  state_ss = (DiffState *)malloc(sizeof(DiffState));
-#endif // CONFIG_DIFFTEST_REPLAY
 
 #ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
   mma_verifier = nullptr;
@@ -328,7 +325,6 @@ Difftest::~Difftest() {
     delete proxy;
   }
 #ifdef CONFIG_DIFFTEST_REPLAY
-  free(state_ss);
   if (proxy_reg_ss) {
     free(proxy_reg_ss);
   }
@@ -524,7 +520,7 @@ bool Difftest::in_replay_range() {
 }
 
 void Difftest::replay_snapshot() {
-  memcpy(state_ss, state, sizeof(DiffState));
+  state->replay_snapshot();
   memcpy(proxy_reg_ss, &proxy->state, sizeof(ref_state_t));
   proxy->ref_csrcpy(squash_csr_buf, REF_TO_DUT);
   proxy->ref_store_log_reset();
@@ -543,7 +539,8 @@ void Difftest::do_replay() {
   replay_status.in_replay = true;
   replay_status.trace_head = info.trace_head;
   replay_status.trace_size = info.trace_size;
-  memcpy(state, state_ss, sizeof(DiffState));
+  state->replay_restore();
+  pc_mismatch = false;
   memcpy(&proxy->state, proxy_reg_ss, sizeof(ref_state_t));
   proxy->ref_regcpy(&proxy->state, DUT_TO_REF, false);
   proxy->ref_csrcpy(squash_csr_buf, DUT_TO_REF);
@@ -555,28 +552,6 @@ void Difftest::do_replay() {
   }
 #endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
   difftest_replay_head(info.trace_head);
-  // clear buffered queue
-#ifdef CONFIG_DIFFTEST_STOREEVENT
-  while (!state->store_event_queue.empty())
-    state->store_event_queue.pop();
-#endif // CONFIG_DIFFTEST_STOREEVENT
-#if defined(CONFIG_DIFFTEST_LOADEVENT) && defined(CONFIG_DIFFTEST_SQUASH)
-  while (!state->load_event_queue.empty())
-    state->load_event_queue.pop();
-#endif
-#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
-  for (auto &entry: state->matrix_sw_rob) {
-    if (entry.res != nullptr) {
-      delete[] entry.res;
-      entry.res = nullptr;
-    }
-  }
-  state->matrix_sw_rob.clear();
-#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
-#ifdef CONFIG_DIFFTEST_MSYNCEVENT
-  while (!state->msync_event_queue.empty())
-    state->msync_event_queue.pop();
-#endif // CONFIG_DIFFTEST_MSYNCEVENT
 }
 #endif // CONFIG_DIFFTEST_REPLAY
 

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -540,7 +540,6 @@ void Difftest::do_replay() {
   replay_status.trace_head = info.trace_head;
   replay_status.trace_size = info.trace_size;
   state->replay_restore();
-  pc_mismatch = false;
   memcpy(&proxy->state, proxy_reg_ss, sizeof(ref_state_t));
   proxy->ref_regcpy(&proxy->state, DUT_TO_REF, false);
   proxy->ref_csrcpy(squash_csr_buf, DUT_TO_REF);
@@ -552,6 +551,16 @@ void Difftest::do_replay() {
   }
 #endif // CONFIG_DIFFTEST_MATRIXSTOREEVENT
   difftest_replay_head(info.trace_head);
+  // clear buffered queue
+#ifdef CONFIG_DIFFTEST_AMUCTRLEVENT
+  for (auto &entry: state->matrix_sw_rob) {
+    if (entry.res != nullptr) {
+      delete[] entry.res;
+      entry.res = nullptr;
+    }
+  }
+  state->matrix_sw_rob.clear();
+#endif // CONFIG_DIFFTEST_AMUCTRLEVENT
 }
 #endif // CONFIG_DIFFTEST_REPLAY
 

--- a/src/test/csrc/difftest/difftest.h
+++ b/src/test/csrc/difftest/difftest.h
@@ -243,7 +243,6 @@ protected:
     int trace_size;
   } replay_status;
 
-  DiffState *state_ss = NULL;
   uint8_t *proxy_reg_ss = NULL;
   uint64_t squash_csr_buf[4096];
   bool can_replay();


### PR DESCRIPTION
## Summary

- Replace the whole-object DiffState memcpy with value-only state assignment.
- Keep queue, set, and trace ownership outside the replay snapshot, and clear transient state during replay restore.
- Leave the matrix replay handling unchanged.

## Replay queue ordering

squashQueue processes store/load events in stamp order. Therefore, all store/load events before replay_window have already completed checking. The pending store/load queues are cleared when restoring the replay snapshot instead of being copied.

## Validation

- Generated difftest RTL with ESBR and ESB configurations.
- Compiled all difftest C++ translation units with C++11.
- Ran the replay-state restore and container cleanup test with ASan and UBSan.