### PR TITLE
fix(fpga): recover specified name of XMR probe

### DIFF
--- a/src/main/scala/Gateway.scala
+++ b/src/main/scala/Gateway.scala
@@ -191,7 +191,7 @@ object Gateway {
   }
 
   def apply[T <: DifftestBundle](gen: T, delay: Int): T = {
-    val ret = WireInit(0.U.asTypeOf(gen)).suggestName(gen.desiredCppName)
+    val ret = WireInit(0.U.asTypeOf(gen))
     val bundle = if (config.isFPGA && gen.fpgaFilterElems.nonEmpty) {
       val filtered = WireInit(ret)
       gen.fpgaFilterElems.foreach { name =>
@@ -205,6 +205,8 @@ object Gateway {
     } else {
       ret
     }
+    // Base DUT probe names on desiredCppName instead of automatically enumerated variable indices.
+    bundle.suggestName(gen.desiredCppName)
     dontTouch(bundle)
     if (!config.traceLoad) {
       if (config.needEndpoint) {


### PR DESCRIPTION
Previous #794 specifies explicit signal names for Difftest sources, so that 
target signals can be directly captured via XMR paths in case like ILA.
For example, `val xx = DifftestModule(new DifftestTrapEvent)`,
the corresponding signal name will be exposed as `xx_trap`.

However, the suggestName only works for last defined varible before
endpoint consuming. #948 introduced a filtered copy after naming `ret`,
missing the specified name, this change move the `suggestName` back to
last variable.